### PR TITLE
add version watermark to XML responses

### DIFF
--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -1,6 +1,6 @@
 import lxml
 from werkzeug.wrappers import Response
-from pywps import OWS, NAMESPACES, OGCUNIT
+from pywps import __version__, OWS, NAMESPACES, OGCUNIT
 
 
 def xpath_ns(el, path):
@@ -8,7 +8,9 @@ def xpath_ns(el, path):
 
 
 def xml_response(doc):
-    response = Response(lxml.etree.tostring(doc, pretty_print=True),
-                    content_type='text/xml')
+    pywps_version_comment = '<!-- PyWPS %s -->\n' % __version__
+    xml = lxml.etree.tostring(doc, pretty_print=True)
+    response = Response(pywps_version_comment.encode('utf8') + xml,
+                        content_type='text/xml')
     response.status_percentage = 100;
     return response

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -37,6 +37,7 @@ from werkzeug.http import HTTP_STATUS_CODES
 
 import logging
 
+from pywps import __version__
 
 class NoApplicableCode(HTTPException):
     """No applicable code exception implementation
@@ -77,12 +78,14 @@ class NoApplicableCode(HTTPException):
         """Get the XML body."""
         return text_type((
             u'<?xml version="1.0" encoding="UTF-8"?>\n'
+            u'<!-- PyWPS %(version)s -->\n'
             u'<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsExceptionReport.xsd" version="1.0.0">'
             u'<ows:Exception exceptionCode="%(name)s" locator="%(locator)s" >'
             u'%(description)s'
             u'</ows:Exception>'
             u'</ows:ExceptionReport>'
         ) % {
+            'version': __version__,
             'code':         self.code,
             'locator':         escape(self.locator),
             'name':         escape(self.name),

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 import lxml.etree
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
-from pywps import NAMESPACES
+from pywps import __version__, NAMESPACES
 
 import logging
 
@@ -58,3 +58,13 @@ def assert_response_success(resp):
     assert resp.headers['Content-Type'] == 'text/xml'
     success = resp.xpath('/wps:ExecuteResponse/wps:Status/wps:ProcessSucceeded')
     assert len(success) == 1
+
+
+def assert_pywps_version(resp):
+    # get first child of root element
+    root_firstchild = resp.xpath('/*')[0].getprevious()
+    assert isinstance(root_firstchild, lxml.etree._Comment)
+    tokens = root_firstchild.text.split()
+    assert len(tokens) == 2
+    assert tokens[0] == 'PyWPS'
+    assert tokens[1] == __version__

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2,7 +2,7 @@ import unittest
 import lxml.etree
 from pywps.app import Process, Service
 from pywps import WPS, OWS
-from tests.common import client_for
+from tests.common import assert_pywps_version, client_for
 
 class BadRequestTest(unittest.TestCase):
 
@@ -84,6 +84,9 @@ class CapabilitiesTest(unittest.TestCase):
         assert resp.status_code == 400
         assert exception[0].attrib['exceptionCode'] == 'VersionNegotiationFailed'
 
+    def test_pywps_version(self):
+        resp = self.client.get('?service=WPS&request=GetCapabilities')
+        assert_pywps_version(resp)
 
 
 def load_tests(loader=None, tests=None, pattern=None):

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -9,7 +9,7 @@ from pywps.inout.formats import Format
 from pywps.inout.literaltypes import AllowedValue
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE
 
-from tests.common import client_for
+from tests.common import assert_pywps_version, client_for
 
 ProcessDescription = namedtuple('ProcessDescription', ['identifier', 'inputs'])
 
@@ -64,6 +64,7 @@ class DescribeProcessTest(unittest.TestCase):
         identifiers = [desc.identifier for desc in get_describe_result(resp)]
         assert 'ping' in identifiers
         assert 'hello' in identifiers
+        assert_pywps_version(resp)
 
     def test_get_request_zero_args(self):
         resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,9 +1,8 @@
 import unittest
 from pywps import Process, Service, WPS, OWS
 from pywps.app.basic import xpath_ns
-from tests.common import client_for
+from tests.common import assert_pywps_version, client_for
 import lxml.etree
-
 
 
 class ExceptionsTest(unittest.TestCase):
@@ -17,6 +16,7 @@ class ExceptionsTest(unittest.TestCase):
         assert exception_el.attrib['exceptionCode'] == 'InvalidParameterValue'
         assert resp.status_code == 400
         assert resp.headers['Content-Type'] == 'text/xml'
+        assert_pywps_version(resp)
 
     def test_missing_parameter_value(self):
         resp = self.client.get()


### PR DESCRIPTION
# Overview
This PR adds an XML comment to all XML response documents articulating the given version.  The value here is being able to easily identify the version being deployed (makes detecting versionitis/debugging multiple versions very straightforward).

# Related Issue / Discussion
None
# Additional Information
None