### PR TITLE
fixed init of logging

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -1468,7 +1468,7 @@ if __name__ == "__main__":
             activate_script = os.path.join(venv, 'bin', 'activate_this.py')
             if os.path.isfile(activate_script):
                 execfile(activate_script, dict(__file__=activate_script))
-        wps.setLogFile()
+        wps.setLogFile(clear_handlers=True)
         LOGGER.info("Spawn process started, continuting to execute the process")
         # fix some inputs
         wps.inputs["responseform"]["responsedocument"]["status"] = False

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -110,7 +110,7 @@ LOGGER = logging.getLogger(__name__)
 
 logFile = None
 
-class Pywps:
+class Pywps(object):
     """This is main PyWPS Class, which parses the request, performs the
     desired operation and writes required response back.
 
@@ -253,7 +253,7 @@ class Pywps:
         """
         global logFile
         fileName = config.getConfigValue("server","logFile")
-        logLevel = eval("LOGGER."+config.getConfigValue("server","logLevel").upper())
+        logLevel = eval("logging."+config.getConfigValue("server","logLevel").upper())
         format = "PyWPS [%(asctime)s] %(levelname)s: %(message)s"
 
         if clear_handlers and len(logging.root.handlers) > 0:
@@ -261,9 +261,9 @@ class Pywps:
             logging.root.handlers[:] = []
         
         if not fileName:
-            LOGGER.basicConfig(level=logLevel,format=format)
+            logging.basicConfig(level=logLevel,format=format)
         else:
-            LOGGER.basicConfig(filename=fileName,level=logLevel,format=format)
+            logging.basicConfig(filename=fileName,level=logLevel,format=format)
             logFile = open(fileName, "a")
 
 

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -65,8 +65,8 @@ example how to use this module::
 
 __all__ = [ "Parser","processes", "Process", "Exceptions", "Wps", "Templates","Template","XSLT","Ftp"]
 
-# Author:	Jachym Cepicky
-#        	http://les-ejk.cz
+# Author:   Jachym Cepicky
+#           http://les-ejk.cz
 # License:
 #
 # Web Processing Service implementation
@@ -248,13 +248,18 @@ class Pywps:
         self.response = self.request.response
         return self.response
 
-    def setLogFile(self):
+    def setLogFile(self, clear_handlers=False):
         """Set :data:`logFile`. Default is sys.stderr
         """
         global logFile
         fileName = config.getConfigValue("server","logFile")
         logLevel = eval("LOGGER."+config.getConfigValue("server","logLevel").upper())
         format = "PyWPS [%(asctime)s] %(levelname)s: %(message)s"
+
+        if clear_handlers and len(logging.root.handlers) > 0:
+            # somehow need to clear handlers for async processes
+            logging.root.handlers[:] = []
+        
         if not fileName:
             LOGGER.basicConfig(level=logLevel,format=format)
         else:


### PR DESCRIPTION
fixes init of logging caused by patch #45. logging.basicConfig() was accidently replaced by LOGGER.basicConfig() 

Adds workaround for logging init in case of async execution. Needs to remove logging handlers before calling logging.basicConfig().