### PR TITLE
added converters for datetime, date and time

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/geopython/pywps.git
 
 Package: python-pywps
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, python-pkg-resources, python-flufl.enum, python-jsonschema, python-lxml, python-owslib, python-werkzeug
+Depends: ${misc:Depends}, ${python:Depends}, python-pkg-resources, python-dateutil, python-flufl.enum, python-jsonschema, python-lxml, python-owslib, python-werkzeug
 Suggests: grass, apache2, apache
 Homepage: http://pywps.org
 Description: OGC Web Processing Service (WPS) Implementation

--- a/docs/demobuffer.py
+++ b/docs/demobuffer.py
@@ -26,6 +26,7 @@
 __author__ = 'Jachym Cepicky'
 
 from pywps import Process, LiteralInput, ComplexOutput, ComplexInput, Format
+from pywps.app.Common import Metadata
 from pywps.validator.mode import MODE
 from pywps.inout.formats import FORMATS
 
@@ -56,6 +57,7 @@ class DemoBuffer(Process):
             version='1.0.0',
             title='Buffer',
             abstract='This process demonstrates, how to create any process in PyWPS environment',
+            metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')])
             inputs=inputs,
             outputs=outputs,
             store_supported=True,

--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -1,0 +1,31 @@
+##################################################################
+# Copyright 2016 OSGeo Foundation,                               #
+# represented by PyWPS Project Steering Committee,               #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+
+import logging
+
+LOGGER = logging.getLogger("PYWPS")
+
+
+class Metadata(object):
+    """
+    ows:Metadata content model.
+
+    :param title: Metadata title, human readable string
+    :param href: fully qualified URL
+    :param type_: fully qualified URL
+    """
+
+    def __init__(self, title, href=None, type_='simple'):
+        self.title = title
+        self.href = href
+        self.type = type_
+
+    def __iter__(self):
+        yield '{http://www.w3.org/1999/xlink}title', self.title
+        if self.href is not None:
+            yield '{http://www.w3.org/1999/xlink}href', self.href
+        yield '{http://www.w3.org/1999/xlink}type', self.type

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -41,6 +41,8 @@ class Process(object):
                    should be :class:`~LiteralOutput` and :class:`~ComplexOutput`
                    and :class:`~BoundingBoxOutput`
                    objects.
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, handler, identifier, title, abstract='', profile=[], metadata=[], inputs=[],
@@ -78,9 +80,8 @@ class Process(object):
         )
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
-        # TODO: See Table 32 Metadata in OGC 06-121r3
-        # for m in self.metadata:
-        #    doc.append(OWS.Metadata(m))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
         if self.profile:
             doc.append(OWS.Profile(self.profile))
         if self.version != 'None':
@@ -110,7 +111,7 @@ class Process(object):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata({'{http://www.w3.org/1999/xlink}title': m}))
+            doc.append(OWS.Metadata(dict(m)))
 
         for p in self.profile:
             doc.append(WPS.Profile(p))

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -48,7 +48,7 @@ class Service(object):
 
         if config.get_config_value('logging', 'file') and config.get_config_value('logging', 'level'):
             LOGGER.setLevel(getattr(logging, config.get_config_value('logging', 'level')))
-            msg_fmt = '%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s'
+            msg_fmt = '%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s'  # noqa
             fh = logging.FileHandler(config.get_config_value('logging', 'file'))
             fh.setFormatter(logging.Formatter(msg_fmt))
             LOGGER.addHandler(fh)
@@ -326,9 +326,9 @@ class Service(object):
                     raise MissingParameterValue(
                         inpt.identifier, inpt.identifier)
                 else:
-                    #inputs = deque(maxlen=inpt.max_occurs)
-                    #inputs.append(inpt.clone())
-                    #data_inputs[inpt.identifier] = inputs
+                    # inputs = deque(maxlen=inpt.max_occurs)
+                    # inputs.append(inpt.clone())
+                    # data_inputs[inpt.identifier] = inputs
                     pass
             else:
                 # Replace the dicts with the dict of Literal/Complex inputs

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -44,8 +44,8 @@ FORMATS = _FORMATS(
     _FORMAT('application/x-ogc-wms; version=1.3.0', '.xml', None),
     _FORMAT('application/x-ogc-wms; version=1.1.0', '.xml', None),
     _FORMAT('application/x-ogc-wms; version=1.0.0', '.xml', None),
-    _FORMAT('text/plain', '.txt',  None),
-    _FORMAT('application/x-netcdf', '.nc',  None),
+    _FORMAT('text/plain', '.txt', None),
+    _FORMAT('application/x-netcdf', '.nc', None),
 )
 
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -22,14 +22,14 @@ class BoundingBoxInput(basic.BBoxInput):
     :param int dimensions: 2 or 3
     :param int min_occurs: how many times this input occurs
     :param int max_occurs: how many times this input occurs
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=None, min_occurs=1,
+                 dimensions=2, metadata=[], min_occurs=1,
                  max_occurs=1,
                  mode=MODE.NONE):
-        if metadata is None:
-            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions, mode=mode)
@@ -54,8 +54,8 @@ class BoundingBoxInput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         bbox_data_doc = E.BoundingBoxData()
         doc.append(bbox_data_doc)
@@ -124,8 +124,6 @@ class ComplexInput(basic.ComplexInput):
                  max_occurs=1, mode=MODE.NONE):
         """constructor"""
 
-        if metadata is None:
-            metadata = []
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
                                     supported_formats=supported_formats,
@@ -166,8 +164,8 @@ class ComplexInput(basic.ComplexInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         doc.append(
             E.ComplexData(
@@ -251,10 +249,12 @@ class LiteralInput(basic.LiteralInput):
     :param int max_occurs: maximum occurence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param pywps.inout.literaltypes.AnyValue allowed_values: or :py:class:`pywps.inout.literaltypes.AllowedValue` object
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, data_type='integer', abstract='',
-                 metadata=None, uoms=None, default=None,
+                 metadata=[], uoms=None, default=None,
                  min_occurs=1, max_occurs=1,
                  mode=MODE.SIMPLE, allowed_values=AnyValue):
         """Constructor
@@ -284,8 +284,8 @@ class LiteralInput(basic.LiteralInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         literal_data_doc = E.LiteralData()
 

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -277,6 +277,7 @@ def convert_time(inpt):
         inpt = convert_datetime(inpt).time()
     return inpt
 
+
 def convert_date(inpt):
     """Return value of input
     date formating assumed according to ISO standard:
@@ -290,6 +291,7 @@ def convert_date(inpt):
     if not isinstance(inpt, datetime.date):
         inpt = convert_datetime(inpt).date()
     return inpt
+
 
 def convert_datetime(inpt):
     """Return value of input

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -9,14 +9,20 @@
 
 from pywps._compat import urlparse
 import time
+from dateutil.parser import parse as date_parser
+import datetime
 from pywps.exceptions import InvalidParameterValue
 from pywps.validator.allowed_value import RANGECLOSURETYPE
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE
 from pywps._compat import PY2
 from pywps import OWS, NAMESPACES
 
+import logging
+LOGGER = logging.getLogger('PYWPS')
+
 LITERAL_DATA_TYPES = ('float', 'boolean', 'integer', 'string',
-                      'positiveInteger', 'anyURI', 'time', 'scale', 'angle',
+                      'positiveInteger', 'anyURI', 'time', 'date', 'dateTime',
+                      'scale', 'angle',
                       'nonNegativeInteger')
 
 # currently we are supporting just ^^^ data types, feel free to add support for
@@ -136,6 +142,10 @@ def get_converter(convertor):
                 convert = convert_anyURI
             elif data_type == 'time':
                 convert = convert_time
+            elif data_type == 'date':
+                convert = convert_date
+            elif data_type == 'dateTime':
+                convert = convert_datetime
             elif data_type == 'scale':
                 convert = convert_scale
             elif data_type == 'angle':
@@ -255,14 +265,51 @@ def convert_anyURI(inpt):
 
 def convert_time(inpt):
     """Return value of input
-    time formating assumed according to ISO standard
+    time formating assumed according to ISO standard:
 
-    http://www.w3.org/TR/NOTE-datetime
+    https://www.w3.org/TR/xmlschema-2/#time
 
-    :rtype: time object
+    Examples: 12:00:00
+
+    :rtype: datetime.time object
     """
-    time_format = '%Y-%m-%dT%H:%M:%S%Z'
-    inpt = time.strptime(convert_string(inpt), time_format)
+    if not isinstance(inpt, datetime.time):
+        inpt = convert_datetime(inpt).time()
+    return inpt
+
+def convert_date(inpt):
+    """Return value of input
+    date formating assumed according to ISO standard:
+
+    https://www.w3.org/TR/xmlschema-2/#date
+
+    Examples: 2016-09-20
+
+    :rtype: datetime.date object
+    """
+    if not isinstance(inpt, datetime.date):
+        inpt = convert_datetime(inpt).date()
+    return inpt
+
+def convert_datetime(inpt):
+    """Return value of input
+    dateTime formating assumed according to ISO standard:
+
+    * http://www.w3.org/TR/NOTE-datetime
+    * https://www.w3.org/TR/xmlschema-2/#dateTime
+
+    Examples: 2016-09-20T12:00:00, 2012-12-31T06:30:00Z,
+              2017-01-01T18:00:00+01:00
+
+    :rtype: datetime.datetime object
+    """
+    # TODO: %z directive works only with python 3
+    # time_format = '%Y-%m-%dT%H:%M:%S%z'
+    # time_format = '%Y-%m-%dT%H:%M:%S%Z'
+    # inpt = time.strptime(convert_string(inpt), time_format)
+    if not isinstance(inpt, datetime.datetime):
+        inpt = convert_string(inpt)
+        inpt = date_parser(inpt)
     return inpt
 
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -9,6 +9,7 @@ from pywps._compat import text_type
 from pywps import E, WPS, OWS, OGCTYPE, NAMESPACES
 from pywps.inout import basic
 from pywps.inout.storage import FileStorage
+from pywps.inout.formats import Format
 from pywps.validator.mode import MODE
 import lxml.etree as etree
 
@@ -23,14 +24,14 @@ class BoundingBoxOutput(basic.BBoxInput):
     :param int min_occurs: minimum occurence
     :param int max_occurs: maximum occurence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=None, min_occurs='1',
+                 dimensions=2, metadata=[], min_occurs='1',
                  max_occurs='1', as_reference=False,
                  mode=MODE.NONE):
-        if metadata is None:
-            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions, mode=mode)
@@ -49,8 +50,8 @@ class BoundingBoxOutput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         bbox_data_doc = E.BoundingBoxOutput()
         doc.append(bbox_data_doc)
@@ -97,10 +98,12 @@ class ComplexOutput(basic.ComplexOutput):
         formats. The first format in the list will be used as the default.
     :param str abstract: Description of the output
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, supported_formats=None,
-                 abstract='', metadata=None, mode=MODE.NONE):
+                 abstract='', metadata=[], mode=MODE.NONE):
         if metadata is None:
             metadata = []
 
@@ -128,7 +131,7 @@ class ComplexOutput(basic.ComplexOutput):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+            doc.append(OWS.Metadata(dict(m)))
 
         doc.append(
             E.ComplexOutput(
@@ -216,12 +219,12 @@ class LiteralOutput(basic.LiteralOutput):
     :param str abstract: Input abstract
     :param str uoms: units
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, data_type='string', abstract='',
                  metadata=[], uoms=[], mode=MODE.SIMPLE):
-        if metadata is None:
-            metadata = []
         if uoms is None:
             uoms = []
         basic.LiteralOutput.__init__(self, identifier, title=title,
@@ -239,7 +242,7 @@ class LiteralOutput(basic.LiteralOutput):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata(m))
+            doc.append(OWS.Metadata(dict(m)))
 
         literal_data_doc = E.LiteralOutput()
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -102,7 +102,7 @@ class ComplexOutput(basic.ComplexOutput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title,  supported_formats=None,
+    def __init__(self, identifier, title, supported_formats=None,
                  abstract='', metadata=None,
                  as_reference=False, mode=MODE.NONE):
         if metadata is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsonschema
 lxml
 werkzeug
 SQLAlchemy
+dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jsonschema
 lxml
 werkzeug
 SQLAlchemy
-dateutil
+python-dateutil

--- a/tests/process.py
+++ b/tests/process.py
@@ -37,7 +37,8 @@ class ProcessTestCase(unittest.TestCase):
                               BoundingBoxInput("bbox", title="BBox", crss=[]),
                               ComplexInput("vector", title="Vector")
                           ],
-                          outputs=[]
+                          outputs=[],
+                          metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]) 
         )
         inputs = {
             input.identifier: input.title

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8,6 +8,7 @@ import unittest
 import lxml
 import lxml.etree
 from pywps.app import Process, Service
+from pywps.app.Common import Metadata
 from pywps import WPS, OWS
 from tests.common import assert_pywps_version, client_for
 
@@ -45,7 +46,7 @@ class CapabilitiesTest(unittest.TestCase):
     def setUp(self):
         def pr1(): pass
         def pr2(): pass
-        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1'), Process(pr2, 'pr2', 'Process 2')]))
+        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1', metadata=[Metadata('pr1 metadata')]), Process(pr2, 'pr2', 'Process 2', metadata=[Metadata('pr2 metadata')])]))
 
     def check_capabilities_response(self, resp):
         assert resp.status_code == 200
@@ -59,6 +60,12 @@ class CapabilitiesTest(unittest.TestCase):
                                 '/wps:Process'
                                 '/ows:Identifier')
         assert sorted(names.split()) == ['pr1', 'pr2']
+
+        metadatas = resp.xpath('/wps:Capabilities'
+                               '/wps:ProcessOfferings'
+                               '/wps:Process'
+                               '/ows:Metadata')
+        assert len(metadatas) == 2
 
     def test_get_request(self):
         resp = self.client.get('?Request=GetCapabilities&service=WpS')

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -7,6 +7,7 @@
 ##################################################################
 
 import unittest
+import datetime
 from pywps.inout.literaltypes import *
 
 class ConvertorTest(unittest.TestCase):
@@ -42,6 +43,36 @@ class ConvertorTest(unittest.TestCase):
         self.assertFalse(convert_boolean(False))
         self.assertFalse(convert_boolean(0))
         self.assertTrue(convert_boolean(-1))
+
+    def test_time(self):
+        """Test time convertor"""
+        self.assertEqual(convert_time("12:00:00"),
+                         datetime.time(12, 0, 0))
+        self.assertTrue(isinstance(
+            convert_time(datetime.time(14)),
+            datetime.time))
+
+    def test_date(self):
+        """Test date convertor"""
+        self.assertEqual(convert_date("2011-07-21"),
+                         datetime.date(2011, 7, 21))
+        self.assertTrue(isinstance(
+            convert_date(datetime.date(2012, 12, 31)),
+            datetime.date))
+
+    def test_datetime(self):
+        """Test datetime convertor"""
+        self.assertEqual(convert_datetime("2016-09-22T12:00:00"),
+                         datetime.datetime(2016, 9, 22, 12))
+        self.assertTrue(isinstance(
+            convert_datetime("2016-09-22T12:00:00Z"),
+            datetime.datetime))
+        self.assertTrue(isinstance(
+            convert_datetime("2016-09-22T12:00:00+01:00"),
+            datetime.datetime))
+        self.assertTrue(isinstance(
+            convert_datetime(datetime.datetime(2016, 9, 22, 6)),
+            datetime.datetime))
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

added converter for datetime, date and time to `literaltypes`. Uses `dateutil.parser` to parse datetime strings including time-zone. The previous format string with `%z` did only work on python 3.x, but not on python 2.7.

This patch includes unittests for the datetime converters.

The `python-dateutil` package has been added to the requirements.
# Related Issue / Discussion

see gitter chat.
# Additional Information
# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)
- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
