### PR TITLE
use os.devnull to avoid a deadlock by subprocess.PIPE when

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -366,10 +366,11 @@ class Execute(Request):
             # spawn this process
             logging.info("Spawning process to the background")
             self.outputFile.name
-            subprocess.Popen([sys.executable,__file__,
+            FNULL = open(os.devnull,"w")
+            subprocess.Popen([sys.executable, __file__,
                 os.path.join(tmpPath, self.__pickleFileName+"-"+str(self.wps.UUID)),self.outputFile.name],
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE)
+                stdout=FNULL,#subprocess.PIPE, 
+                stderr=FNULL)#subprocess.PIPE)
             logging.info("This is parent process, end.")
 
             # close the outputs ..


### PR DESCRIPTION
it is not read anyhow. 

This issue occurs in combination with a wps process that calls another wps process several times sequentially. 
OWSLib is used to run these requests. It makes heavy use of print statements, which results in filling
whatever stdout  references too quite fast. It seems that due to not reading subprocess.PIPE 
the buffer is full and the process deadlocks at a print statement.

The same test with using os.devnull runs without issues, as there will be no full buffer that blocks. 

For subprocess.PIPE 49 wps processes was enough to deadlock, while for os.devnull 1000 sub wps processes ran just fine.

The alternative would be to not set stdout and stderr, but then all messages will be print
on the WPS server.
