### PR TITLE
Fix handling of optional inputs

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -321,7 +321,9 @@ class Service(object):
                     raise MissingParameterValue(
                         inpt.identifier, inpt.identifier)
                 else:
-                    data_inputs[inpt.identifier] = inpt.clone()
+                    inputs = deque(maxlen=inpt.max_occurs)
+                    inputs.append(inpt.clone())
+                    data_inputs[inpt.identifier] = inputs
 
             # Replace the dicts with the dict of Literal/Complex inputs
             # set the input to the type defined in the process


### PR DESCRIPTION
# Overview

My colleague @mwa applied this patch to fix the handling of optional input params (min_occurs=0) which aren't passed. He ended the three lines with a "continue" statement, which seems not necessary to me. I didn't verify the patch myself, but the WPS application is working on a customer machine...

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines

