### PR TITLE
changed the way sys.path is updated in Execute

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -35,7 +35,8 @@ import sys,os
 #        os.path.dirname( os.path.abspath(__file__)) ,"..","..","..")
 #    )
 
-sys.path[0]= os.path.join(os.path.dirname( os.path.abspath(__file__)) ,"..","..","..")
+sys.path.insert(1, os.path.join(os.path.dirname( os.path.abspath(__file__)),
+                "..","..",".."))
 import pywps
 import pywps.Ftp
 from pywps import config


### PR DESCRIPTION
This pull request alters the way the Execute module changes the python path variable.

Instead of reassigning sys.path[0] to a specific path, this patch adds this path to sys.path in the second position (sys.path[1]). The rationale for this is:

1 - I could not understand why sys.path[0] would need to be reassigned
2 - It was breaking my attempts of running pywps with django as the altering of sys.path caused my custom modules to not be seen by pywps
3 - According to official python docs (https://docs.python.org/2/library/sys.html#sys.path), sys.path[0] should not be tampered with

The following thread on stackoverflow has some useful info on this topic: http://stackoverflow.com/questions/10095037/why-use-sys-path-appendpath-instead-of-sys-path-insert1-path
