### PR TITLE
Exception cleanup

### DIFF
--- a/pywps/Exceptions.py
+++ b/pywps/Exceptions.py
@@ -85,6 +85,7 @@ class InvalidParameterValue(WPSException):
     def __init__(self,value,text=None):
         self.code = "InvalidParameterValue"
         self.locator = str(value)
+        self.message = text
         self._make_xml()
         if text:
             self.ExceptionText = self.document.createElement("ExceptionText")

--- a/pywps/Exceptions.py
+++ b/pywps/Exceptions.py
@@ -82,10 +82,15 @@ class MissingParameterValue(WPSException):
 
 class InvalidParameterValue(WPSException):
     """InvalidParameterValue WPS Exception"""
-    def __init__(self,value):
+    def __init__(self,value,text=None):
         self.code = "InvalidParameterValue"
         self.locator = str(value)
         self._make_xml()
+        if text:
+            self.ExceptionText = self.document.createElement("ExceptionText")
+            self.ExceptionText.appendChild(self.document.createTextNode(str(text)))
+            self.Exception.appendChild(self.ExceptionText)
+            self.value = xml_text_escape(text)
 
 class NoApplicableCode(WPSException):
     """NoApplicableCode WPS Exception"""
@@ -97,7 +102,7 @@ class NoApplicableCode(WPSException):
         self.message = value
         if value:
             self.ExceptionText = self.document.createElement("ExceptionText")
-            self.ExceptionText.appendChild(self.document.createTextNode(repr(value)))
+            self.ExceptionText.appendChild(self.document.createTextNode(str(value)))
             self.Exception.appendChild(self.ExceptionText)
             self.value = xml_text_escape(value)
 

--- a/pywps/Parser/Execute.py
+++ b/pywps/Parser/Execute.py
@@ -110,7 +110,7 @@ class Post(PostParser):
             self.inputs["responseform"].has_key("responsedocument")) and \
             self.inputs["responseform"]["responsedocument"] and \
             self.inputs["responseform"]["rawdataoutput"]:
-            raise pywps.InvalidParameterValue(
+            raise pywps.InvalidParameterValue("responseDocument",
                 "Either responseDocument or rawDataOutput should be specified, but not both")
         if not self.inputs["responseform"].has_key("rawdataoutput"):
                self.inputs["responseform"]["rawdataoutput"] = {}
@@ -517,7 +517,7 @@ class Get(GetParser):
         # Either responseDocument or rawDataOutput should be specified, not both
         if len(self.inputs["responseform"]["rawdataoutput"])>0 and \
             len(self.inputs["responseform"]["responsedocument"])>0:
-            raise pywps.InvalidParameterValue(
+            raise pywps.InvalidParameterValue("responseDocument",
                 "Either responseDocument or rawDataOutput should be specified, but not both")
         return self.inputs
 

--- a/pywps/Parser/Get.py
+++ b/pywps/Parser/Get.py
@@ -138,7 +138,8 @@ class Get(Parser):
             self.requestParser = Execute.Get(self.wps)
             self.inputs["request"] = self.EXECUTE
         else:
-            raise InvalidParameterValue("request")
+            raise InvalidParameterValue("request",
+                "Unsupported request type '%s'" % self.unparsedInputs["request"])
 
 
     def checkService(self):
@@ -151,7 +152,8 @@ class Get(Parser):
             if value.lower() == "wsdl":
                 self.inputs["service"] = "wsdl"
             elif value.lower() != "wps":
-                raise InvalidParameterValue("service")
+                raise InvalidParameterValue("service",
+                    "Unsupported service type '%s'" % self.unparsedInputs["service"])
             else:
                 self.inputs["service"] = "wps"
         else:
@@ -164,7 +166,8 @@ class Get(Parser):
         if "language" in self.unparsedInputs:
             value=Lang.getCode(self.unparsedInputs["language"].lower())
             if value not in self.wps.languages:
-                raise InvalidParameterValue("language")
+                raise InvalidParameterValue("language",
+                    "Unsupported language type '%s'" % value)
             else:
                 self.inputs["language"] = value
         else:

--- a/pywps/Process/InAndOutputs.py
+++ b/pywps/Process/InAndOutputs.py
@@ -260,7 +260,8 @@ class LiteralInput(Input):
         if  type(value)!= types.BooleanType:
             for char in self.restrictedCharacters:
                 if value.find(char) > -1:
-                    raise Exceptions.InvalidParameterValue(value)
+                    raise Exceptions.InvalidParameterValue("datainputs",
+                        "Input [%s] has a value %s which contains unallowed characters." % (self.identifier, str(value)))
 
         # type
         try:
@@ -274,7 +275,8 @@ class LiteralInput(Input):
                 value = bool(value)
             #TODO other types missing
         except (ValueError), e:
-            raise Exceptions.InvalidParameterValue(value)
+            raise Exceptions.InvalidParameterValue("datainputs",
+                "Input [%s] has a value %s which is the wrong data type." % (self.identifier, str(value)))
 
         # value list
         if "*" in self.values:
@@ -293,7 +295,8 @@ class LiteralInput(Input):
                 if str(value) == str(allowed):
                     return value
 
-        raise Exceptions.InvalidParameterValue(value)
+        raise Exceptions.InvalidParameterValue("datainputs",
+            "Input [%s] has a value %s which is out of range." % (self.identifier, str(value)))
 
 class ComplexInput(Input):
     """ComplexInput type

--- a/pywps/Templates/1_0_0/Execute.tmpl
+++ b/pywps/Templates/1_0_0/Execute.tmpl
@@ -35,7 +35,7 @@
         </TMPL_IF>
         <TMPL_IF processfailed>
         <wps:ProcessFailed>
-            <ows:ExceptionReport version=1.0.0>
+            <ows:ExceptionReport version="1.0.0">
                 <TMPL_IF exceptiontext>
                 <ows:Exception exceptionCode="<TMPL_VAR exceptioncode>" locator="<TMPL_VAR locator>">
                     <ows:ExceptionText><TMPL_VAR exceptiontext></ows:ExceptionText>

--- a/pywps/Templates/1_0_0/Execute.tmpl
+++ b/pywps/Templates/1_0_0/Execute.tmpl
@@ -35,7 +35,7 @@
         </TMPL_IF>
         <TMPL_IF processfailed>
         <wps:ProcessFailed>
-            <wps:ExceptionReport>
+            <ows:ExceptionReport version=1.0.0>
                 <TMPL_IF exceptiontext>
                 <ows:Exception exceptionCode="<TMPL_VAR exceptioncode>" locator="<TMPL_VAR locator>">
                     <ows:ExceptionText><TMPL_VAR exceptiontext></ows:ExceptionText>
@@ -43,7 +43,7 @@
                 <TMPL_ELSE>
                 <ows:Exception exceptionCode="<TMPL_VAR exceptioncode>" locator="<TMPL_VAR locator>" />
                 </TMPL_IF>
-            </wps:ExceptionReport>
+            </ows:ExceptionReport>
         </wps:ProcessFailed>
         </TMPL_IF>
     </wps:Status>

--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -304,7 +304,8 @@ class Execute(Request):
         # check rawdataoutput against process
         if self.rawDataOutput and self.rawDataOutput not in self.process.outputs:
             self.cleanEnv()
-            raise pywps.InvalidParameterValue("rawDataOutput")
+            raise pywps.InvalidParameterValue("rawDataOutput",
+                "Output [%s] is not defined" % self.rawDataOutput)
 
         # check storeExecuteResponse against process
         if self.storeRequired and not self.process.storeSupported:
@@ -315,14 +316,14 @@ class Execute(Request):
         # check status against process
         if self.statusRequired and not self.process.statusSupported:
             self.cleanEnv()
-            raise pywps.InvalidParameterValue(
+            raise pywps.InvalidParameterValue("status",
                 "status is true, but the process does not support status updates")
 
         # OGC 05-007r7 page 43
         # if status is true and storeExecuteResponse is false, raise an exception
         if self.statusRequired and not self.storeRequired:
             self.cleanEnv()
-            raise pywps.InvalidParameterValue(
+            raise pywps.InvalidParameterValue("status"
                 "status is true, but storeExecuteResponse is false")
       
        #check storeExecuteResponse agains asReference=true
@@ -330,7 +331,8 @@ class Execute(Request):
            #check the array for asreference': True
                if len([item for item in  self.wps.inputs["responseform"]["responsedocument"]["outputs"] if ("asreference" in item and item["asreference"]==True) ]):
                    self.cleanEnv()
-                   raise pywps.InvalidParameterValue("storeExecuteResponse is false, but output(s) are requested as reference(s)")
+                   raise pywps.InvalidParameterValue("storeExecuteResponse",
+                       "storeExecuteResponse is false, but output(s) are requested as reference(s)")
            
         
             
@@ -471,16 +473,17 @@ class Execute(Request):
         # import the right package
         self.process = None
         try:
-            self.process = self.getProcess(self.wps.inputs["identifier"])
+            id = self.wps.inputs["identifier"]
+            self.process = self.getProcess(id)
         except Exception, e:
             self.cleanEnv()
-            raise pywps.InvalidParameterValue(
-                    self.wps.inputs["identifier"])
+            raise pywps.InvalidParameterValue("identifier", 
+                "Unknown identifier '%s'" % (id[0] if isinstance(id,list) else id))
 
         if not self.process:
             self.cleanEnv()
-            raise pywps.InvalidParameterValue(
-                    self.wps.inputs["identifier"])
+            raise pywps.InvalidParameterValue("identifier",
+                "Unknown identifier '%s'" % (id[0] if isinstance(id,list) else id))
 
         # set proper method for status change
         self.process.pywps = self.wps
@@ -532,7 +535,7 @@ class Execute(Request):
                             resp = input.setValue(inp)
                             if resp:
                                 self.cleanEnv()
-                                raise pywps.InvalidParameterValue(resp)
+                                raise pywps.InvalidParameterValue("datainputs", resp)
             except KeyError,e:
                 pass
 

--- a/pywps/Wps/__init__.py
+++ b/pywps/Wps/__init__.py
@@ -339,7 +339,8 @@ http://wiki.rsg.pml.ac.uk/pywps/Introduction
                 continue
             if process.identifier == identifier:
                 return process
-        raise pywps.Exceptions.InvalidParameterValue(identifier)
+        raise pywps.Exceptions.InvalidParameterValue("identifier",
+            "Unknown identifier '%s'" % identifier)
 
     def getProcesses(self, identifiers=None):
         """Get list of processes identified by list of identifiers
@@ -348,7 +349,6 @@ http://wiki.rsg.pml.ac.uk/pywps/Introduction
             or 'all'
         :returns: list of process instances or none
         """
-
         if not identifiers:
             raise pywps.Exceptions.MissingParameterValue("Identifier")
 
@@ -366,7 +366,7 @@ http://wiki.rsg.pml.ac.uk/pywps/Introduction
                     processes.append(self.getProcess(identifier))
 
             if len(processes) == 0:
-                raise pywps.Exceptions.InvalidParameterValue(identifier)
+                raise pywps.Exceptions.InvalidParameterValue("identifier")
             else:
                 return processes
 

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -214,7 +214,7 @@ class Pywps:
         return self.inputs
 
     def performRequest(self,inputs = None, processes=None):
-        """Performs the desired WSP Request.
+        """Performs the desired WPS Request.
 
         :param inputs: idealy self.inputs (Default) object, result from
             parseRequest. Default is self.inputs
@@ -240,8 +240,8 @@ class Pywps:
             from pywps.Wps.Wsdl import Wsdl
             self.request = Wsdl(self)
         else:
-            raise Exceptions.InvalidParameterValue(
-                    "request: "+inputs["request"])
+            raise Exceptions.InvalidParameterValue("request",
+                "Unsupported request type '%s'" % inputs["request"])
         self.response = self.request.response
         return self.response
 


### PR DESCRIPTION
This addresses two issues related to exceptions.

1. The simpler issue is a couple of slight corrections to Execute.tmpl.  First, the `ExceptionReport` element was erroneously in the `wps` namespace when it should be in `ows`.  Secondly, this element was missing a required `version` attribute.  Without these changes, exception outputs would not pass XML schema validation.
2. The second issue is a bit more involved.  Here I have altered `InvalidParameterValue` to take an optional `text` parameter for expressing `ExceptionText`.  This is helpful for indicating the value of the invalid parameter and is recommended in the OGC Web Service Common Standard (see [OGC 06-121r9](http://portal.opengeospatial.org/files/?artifact_id=38867), Page 45, Table 27, Footnote a).  Prior to this change I found it difficult to understand the source of some exceptions that I caused when exercising corner cases.  Furthermore, I have scrubbed much of the code base to add more informative text to `InvalidParameterValue` exceptions where it seemed to make sense, and also ensured that a parameter locator was clearly noted as opposed to a value which was sometimes being used.