### PR TITLE
install demo with https://github.com:ldesousa/pywps-4-demo.git pywps-…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ Or in alternative install it manually:
 Install demo service
 --------------------
 
-    $ git clone git@github.com:ldesousa/pywps-4-demo.git pywps-4-demo
+    $ git clone https://github.com/ldesousa/pywps-4-demo.git pywps-4-demo
     
 
 Run demo


### PR DESCRIPTION
# Overview
Minor doc fix `INSTALL.md`: `git clone git@github.com:ldesousa/pywps-4-demo.git pywps-4-demo` will work only if one has a keypair bound with GH. When e.g. in a clean OS env (e.g. Ubuntu via Vagrant) it may be more convenient to use `git clone https://github.com:ldesousa/pywps-4-demo.git pywps-4-demo` just like the pywps.git clone-example itself. Also to test workflow for contributing  to PyWPS :-)

# Related Issue / Discussion
N.A.
# Additional Information
N.A.
# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines

…4-demo