### PR TITLE
fix wrong exeption message escaping

### DIFF
--- a/pywps/Exceptions.py
+++ b/pywps/Exceptions.py
@@ -26,6 +26,7 @@ from re import escape
 from pywps.Soap import SOAP
 import pywps.Soap
 import sys
+from xml.sax.saxutils import escape as xml_text_escape
 
 called = 0
 
@@ -98,7 +99,7 @@ class NoApplicableCode(WPSException):
             self.ExceptionText = self.document.createElement("ExceptionText")
             self.ExceptionText.appendChild(self.document.createTextNode(repr(value)))
             self.Exception.appendChild(self.ExceptionText)
-            self.value = escape(value)
+            self.value = xml_text_escape(value)
 
 class VersionNegotiationFailed(WPSException):
     """VersionNegotiationFailed WPS Exception"""


### PR DESCRIPTION
Hello,

Current escaping of error string escape space as "\ ". This is not necessary, thus I propose to escape using saxutils escaping function that look more apropriate than the base python escape function.

Best regards