### PR TITLE
Throw exception if any field in DataInputs is not defined

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -541,6 +541,11 @@ class Execute(Request):
             except KeyError,e:
                 pass
 
+        # make sure, all inputs are defined
+        for inp in self.wps.inputs["datainputs"]:
+            if not inp["identifier"] in self.process.inputs:
+                raise pywps.pywps.InvalidParameterValue("Input [%s] is not defined" % inp["identifier"])
+
         # make sure, all inputs have minimum required number of values
         for identifier in self.process.inputs:
             input = self.process.inputs[identifier]

--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -542,9 +542,11 @@ class Execute(Request):
                 pass
 
         # make sure, all inputs are defined
-        for inp in self.wps.inputs["datainputs"]:
-            if not inp["identifier"] in self.process.inputs:
-                raise pywps.pywps.InvalidParameterValue("Input [%s] is not defined" % inp["identifier"])
+        if self.wps.inputs["datainputs"]:
+            for inp in self.wps.inputs["datainputs"]:
+                if not inp["identifier"] in self.process.inputs:
+                    raise pywps.pywps.InvalidParameterValue(
+                        "Input [%s] is not defined" % inp["identifier"])
 
         # make sure, all inputs have minimum required number of values
         for identifier in self.process.inputs:

--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -545,7 +545,7 @@ class Execute(Request):
         if self.wps.inputs["datainputs"]:
             for inp in self.wps.inputs["datainputs"]:
                 if not inp["identifier"] in self.process.inputs:
-                    raise pywps.pywps.InvalidParameterValue(
+                    raise pywps.pywps.InvalidParameterValue("datainputs",
                         "Input [%s] is not defined" % inp["identifier"])
 
         # make sure, all inputs have minimum required number of values


### PR DESCRIPTION
Throw `InvalidParameterValue` exception if any field in DataInputs is not a defined input parameter.  This is mandatory per Web Processing Service Standard [OGC 05-007r7](http://portal.opengeospatial.org/files/?artifact_id=24151) page 39, Section 10.2.2.1, item 4.