### PR TITLE
s/tab/4 spaces/, cleanup XML requests

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -54,8 +54,8 @@ To use PyWPS-4 the user must code processes and publish them through a service.
 A demo service is available that makes up a good starting point for first time users.
 It can be cloned directly into the user area:
 
-	$ git clone https://github.com/pywps/pywps-4-demo.git
-	
+    $ git clone https://github.com/pywps/pywps-4-demo.git
+
 It may be run right away through the *demo.py* script. 
 First time users should start by studying the demo project structure and then code their own processes.
 

--- a/pywps/resources/schemas/wps_all.xsd
+++ b/pywps/resources/schemas/wps_all.xsd
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:wps="http://www.opengis.net/wps/1.0.0" targetNamespace="http://www.opengis.net/wps/1.0.0" elementFormDefault="unqualified" xml:lang="en" version="1.0.0.3">
-	<include schemaLocation="http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd"/>
+  <include schemaLocation="http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd"/>
 </schema>

--- a/tests/requests/wps_describeprocess_request.xml
+++ b/tests/requests/wps_describeprocess_request.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<DescribeProcess xmlns="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsDescribeProcess_request.xsd" service="WPS" version="1.0.0" language="en">
-	<ows:Identifier>intersection</ows:Identifier>
-	<ows:Identifier>union</ows:Identifier>
-</DescribeProcess>
+<!--
+
+DescribeProcess operation request.
+
+Equivalent GET request is
+
+http://foo.bar/foo?
+    service=WPS&
+    version=1.0.0&
+    language=en-CA&
+    request=DescribeProcess&
+    identifier=intersection,union
+
+-->
+<wps:DescribeProcess language="en" service="WPS" version="1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_request.xsd">
+  <ows:Identifier>intersection</ows:Identifier>
+  <ows:Identifier>union</ows:Identifier>
+</wps:DescribeProcess>

--- a/tests/requests/wps_execute_request-boundingbox.xml
+++ b/tests/requests/wps_execute_request-boundingbox.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
-../wpsExecute_request.xsd">
-	<ows:Identifier>BBox</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>bbox</ows:Identifier>
-			<ows:Title>Bounding box</ows:Title>
-                        <wps:Data>
-                            <wps:BoundingBoxData crs="urn:ogc:crs:EPSG:6.3:26986" dimensions="2">
-                                <ows:LowerCorner>189000 834000</ows:LowerCorner>
-                                <ows:UpperCorner>285000 962000</ows:UpperCorner>
-                            </wps:BoundingBoxData>
-                        </wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+  <ows:Identifier>BBox</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>bbox</ows:Identifier>
+      <ows:Title>Bounding box</ows:Title>
+      <wps:Data>
+        <wps:BoundingBoxData crs="urn:ogc:crs:EPSG:6.3:26986" dimensions="2">
+          <ows:LowerCorner>189000 834000</ows:LowerCorner>
+          <ows:UpperCorner>285000 962000</ows:UpperCorner>
+        </wps:BoundingBoxData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
 </wps:Execute>

--- a/tests/requests/wps_execute_request-complexvalue.xml
+++ b/tests/requests/wps_execute_request-complexvalue.xml
@@ -1,48 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- Execute operation request assuming use of optional formats and output elements.-->
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
-../wpsExecute_request.xsd">
-	<ows:Identifier>Reclassification</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>InputLayer</ows:Identifier>
-			<ows:Title>The layer which's values shall be reclassified</ows:Title>
-			<wps:Reference xlink:href="http://orchestra.pisa.intecs.it/geoserver/test/height.tif" method="GET"/>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferDistance</ows:Identifier>
-			<ows:Title>Distance which people will walk to get to a playground.</ows:Title>
-			<wps:Data>
-				<wps:ComplexData>
-					<!--embedded XML begins here.-->
-					<RangeToValueMappings xmlns="http://mas.orchestra.jrc.it" xmlns:ows="http://www.opengeospatial.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-						<Mapping>
-							<ows:Range ows:rangeClosure="closed-open">
-								<ows:MinimumValue>0</ows:MinimumValue>
-								<ows:MaximumValue>119</ows:MaximumValue>
-							</ows:Range>
-							<ows:Value>A</ows:Value>
-						</Mapping>
-						<Mapping>
-							<ows:Range ows:rangeClosure="closed-open">
-								<ows:MinimumValue>120</ows:MinimumValue>
-								<ows:MaximumValue/>
-							</ows:Range>
-							<ows:Value>B</ows:Value>
-						</Mapping>
-					</RangeToValueMappings>
-					<!--embedded XML ends here.-->
-				</wps:ComplexData>
-			</wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
-	<wps:ResponseForm>
-		<wps:ResponseDocument storeExecuteResponse="true" lineage="true" status="true">
-			<wps:Output asReference="true">
-				<ows:Identifier>Outlayer</ows:Identifier>
-				<ows:Title>Reclassified Layer.</ows:Title>
-				<ows:Abstract>Layer classified into two classes, where class A is less than or equal 120 and class B is more than 120.</ows:Abstract>
-			</wps:Output>
-		</wps:ResponseDocument>
-	</wps:ResponseForm>
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+  <ows:Identifier>Reclassification</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>InputLayer</ows:Identifier>
+      <ows:Title>The layer which's values shall be reclassified</ows:Title>
+      <wps:Reference method="GET" xlink:href="http://orchestra.pisa.intecs.it/geoserver/test/height.tif"/>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferDistance</ows:Identifier>
+      <ows:Title>Distance which people will walk to get to a playground.</ows:Title>
+      <wps:Data>
+        <wps:ComplexData>
+          <!--embedded XML begins here.-->
+          <RangeToValueMappings xmlns="http://mas.orchestra.jrc.it" xmlns:ows="http://www.opengeospatial.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <Mapping>
+              <ows:Range ows:rangeClosure="closed-open">
+                <ows:MinimumValue>0</ows:MinimumValue>
+                <ows:MaximumValue>119</ows:MaximumValue>
+              </ows:Range>
+              <ows:Value>A</ows:Value>
+            </Mapping>
+            <Mapping>
+              <ows:Range ows:rangeClosure="closed-open">
+                <ows:MinimumValue>120</ows:MinimumValue>
+                <ows:MaximumValue/>
+              </ows:Range>
+              <ows:Value>B</ows:Value>
+            </Mapping>
+          </RangeToValueMappings>
+          <!--embedded XML ends here.-->
+        </wps:ComplexData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:ResponseDocument lineage="true" status="true" storeExecuteResponse="true">
+      <wps:Output asReference="true">
+        <ows:Identifier>Outlayer</ows:Identifier>
+        <ows:Title>Reclassified Layer.</ows:Title>
+        <ows:Abstract>Layer classified into two classes, where class A is less than or equal 120 and class B is more than 120.</ows:Abstract>
+      </wps:Output>
+    </wps:ResponseDocument>
+  </wps:ResponseForm>
 </wps:Execute>

--- a/tests/requests/wps_execute_request-responsedocument-1.xml
+++ b/tests/requests/wps_execute_request-responsedocument-1.xml
@@ -1,40 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Execute operation request assuming use of default formats.-->
-<!-- Equivalent GET request is 
-		http://foo.bar/foo?
-			Service=WPS&
-			Version=1.0.0&
-			Language=en-CA&
-			Request=Execute&
-			Identifier=Buffer&
-			DataInputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400]
-			ResponseDocument=[BufferedPolygon=@asReference=true]&
-			storeExecuteResponse=true
+<!--
+
+Execute operation request assuming use of default formats.
+
+Equivalent GET request is:
+
+http://foo.bar/foo?
+    service=WPS&
+    version=1.0.0&
+    language=en-CA&
+    request=Execute&
+    identifier=Buffer&
+    datainputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400] ResponseDocument=[BufferedPolygon=@asReference=true]&
+    storeexecuteresponse=true
+
 -->
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
-../wpsExecute_request.xsd">
-	<ows:Identifier>Buffer</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>InputPolygon</ows:Identifier>
-			<ows:Title>Playground area</ows:Title>
-			<wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferDistance</ows:Identifier>
-			<ows:Title>Distance which people will walk to get to a playground.</ows:Title>
-			<wps:Data>
-				<wps:LiteralData>400</wps:LiteralData>
-			</wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
-	<wps:ResponseForm>
-		<wps:ResponseDocument storeExecuteResponse="true">
-			<wps:Output asReference="true">
-				<ows:Identifier>BufferedPolygon</ows:Identifier>
-				<ows:Title>Area serviced by playground.</ows:Title>
-				<ows:Abstract>Area within which most users of this playground will live.</ows:Abstract>
-			</wps:Output>
-		</wps:ResponseDocument>
-	</wps:ResponseForm>
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ihttp://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+  <ows:Identifier>Buffer</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>InputPolygon</ows:Identifier>
+      <ows:Title>Playground area</ows:Title>
+      <wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferDistance</ows:Identifier>
+      <ows:Title>Distance which people will walk to get to a playground.</ows:Title>
+      <wps:Data>
+        <wps:LiteralData>400</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:ResponseDocument storeExecuteResponse="true">
+      <wps:Output asReference="true">
+        <ows:Identifier>BufferedPolygon</ows:Identifier>
+        <ows:Title>Area serviced by playground.</ows:Title>
+        <ows:Abstract>Area within which most users of this playground will live.</ows:Abstract>
+      </wps:Output>
+    </wps:ResponseDocument>
+  </wps:ResponseForm>
 </wps:Execute>

--- a/tests/requests/wps_execute_request-responsedocument-2.xml
+++ b/tests/requests/wps_execute_request-responsedocument-2.xml
@@ -1,43 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Execute operation request assuming use of optional formats and output elements.-->
-<!-- Equivalent GET request is 
-		http://foo.bar/foo?
-			Service=WPS&
-			Version=1.0.0&
-			Language=en-CA&
-			Request=Execute&
-			Identifier=Buffer&
-			DataInputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml@method=POST@mimeType=text/xml@encoding=UTF-8@schema=http%3A%2F%2Ffoo.bar%2Fgml_polygon_schema.xsd
-			;BufferDistance=400@uom=feet]&
-			ResponseDocument=[BufferedPolygon=@asReference=true]&
-			storeExecuteResponse=true&
-			lineage=true&
-			status=true
+<!--
+
+Execute operation request assuming use of optional formats and output elements.
+
+Equivalent GET request is:
+
+http://foo.bar/foo?
+    service=WPS&
+    version=1.0.0&
+    language=en-CA&
+    request=Execute&
+    identifier=Buffer&
+    datainputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml@method=POST@mimeType=text/xml@encoding=UTF-8@schema=http%3A%2F%2Ffoo.bar%2Fgml_polygon_schema.xsd;BufferDistance=400@uom=feet]&
+    responsedocument=[BufferedPolygon=@asReference=true]&
+    storeexecuteresponse=true&
+    lineage=true&
+    status=true
+
 -->
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
-../wpsExecute_request.xsd">
-	<ows:Identifier>Buffer</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>InputPolygon</ows:Identifier>
-			<ows:Title>Playground area</ows:Title>
-			<wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml" method="POST" mimeType="text/xml" encoding="UTF-8" schema="http://foo.bar/gml_polygon_schema.xsd"/>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferDistance</ows:Identifier>
-			<ows:Title>Distance which people will walk to get to a playground.</ows:Title>
-			<wps:Data>
-				<wps:LiteralData uom="feet">400</wps:LiteralData>
-			</wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
-	<wps:ResponseForm>
-		<wps:ResponseDocument storeExecuteResponse="true" lineage="true" status="true">
-			<wps:Output asReference="true">
-				<ows:Identifier>BufferedPolygon</ows:Identifier>
-				<ows:Title>Area serviced by playground.</ows:Title>
-				<ows:Abstract>Area within which most users of this playground will live.</ows:Abstract>
-			</wps:Output>
-		</wps:ResponseDocument>
-	</wps:ResponseForm>
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+  <ows:Identifier>Buffer</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>InputPolygon</ows:Identifier>
+      <ows:Title>Playground area</ows:Title>
+      <wps:Reference encoding="UTF-8" method="POST" mimeType="text/xml" schema="http://foo.bar/gml_polygon_schema.xsd" xlink:href="http://foo.bar/some_WFS_request.xml"/>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferDistance</ows:Identifier>
+      <ows:Title>Distance which people will walk to get to a playground.</ows:Title>
+      <wps:Data>
+        <wps:LiteralData uom="feet">400</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:ResponseDocument lineage="true" status="true" storeExecuteResponse="true">
+      <wps:Output asReference="true">
+        <ows:Identifier>BufferedPolygon</ows:Identifier>
+        <ows:Title>Area serviced by playground.</ows:Title>
+        <ows:Abstract>Area within which most users of this playground will live.</ows:Abstract>
+      </wps:Output>
+    </wps:ResponseDocument>
+  </wps:ResponseForm>
 </wps:Execute>

--- a/tests/requests/wps_execute_request_extended-responsedocument.xml
+++ b/tests/requests/wps_execute_request_extended-responsedocument.xml
@@ -1,62 +1,66 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Execute operation request assuming use of default formats.-->
-<!-- Equivalent GET request (without the BufferZoneWidth) is 
-		http://foo.bar/foo?
-			Service=WPS&
-			Version=1.0.0&
-			Language=en-CA&
-			Request=Execute&
-			Identifier=Buffer&
-			DataInputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400]
-			ResponseDocument=[BufferedPolygon=@asReference=true]&
-			storeExecuteResponse=true
+<!--
+
+Execute operation request assuming use of default formats.
+
+Equivalent GET request (without the BufferZoneWidth) is:
+
+http://foo.bar/foo?
+    service=WPS&
+    version=1.0.0&
+    language=en-CA&
+    request=Execute&
+    identifier=Buffer&
+    datainputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400]&
+    responsedocument=[BufferedPolygon=@asReference=true]&
+    storeexecuteresponse=true
+
 -->
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
-../wpsExecute_request.xsd">
-	<ows:Identifier>Buffer</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>InputPolygon</ows:Identifier>
-			<ows:Title>Playground area</ows:Title>
-			<wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferDistance</ows:Identifier>
-			<ows:Title>Distance which people will walk to get to a playground .</ows:Title>
-			<wps:Data>
-				<wps:LiteralData>400</wps:LiteralData>
-			</wps:Data>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferZoneWidth</ows:Identifier>
-			<ows:Title>Defining buffer zone width</ows:Title>
-			<wps:Data>
-				<wps:ComplexData schema="http://foo.bar/MyComplexValueSchema.xsd" mimeType="text/xml" encoding="UTF-8">
-					<BufferZones>
-						<Zone>
-							<ows:Range ows:rangeClosure="closed">
-								<ows:MinimumValue>0</ows:MinimumValue>
-								<ows:MaximumValue>100</ows:MaximumValue>
-							</ows:Range>
-						</Zone>
-						<Zone>
-							<ows:Range ows:rangeClosure="open-closed">
-								<ows:MinimumValue>100</ows:MinimumValue>
-								<ows:MaximumValue>400</ows:MaximumValue>
-							</ows:Range>
-						</Zone>
-					</BufferZones>
-				</wps:ComplexData>
-			</wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
-	<wps:ResponseForm>
-		<wps:ResponseDocument storeExecuteResponse="true">
-			<wps:Output asReference="true">
-				<ows:Identifier>BufferedPolygon</ows:Identifier>
-				<ows:Title>Area serviced by playground.</ows:Title>
-				<ows:Abstract>Area within which most users of this playground will live plus the buffer.</ows:Abstract>
-			</wps:Output>
-		</wps:ResponseDocument>
-	</wps:ResponseForm>
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
+  <ows:Identifier>Buffer</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>InputPolygon</ows:Identifier>
+      <ows:Title>Playground area</ows:Title>
+      <wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferDistance</ows:Identifier>
+      <ows:Title>Distance which people will walk to get to a playground .</ows:Title>
+      <wps:Data>
+        <wps:LiteralData>400</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferZoneWidth</ows:Identifier>
+      <ows:Title>Defining buffer zone width</ows:Title>
+      <wps:Data>
+        <wps:ComplexData encoding="UTF-8" mimeType="text/xml" schema="http://foo.bar/MyComplexValueSchema.xsd">
+          <BufferZones>
+            <Zone>
+              <ows:Range ows:rangeClosure="closed">
+                <ows:MinimumValue>0</ows:MinimumValue>
+                <ows:MaximumValue>100</ows:MaximumValue>
+              </ows:Range>
+            </Zone>
+            <Zone>
+              <ows:Range ows:rangeClosure="open-closed">
+                <ows:MinimumValue>100</ows:MinimumValue>
+                <ows:MaximumValue>400</ows:MaximumValue>
+              </ows:Range>
+            </Zone>
+          </BufferZones>
+        </wps:ComplexData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:ResponseDocument storeExecuteResponse="true">
+      <wps:Output asReference="true">
+        <ows:Identifier>BufferedPolygon</ows:Identifier>
+        <ows:Title>Area serviced by playground.</ows:Title>
+        <ows:Abstract>Area within which most users of this playground will live plus the buffer.</ows:Abstract>
+      </wps:Output>
+    </wps:ResponseDocument>
+  </wps:ResponseForm>
 </wps:Execute>

--- a/tests/requests/wps_execute_request_rawdataoutput.xml
+++ b/tests/requests/wps_execute_request_rawdataoutput.xml
@@ -1,36 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Execute operation request assuming use of default formats, and RawDataOutput.-->
-<!-- Equivalent GET request is 
-		http://foo.bar/foo?
-			Service=WPS&
-			Version=1.0.0&
-			Language=en-CA&
-			Request=Execute&
-			Identifier=Buffer&
-			DataInputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400]&
-			RawDataOutput=[BufferedPolygon]
+<!--
+
+Execute operation request assuming use of default formats, and RawDataOutput.
+
+Equivalent GET request is:
+
+http://foo.bar/foo?
+    service=WPS&
+    version=1.0.0&
+    language=en-CA&
+    request=Execute&
+    identifier=Buffer&
+    datainputs=[InputPolygon=@xlink:href=http%3A%2F%2Ffoo.bar%2Fsome_WFS_request.xml;BufferDistance=400]&
+    rawdataoutput=[BufferedPolygon]
 
 -->
-<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
+<wps:Execute service="WPS" version="1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0
 ../wpsExecute_request.xsd">
-	<ows:Identifier>Buffer</ows:Identifier>
-	<wps:DataInputs>
-		<wps:Input>
-			<ows:Identifier>InputPolygon</ows:Identifier>
-			<ows:Title>Playground area</ows:Title>
-			<wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
-		</wps:Input>
-		<wps:Input>
-			<ows:Identifier>BufferDistance</ows:Identifier>
-			<ows:Title>Distance which people will walk to get to a playground.</ows:Title>
-			<wps:Data>
-				<wps:LiteralData>400</wps:LiteralData>
-			</wps:Data>
-		</wps:Input>
-	</wps:DataInputs>
-	<wps:ResponseForm>
-		<wps:RawDataOutput>
-			<ows:Identifier>BufferedPolygon</ows:Identifier>
-		</wps:RawDataOutput>
-	</wps:ResponseForm>
+  <ows:Identifier>Buffer</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>InputPolygon</ows:Identifier>
+      <ows:Title>Playground area</ows:Title>
+      <wps:Reference xlink:href="http://foo.bar/some_WFS_request.xml"/>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>BufferDistance</ows:Identifier>
+      <ows:Title>Distance which people will walk to get to a playground.</ows:Title>
+      <wps:Data>
+        <wps:LiteralData>400</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:RawDataOutput>
+      <ows:Identifier>BufferedPolygon</ows:Identifier>
+    </wps:RawDataOutput>
+  </wps:ResponseForm>
 </wps:Execute>

--- a/tests/requests/wps_getcapabilities_request.xml
+++ b/tests/requests/wps_getcapabilities_request.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- WPS GetCapabilities request-->
 <!-- Equivalent GET request is http://foo.bar/foo?Service=WPS&Version=1.0.0&Request=GetCapabilities&Language=en-CA -->
-<wps:GetCapabilities xmlns:ows="http://www.opengis.net/ows/1.1"
-			xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink"
-			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsGetCapabilities_request.xsd"
-			language="cz" service="WPS">
-			<wps:AcceptVersions>
-				<ows:Version>1.0.0</ows:Version>
-			</wps:AcceptVersions>
-		</wps:GetCapabilities>
+<wps:GetCapabilities language="cz" service="WPS" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsGetCapabilities_request.xsd">
+  <wps:AcceptVersions>
+    <ows:Version>1.0.0</ows:Version>
+  </wps:AcceptVersions>
+</wps:GetCapabilities>


### PR DESCRIPTION
# Overview

This PR replaces all tabs (except for `docs/Makefile` and `debian/rules`) with 4 spaces for consistency/best practice.  As well, XML requests in `tests/requests` are cleaned up for consistency.


# Related Issue / Discussion

None

# Additional Information

None
