### PR TITLE
Make minOccurs/maxOccurs checking more robust.

### DIFF
--- a/pywps/Process/InAndOutputs.py
+++ b/pywps/Process/InAndOutputs.py
@@ -118,18 +118,25 @@ class Input:
                 return resp
         return
 
-    def _setValueWithOccurence(self,oldValues, newValue):
-        """Check min and max occurrence and set this.value"""
-        if self.maxOccurs > 1:
+    def _setValueWithOccurence(self, oldValues, newValue):
+        """Check max occurrence and set this.value"""
+        maxOccursViolated = False
+
+        if (self.maxOccurs == 0) or (self.maxOccurs == 1 and oldValues):
+            maxOccursViolated = True
+        elif self.maxOccurs > 1:
             if not oldValues:
                 oldValues =  [newValue]
             else:
                 if self.maxOccurs > len(oldValues):
                     oldValues.append(newValue)
                 else:
-                    return "Too many occurrences of input [%s]: %s" % (self.identifier,newValue)
+                    maxOccursViolated = True
         else:
             oldValues = newValue
+
+        if maxOccursViolated:
+            return "Too many occurrences of input [%s]: %s" % (self.identifier, newValue)
 
         self.value = oldValues
         return

--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -491,7 +491,7 @@ class Execute(Request):
         self.process.spawned = self.spawned
 
     def consolidateInputs(self):
-        """ Donwload and control input data, defined by the client """
+        """ Download and control input data, defined by the client """
         # calculate maximum allowed input size
         maxFileSize = self.calculateMaxInputSize()
 
@@ -536,12 +536,26 @@ class Execute(Request):
             except KeyError,e:
                 pass
 
-        # make sure, all inputs do have values
+        # make sure, all inputs have minimum required number of values
         for identifier in self.process.inputs:
             input = self.process.inputs[identifier]
-            if input.getValue() == None and input.minOccurs > 0:
-                self.cleanEnv()
-                raise pywps.MissingParameterValue(identifier)
+            if input.minOccurs > 0:
+                val = input.getValue()
+
+                if val == None:
+                    self.cleanEnv()
+                    raise pywps.MissingParameterValue(identifier)
+                else:
+                    if type(val) == types.ListType:
+                        numOccurs = len(val)
+                    else:
+                        numOccurs = 1
+
+                    if numOccurs < input.minOccurs: 
+                        self.cleanEnv()
+                        raise pywps.MissingParameterValue(
+                            "Too few occurrences of input [%s]: expected %d found %d" % 
+                            (identifier, input.minOccurs, numOccurs))
 
     def consolidateOutputs(self):
         """Set desired attributes (e.g. asReference) for each output"""


### PR DESCRIPTION
Fix holes in validating that minOccurs/maxOccurs for inputs are not violated:
1) In _setValueWithOccurence(), check the cases where maxOccurs equals 0 or 1,
in addition to the >1 case.
2) In consolidateInputs() check that minOccurs is always satisfied, including for
the minOccurs>1 case, rather than just checking that there is any single occurrence.