### PR TITLE
tweaked wsgi script

### DIFF
--- a/webservices/wsgi/wsgiwps.py
+++ b/webservices/wsgi/wsgiwps.py
@@ -32,14 +32,10 @@ PyWPS wsgi script
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-import sys
-
-sys.path.append("/home/jachym/usr/src/pywps/trunk/")
-
 import pywps
 from pywps.Exceptions import *
 
-def dispatchWps(environ, start_response):
+def application(environ, start_response):
 
     status = '200 OK'
     response_headers = [('Content-type','text/xml')]
@@ -82,5 +78,5 @@ if __name__ == '__main__':
         )[0],"tests","processes")
 
     from wsgiref.simple_server import make_server
-    srv = make_server('localhost', 8081, dispatchWps)
+    srv = make_server('localhost', 8081, application)
     srv.serve_forever()


### PR DESCRIPTION
This pull request cleans up the wsgi script a bit.
I have removed local imports under assumption that the wsgiwps script is to be run after PyWPS has been successfully installed. Also renamed the main function to 'aplication' in order to be able to use it with apache's mod_wsgi.

The changes can be tested by running the wsgiwps module standalone, which will create a testing wsgi server that awaits requests:

``` bash
$ cd webservices/wsgi
$ python wsgiwps.py
```

and then using another terminal to fire up a GetCapabilities request with, for example, oswlib:

``` python
from owslib.wps import WebProcessingService
wps = WebProcessingService('http://localhost:8081')
```
