### PR TITLE
Use the configFiles input argument to PyWPS

### DIFF
--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -176,6 +176,7 @@ class Pywps:
         """
 
         # get settings
+        config.loadConfiguration(configFiles)
         self.setLogFile()
         self.UUID = uuid.uuid1().__str__()
 


### PR DESCRIPTION
This pull request makes a PyWPS instance actually use the configFiles input argument to its **init** method.

The input argument was already there, but was not being used in the code. I just wired it to the appropriate method.
I am finding this functionality useful in a apache mod_wsgi context. It allows me to control where the PyWPS instance will read its configuration inside the wpswsgi script , thus removing the need to setup an environment variable for PYWPS_CFG in the apache configuration file.
