### PR TITLE
Base64 encode from source file directly to destination variable

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -1001,13 +1001,13 @@ class Execute(Request):
         # CDATA section in output
             #attention to application/xml
             if output.format["mimetype"].find("text") < 0 and output.format["mimetype"].find("xml")<0:
-            #complexOutput["cdata"] = 1
-                os.rename(output.value, output.value+".binary")
-                base64.encode(open(output.value+".binary"),open(output.value,"w"))
-            
+                with open(output.value, "rb") as f:
+                    complexOutput["complexdata"] = base64.encodestring(f.read()) 
         
         # set output value
-        complexOutput["complexdata"] = open(output.value,"r").read()
+        if not "complexdata" in complexOutput:
+            with open(output.value, "r") as f:
+                complexOutput["complexdata"] = f.read()
 
         # remove <?xml version= ... part from beginning of some xml
         # documents


### PR DESCRIPTION
Use base64.encodestring() to read from file and encode directly to
complexOutput["complexdata"].  Rather than the process of read from file,
base64 encode, write to file, and then read from file again.

Also, use "with" syntax to ensure files are closed after use.