### PR TITLE
added getInputValues() method

### DIFF
--- a/pywps/Process/__init__.py
+++ b/pywps/Process/__init__.py
@@ -661,6 +661,18 @@ class WPSProcess:
         except:
             return None
 
+    def getInputValues(self, identifier):
+        """Get input values according to identifier
+        :param identifier: input identifier
+        :return: a list of input values
+        """
+        values = self.getInputValue(identifier)
+        if values is None:
+            values = []
+        elif type(values) != types.ListType:
+            values = [values]
+        return values
+        
     def setOutputValue(self,identifier,value):
         """Set output value
 


### PR DESCRIPTION
the existing getInputValue() returns either a single value or a list. In those cases where i usually expect a list (even with a single value) i use this convenience method getInputValues() so i don't need to check in my processes.

Cleaned up merge, see #98