### PR TITLE
add support for python and grass gis

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -57,6 +57,9 @@ PyWPS ships with a sample configuration (``default-sample.cfg``).  Copy the file
 - **contact_instructions**: the how to contact the provider contact
 - **contact_role**: the role of the provider contact as per the `ISO 19115 CI_RoleCode codelist <http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode>`_).  Accepted values are ``author``, ``processor``, ``publisher``, ``custodian``, ``pointOfContact``, ``distributor``, ``user``, ``resourceProvider``, ``originator``, ``owner``, ``principalInvestigator``
 
+**[grass]**
+- **gisbase**: directory of GRASS GIS instalation, refered as `GISBASE <https://grass.osgeo.org/grass73/manuals/variables.html>`_
+
 -----------
 Sample file
 -----------
@@ -102,3 +105,6 @@ Sample file
   contact_hours=Hours of Service
   contact_instructions=During hours of service.  Off on weekends.
   contact_role=pointOfContact
+
+  [grass]
+  gisbase=/usr/local/grass-7.3.svn/

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -34,7 +34,7 @@ from lxml.builder import ElementMaker
 
 __version__ = '4.0.0-alpha2'
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 LOGGER.debug('setting core variables')
 

--- a/pywps/_compat.py
+++ b/pywps/_compat.py
@@ -30,7 +30,7 @@
 import logging
 import sys
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 PY2 = sys.version_info[0] == 2
 
 if PY2:

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -28,16 +28,19 @@ import os
 import sys
 import traceback
 import json
+import shutil
+import tempfile
 
 from pywps import WPS, OWS, E, dblog
 from pywps.app.WPSResponse import WPSResponse
 from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
+from pywps._compat import PY2
 from pywps.exceptions import StorageNotSupported, OperationNotSupported, \
-    ServerBusy
+    ServerBusy, NoApplicableCode
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("PYWPS")
 
 class Process(object):
     """
@@ -57,7 +60,7 @@ class Process(object):
     """
 
     def __init__(self, handler, identifier, title, abstract='', profile=[], metadata=[], inputs=[],
-                 outputs=[], version='None', store_supported=False, status_supported=False):
+                 outputs=[], version='None', store_supported=False, status_supported=False, grass_location=None):
         self.identifier = identifier
         self.handler = handler
         self.title = title
@@ -71,6 +74,9 @@ class Process(object):
         self.status_location = ''
         self.status_url = ''
         self.workdir = None
+        self._grass_mapset = None
+        self.grass_location = grass_location
+
 
         if store_supported:
             self.store_supported = 'true'
@@ -81,6 +87,8 @@ class Process(object):
             self.status_supported = 'true'
         else:
             self.status_supported = 'false'
+
+
 
     def capabilities_xml(self):
         doc = WPS.Process(
@@ -134,7 +142,6 @@ class Process(object):
         return doc
 
     def execute(self, wps_request, uuid):
-
         self._set_uuid(uuid)
         async = False
         wps_response = WPSResponse(self, wps_request, self.uuid)
@@ -230,12 +237,13 @@ class Process(object):
 
     def _run_process(self, wps_request, wps_response):
         try:
+            self._set_grass()
             wps_response = self.handler(wps_request, wps_response)
 
             # if status not yet set to 100% then do it after execution was successful
             if wps_response.status_percentage != 100:
                 LOGGER.debug('Updating process status to 100% if everything went correctly')
-                wps_response.update_status('PyWPS Process finished', 100)
+                wps_response.update_status('PyWPS Process finished', 100, wps_response.DONE_STATUS)
         except Exception as e:
             traceback.print_exc()
             LOGGER.debug('Retrieving file and line number where exception occurred')
@@ -276,6 +284,15 @@ class Process(object):
 
         return wps_response
 
+    def clean(self):
+        """Clean the process working dir and other temporary files
+        """
+        LOGGER.info("Removing temporary working directory: %s" % self.workdir)
+        shutil.rmtree(self.workdir)
+        if self._grass_mapset and os.path.isdir(self._grass_mapset):
+            LOGGER.info("Removing temporary GRASS GIS mapset: %s" % self._grass_mapset)
+            shutil.rmtree(self._grass_mapset)
+
     def set_workdir(self, workdir):
         """Set working dir for all inputs and outputs
 
@@ -288,3 +305,85 @@ class Process(object):
 
         for outpt in self.outputs:
             outpt.workdir = workdir
+
+    def _set_grass(self):
+        """Handle given grass_location parameter of the constructor
+
+        location is either directory name or 'epsg:1234' form
+
+        in the first case, new temporary mapset within the location will be
+        created
+
+        in the second case, location will be created in self.workdir
+
+        the mapset should be deleted automatically using self.clean() method
+        """
+
+        if not PY2:
+            raise NoApplicableCode(
+                'Seems PyWPS is running in Python-3 ' +
+                'environment, but GRASS GIS supports Python-2 only')
+
+        if self.grass_location:
+
+            from grass.script import core as grass
+            import grass.script.setup as gsetup
+
+            dbase = ''
+            location = ''
+
+            # HOME needs to be set - and that is usually not the case for httpd
+            # server
+            os.environ['HOME'] =  self.workdir
+
+            # GISRC envvariable needs to be set
+            gisrc = open(os.path.join(self.workdir, 'GISRC'), 'w')
+            gisrc.write("GISDBASE: %s\n" % self.workdir)
+            gisrc.write("GUI: txt\n")
+            gisrc.close()
+            os.environ['GISRC'] = gisrc.name
+
+            # create new location from epsg code
+            if self.grass_location.lower().startswith('epsg:'):
+                epsg = self.grass_location.lower().replace('epsg:', '')
+                dbase = self.workdir
+                os.environ['GISDBASE'] =  self.workdir
+                location = 'pywps_location'
+                grass.run_command('g.gisenv', set="GISDBASE=%s" % dbase)
+                grass.run_command('g.proj', flags="t", location=location, epsg=epsg)
+                LOGGER.debug('GRASS location based on EPSG code created')
+
+            # create temporary mapset within existing location
+            elif os.path.isdir(self.grass_location):
+                LOGGER.debug('Temporary mapset will be created')
+                dbase = os.path.dirname(self.grass_location)
+                location = os.path.basename(self.grass_location)
+                grass.run_command('g.gisenv', set="GISDBASE=%s" % dbase)
+
+            else:
+                raise NoApplicableCode(
+                    'Location does exists or does not seem to be in "EPSG:XXXX" form nor is it existing directory: %s' % location)
+
+            # copy projection files from PERMAMENT mapset to temporary mapset
+            mapset_name = tempfile.mkdtemp(prefix='pywps_', dir=os.path.join(dbase, location))
+            shutil.copy(os.path.join(dbase, location, 'PERMANENT',
+                'DEFAULT_WIND'), os.path.join(mapset_name, 'WIND'))
+            shutil.copy(os.path.join(dbase, location, 'PERMANENT',
+                'PROJ_EPSG'), os.path.join(mapset_name, 'PROJ_EPSG'))
+            shutil.copy(os.path.join(dbase, location, 'PERMANENT',
+                'PROJ_INFO'), os.path.join(mapset_name, 'PROJ_INFO'))
+            shutil.copy(os.path.join(dbase, location, 'PERMANENT',
+                'PROJ_UNITS'), os.path.join(mapset_name, 'PROJ_UNITS'))
+
+            # set _grass_mapset attribute - will be deleted once handler ends
+            self._grass_mapset = mapset_name
+
+            # final initialization
+            LOGGER.debug('GRASS Mapset set to %s' % mapset_name)
+            grass.run_command('g.gisenv', set="LOCATION_NAME=%s" % location)
+            grass.run_command('g.gisenv', set="MAPSET=%s" % os.path.basename(mapset_name))
+
+            LOGGER.debug(
+                'GRASS environment initialised with GISRC {}, GISBASE {}, GISDBASE {}, LOCATION {}, MAPSET {}'.format(
+                os.environ.get('GISRC'), os.environ.get('GISBASE'),
+                dbase, location, os.path.basename(mapset_name)))

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -15,11 +15,11 @@ from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, update_response
 
 from collections import deque
-import shutil
 import os
+import sys
 import uuid
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("PYWPS")
 
 class Service(object):
 
@@ -44,6 +44,7 @@ class Service(object):
             LOGGER.addHandler(fh)
         else:  # NullHandler
             LOGGER.addHandler(logging.NullHandler())
+
 
     def get_capabilities(self):
         process_elements = [p.capabilities_xml()
@@ -284,6 +285,7 @@ class Service(object):
         :param wps_request: pywps.WPSRequest structure with parsed inputs, still in memory
         :param uuid: string identifier of the request
         """
+        self._set_grass()
         response = None
         try:
             process = self.processes[identifier]
@@ -300,7 +302,6 @@ class Service(object):
             response = self._parse_and_execute(process, wps_request, uuid)
         finally:
             os.chdir(olddir)
-            shutil.rmtree(process.workdir)
 
         return response
 
@@ -371,7 +372,9 @@ class Service(object):
             for outpt in wps_request.outputs:
                 for proc_outpt in process.outputs:
                     if outpt == proc_outpt.identifier:
-                        return Response(proc_outpt.data)
+                        resp = Response(proc_outpt.data)
+                        resp.call_on_close(process.clean)
+                        return resp
 
             # if the specified identifier was not found raise error
             raise InvalidParameterValue('')
@@ -495,6 +498,38 @@ class Service(object):
 
         return outinputs
 
+    def _set_grass(self):
+        """Set environment variables needed for GRASS GIS support
+        """
+
+        if not PY2:
+            LOGGER.debug('Python3 is not supported by GRASS')
+            return
+
+        gisbase = config.get_config_value('grass', 'gisbase')
+        if gisbase and os.path.isdir(gisbase):
+            LOGGER.debug('GRASS GISBASE set to %s' % gisbase)
+
+            os.environ['GISBASE'] = gisbase
+
+            os.environ['LD_LIBRARY_PATH'] = '{}:{}'.format(
+                os.environ.get('LD_LIBRARY_PATH'),
+                os.path.join(gisbase, 'lib'))
+            os.putenv('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH'))
+
+            os.environ['PATH'] = '{}:{}:{}'.format(
+                os.environ.get('PATH'),
+                os.path.join(gisbase, 'bin'),
+                os.path.join(gisbase, 'scripts'))
+            os.putenv('PATH', os.environ.get('PATH'))
+
+            python_path = os.path.join(gisbase, 'etc', 'python')
+            os.environ['PYTHONPATH'] = '{}:{}'.format(os.environ.get('PYTHONPATH'),
+                    python_path)
+            os.putenv('PYTHONPATH', os.environ.get('PYTHONPATH'))
+            sys.path.insert(0, python_path)
+
+
     def create_bbox_inputs(self, source, inputs):
         """ Takes the http_request and parses the input to objects
         :return collections.deque:
@@ -509,7 +544,9 @@ class Service(object):
             outinputs.append(newinpt)
 
         if len(outinputs) < source.min_occurs:
-            raise MissingParameterValue(locator=source.identifier)
+            raise MissingParameterValue(
+                description='Number of inputs is lower than minium required number of inputs',
+                locator=source.identifier)
 
         return outinputs
 

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -3,7 +3,7 @@ import lxml
 from werkzeug.wrappers import Response
 from pywps import __version__, OWS, NAMESPACES, OGCUNIT
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 def xpath_ns(el, path):
     return el.xpath(path, namespaces=NAMESPACES)

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -40,7 +40,7 @@ else:
 
 
 config = None
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("PYWPS")
 
 
 def get_config_value(section, option):
@@ -126,6 +126,9 @@ def load_configuration(cfgfiles=None):
     config.set('metadata:main', 'contact_hours', 'Hours of Service')
     config.set('metadata:main', 'contact_instructions', 'During hours of service.  Off on weekends.')
     config.set('metadata:main', 'contact_role', 'pointOfContact')
+
+    config.add_section('grass')
+    config.set('grass', 'gisbase', '')
 
     if not cfgfiles:
         cfgfiles = _get_default_config_files_location()

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -40,7 +40,7 @@ import logging
 from pywps import __version__
 
 logging.basicConfig()
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 class NoApplicableCode(HTTPException):
     """No applicable code exception implementation

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -5,7 +5,7 @@ from pywps._compat import urljoin
 from pywps.exceptions import NotEnoughStorage, NoApplicableCode
 from pywps import configuration as config
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 class STORE_TYPE:
     PATH = 0

--- a/pywps/validator/__init__.py
+++ b/pywps/validator/__init__.py
@@ -8,7 +8,7 @@ import logging
 from pywps.validator.mode import MODE
 from pywps.validator.base import emptyvalidator
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 _VALIDATORS = {
     'application/vnd.geo+json': validategeojson,

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -32,7 +32,7 @@ from pywps.inout.formats.lists import FORMATS
 import mimetypes
 import os
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 def validategml(data_input, mode):
     """GML validation example

--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -31,7 +31,7 @@ from pywps.validator.mode import MODE
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE, RANGECLOSURETYPE
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('PYWPS')
 
 def validate_anyvalue(data_input, mode):
     """Just placeholder, anyvalue is always valid


### PR DESCRIPTION
# Overview

This pull request 

1. Adds support for GRASS GIS in the old (but better) way - the Process can either point to existing location (`grass_location="/path/to/location"`) or create temporary location (`grass_location="epsg:1234"`)

2. Sanitizes inputs to dblog - instead of `insert into ... values {}, {}, {}".format(value1, value2, value3)` `? ? ?` are used in the input of `cursor.execute

3. Fixes cleaning of temporary directory - it is cleaned NOT when the handler finished, but after response is constructed

4. logging LOGGER is now identified by "PYWPS" keyword, rather then `__name__` - all logs should go into one file

# Related Issue / Discussion

#138

# Additional Information

This PR imho contains two critical features - dblog sanitisation and process.workdir cleaning

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines

