### PR TITLE
When pickling compiled templates, open file as binary for writing.

### DIFF
--- a/pywps/Template.py
+++ b/pywps/Template.py
@@ -290,7 +290,7 @@ class TemplateProcessor:
         # store to binary form
         if self._compile:
             try:
-                cPickle.dump(self.tokens, open(self._cfile,"w"), True)
+                cPickle.dump(self.tokens, open(self._cfile,"wb"), True)
             except Exception,e:
                 raise TemplateError("Could not store file in compiled form: %s. Try to set permission for this directory to 777" % e)
 


### PR DESCRIPTION
This is consistent with the unpickling operation where the file is
opened as binary, and without this change, under Windows, unpickling
fails.  This change does not seem to have negative implications for
Linux.