### PR TITLE
move ows:Type into ows:Keywords, provide absolute schemaLocation for …

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -64,7 +64,7 @@ class Service(object):
         if config.get_config_value('metadata:main', 'identification_keywords_type'):
             keywords_type = OWS.Type(config.get_config_value('metadata:main', 'identification_keywords_type'))
             keywords_type.attrib['codeSpace'] = 'ISOTC211/19115'
-            service_ident_doc.append(keywords_type)
+            keywords_doc.append(keywords_type)
 
         service_ident_doc.append(OWS.ServiceType('WPS'))
 

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -79,7 +79,7 @@ class NoApplicableCode(HTTPException):
         return text_type((
             u'<?xml version="1.0" encoding="UTF-8"?>\n'
             u'<!-- PyWPS %(version)s -->\n'
-            u'<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsExceptionReport.xsd" version="1.0.0">'
+            u'<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="1.0.0">'
             u'<ows:Exception exceptionCode="%(name)s" locator="%(locator)s" >'
             u'%(description)s'
             u'</ows:Exception>'


### PR DESCRIPTION
# Overview
This PR fixes XML validation errors for `GetCapabilities` responses as well as provides a full qualified URL for `xsi:schemaLocation` as part of `ows:ExceptionReport` responses.

# Related Issue / Discussion
CITE testing
# Additional Information

