### PR TITLE
Removed to too early generation of processSucceeded status XML file,

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -753,7 +753,7 @@ class Execute(Request):
         if self.storeRequired and (self.status == self.accepted or
                                    #self.status == self.succeeded or
                                    self.status == self.failed or
-                                   self.spawned):
+                                   (self.spawned and self.status != self.succeeded)):
             pywps.response.response(self.response,
                                     self.outputFile,
                                     self.wps.parser.soapVersion,


### PR DESCRIPTION
In asynchronous mode self.spawned is always True. This results in promoteStatus to generate the 
processSucceeded state XML file, while the outputs are not yet generated. When querying with a high frequency this XML with no wps:Output inside is read frequently. For slower update times on unlucky
timings the same may occur, making it seem to happen randomly. 

The change removes the generation of the XML file for self.succeeded. In the main loop processOutputs()
will be called and then the wps.response.response will generated the desired processSucceeded state XML file.
