### PR TITLE
fix: check if complexinput attributes are available for lineage info

### DIFF
--- a/pywps/Wps/Execute/__init__.py
+++ b/pywps/Wps/Execute/__init__.py
@@ -838,9 +838,12 @@ class Execute(Request):
         """
        
         #complexInput needs to be replicated
-        complexInput["encoding"]=wpsInput["encoding"]
-        complexInput["mimetype"]=wpsInput["mimetype"]
-        complexInput["schema"]=wpsInput["schema"]
+        if wpsInput.has_key("encoding"):
+            complexInput["encoding"]=wpsInput["encoding"]
+        if wpsInput.has_key("mimetype"):
+            complexInput["mimetype"]=wpsInput["mimetype"]
+        if wpsInput.has_key("schema"):
+            complexInput["schema"]=wpsInput["schema"]
         complexInput["complexdata"]=wpsInput["value"]
         
         return complexInput


### PR DESCRIPTION
# Overview

i'm using the lineage info of wps. In some cases the attributes "encoding", "mimeType", ... are not available for ComplexDataInput. This patch checks if those attributes are available to avoid an exception otherwise.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines

