### PR TITLE
fix issue#70, close open file handlers

### DIFF
--- a/pywps/Process/InAndOutputs.py
+++ b/pywps/Process/InAndOutputs.py
@@ -1014,12 +1014,10 @@ class ComplexOutput(Output):
         elif value.__class__.__name__=='StringIO' or value.__class__.__name__=='StringO':
             import tempfile
             from os import curdir
-            stringIOName = tempfile.mkstemp(prefix="pywpsOutput",dir=curdir) #(5, '/tmp/pywps-instanceS2j6ve/pywpsOutputZxSM6V')
-            stringIOName=stringIOName[1]
-
-            stringIOFile=open(stringIOName,"w")
-            stringIOFile.write(value.getvalue())
-            stringIOFile.close()
+            fh, stringIOName = tempfile.mkstemp(prefix="pywpsOutput",
+                                                dir=curdir) #(5, '/tmp/pywps-instanceS2j6ve/pywpsOutputZxSM6V')
+            fh.write(value.getvalue())
+            fh.close()
             self.value=stringIOName
         # TODO add more types, like Arrays and lists for example
         else:

--- a/pywps/Wps/Execute/UMN.py
+++ b/pywps/Wps/Execute/UMN.py
@@ -25,7 +25,6 @@ from pywps import config
 import os
 import urllib2
 import logging
-import tempfile
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pywps/Wps/Execute/UMN.py
+++ b/pywps/Wps/Execute/UMN.py
@@ -95,7 +95,6 @@ class UMN:
         if ((mapscript == False) or (gdal== False)):
             return
         
-        tmp = os.path.basename(tempfile.mkstemp()[1])
         self.outputs = {}
         self.process = process
         self.sessionId = sessId

--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -1379,11 +1379,14 @@ class Execute(Request):
              # copy the file to safe place
             outName = os.path.basename(output.value)
             outSuffix = os.path.splitext(outName)[1]
-            tmp = tempfile.mkstemp(suffix=outSuffix, prefix="%s-%s" % (output.identifier,self.pid),dir=os.path.join(config.getConfigValue("server","outputPath")))
-            outFile = tmp[1]
-
+            fh, outFile = tempfile.mkstemp(
+                suffix=outSuffix, 
+                prefix="%s-%s" % (output.identifier, self.pid),
+                dir=os.path.join(config.getConfigValue("server", "outputPath"))
+            )
             if not self._samefile(output.value,outFile):
                 COPY(os.path.abspath(output.value), outFile)
+            fh.close()
 
             #check 
             self.contentType = output.format["mimetype"]


### PR DESCRIPTION
This pull request fixes issue #70 
All usages of `tempfile.mkstemp()` are now handling the returned open file handler and taking care of closing it afterwards.

Module `pywps.Wps.Execute.UMN` wasn't actually using the generated temporary file for anything, so I removed the creation completely.