### PR TITLE
add support for Process Metadata objects

### DIFF
--- a/docs/demobuffer.py
+++ b/docs/demobuffer.py
@@ -26,6 +26,7 @@
 __author__ = 'Jachym Cepicky'
 
 from pywps import Process, LiteralInput, ComplexOutput, ComplexInput, Format
+from pywps.app.Common import Metadata
 from pywps.validator.mode import MODE
 from pywps.inout.formats import FORMATS
 
@@ -56,6 +57,7 @@ class DemoBuffer(Process):
             version='1.0.0',
             title='Buffer',
             abstract='This process demonstrates, how to create any process in PyWPS environment',
+            metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')])
             inputs=inputs,
             outputs=outputs,
             store_supported=True,

--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -1,0 +1,31 @@
+##################################################################
+# Copyright 2016 OSGeo Foundation,                               #
+# represented by PyWPS Project Steering Committee,               #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+
+import logging
+
+LOGGER = logging.getLogger("PYWPS")
+
+
+class Metadata(object):
+    """
+    ows:Metadata content model.
+
+    :param title: Metadata title, human readable string
+    :param href: fully qualified URL
+    :param type_: fully qualified URL
+    """
+
+    def __init__(self, title, href=None, type_='simple'):
+        self.title = title
+        self.href = href
+        self.type = type_
+
+    def __iter__(self):
+        yield '{http://www.w3.org/1999/xlink}title', self.title
+        if self.href is not None:
+            yield '{http://www.w3.org/1999/xlink}href', self.href
+        yield '{http://www.w3.org/1999/xlink}type', self.type

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -41,6 +41,8 @@ class Process(object):
                    should be :class:`~LiteralOutput` and :class:`~ComplexOutput`
                    and :class:`~BoundingBoxOutput`
                    objects.
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, handler, identifier, title, abstract='', profile=[], metadata=[], inputs=[],
@@ -78,9 +80,8 @@ class Process(object):
         )
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
-        # TODO: See Table 32 Metadata in OGC 06-121r3
-        # for m in self.metadata:
-        #    doc.append(OWS.Metadata(m))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
         if self.profile:
             doc.append(OWS.Profile(self.profile))
         if self.version != 'None':
@@ -110,7 +111,7 @@ class Process(object):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata({'{http://www.w3.org/1999/xlink}title': m}))
+            doc.append(OWS.Metadata(dict(m)))
 
         for p in self.profile:
             doc.append(WPS.Profile(p))

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -22,14 +22,14 @@ class BoundingBoxInput(basic.BBoxInput):
     :param int dimensions: 2 or 3
     :param int min_occurs: how many times this input occurs
     :param int max_occurs: how many times this input occurs
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=None, min_occurs=1,
+                 dimensions=2, metadata=[], min_occurs=1,
                  max_occurs=1,
                  mode=MODE.NONE):
-        if metadata is None:
-            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions, mode=mode)
@@ -54,8 +54,8 @@ class BoundingBoxInput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         bbox_data_doc = E.BoundingBoxData()
         doc.append(bbox_data_doc)
@@ -124,8 +124,6 @@ class ComplexInput(basic.ComplexInput):
                  max_occurs=1, mode=MODE.NONE):
         """constructor"""
 
-        if metadata is None:
-            metadata = []
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
                                     supported_formats=supported_formats,
@@ -166,8 +164,8 @@ class ComplexInput(basic.ComplexInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         doc.append(
             E.ComplexData(
@@ -251,10 +249,12 @@ class LiteralInput(basic.LiteralInput):
     :param int max_occurs: maximum occurence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param pywps.inout.literaltypes.AnyValue allowed_values: or :py:class:`pywps.inout.literaltypes.AllowedValue` object
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, data_type='integer', abstract='',
-                 metadata=None, uoms=None, default=None,
+                 metadata=[], uoms=None, default=None,
                  min_occurs=1, max_occurs=1,
                  mode=MODE.SIMPLE, allowed_values=AnyValue):
         """Constructor
@@ -284,8 +284,8 @@ class LiteralInput(basic.LiteralInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         literal_data_doc = E.LiteralData()
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -9,6 +9,7 @@ from pywps._compat import text_type
 from pywps import E, WPS, OWS, OGCTYPE, NAMESPACES
 from pywps.inout import basic
 from pywps.inout.storage import FileStorage
+from pywps.inout.formats import Format
 from pywps.validator.mode import MODE
 import lxml.etree as etree
 
@@ -23,14 +24,14 @@ class BoundingBoxOutput(basic.BBoxInput):
     :param int min_occurs: minimum occurence
     :param int max_occurs: maximum occurence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, crss, abstract='',
-                 dimensions=2, metadata=None, min_occurs='1',
+                 dimensions=2, metadata=[], min_occurs='1',
                  max_occurs='1', as_reference=False,
                  mode=MODE.NONE):
-        if metadata is None:
-            metadata = []
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
                                  dimensions=dimensions, mode=mode)
@@ -49,8 +50,8 @@ class BoundingBoxOutput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        if self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+        for m in self.metadata:
+            doc.append(OWS.Metadata(dict(m)))
 
         bbox_data_doc = E.BoundingBoxOutput()
         doc.append(bbox_data_doc)
@@ -97,10 +98,12 @@ class ComplexOutput(basic.ComplexOutput):
         formats. The first format in the list will be used as the default.
     :param str abstract: Description of the output
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, supported_formats=None,
-                 abstract='', metadata=None, mode=MODE.NONE):
+                 abstract='', metadata=[], mode=MODE.NONE):
         if metadata is None:
             metadata = []
 
@@ -128,7 +131,7 @@ class ComplexOutput(basic.ComplexOutput):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata(*self.metadata))
+            doc.append(OWS.Metadata(dict(m)))
 
         doc.append(
             E.ComplexOutput(
@@ -216,12 +219,12 @@ class LiteralOutput(basic.LiteralOutput):
     :param str abstract: Input abstract
     :param str uoms: units
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param metadata: List of metadata advertised by this process. They
+                     should be :class:`pywps.app.Common.Metadata` objects.
     """
 
     def __init__(self, identifier, title, data_type='string', abstract='',
                  metadata=[], uoms=[], mode=MODE.SIMPLE):
-        if metadata is None:
-            metadata = []
         if uoms is None:
             uoms = []
         basic.LiteralOutput.__init__(self, identifier, title=title,
@@ -239,7 +242,7 @@ class LiteralOutput(basic.LiteralOutput):
             doc.append(OWS.Abstract(self.abstract))
 
         for m in self.metadata:
-            doc.append(OWS.Metadata(m))
+            doc.append(OWS.Metadata(dict(m)))
 
         literal_data_doc = E.LiteralOutput()
 

--- a/tests/process.py
+++ b/tests/process.py
@@ -37,7 +37,8 @@ class ProcessTestCase(unittest.TestCase):
                               BoundingBoxInput("bbox", title="BBox", crss=[]),
                               ComplexInput("vector", title="Vector")
                           ],
-                          outputs=[]
+                          outputs=[],
+                          metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]) 
         )
         inputs = {
             input.identifier: input.title

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8,6 +8,7 @@ import unittest
 import lxml
 import lxml.etree
 from pywps.app import Process, Service
+from pywps.app.Common import Metadata
 from pywps import WPS, OWS
 from tests.common import assert_pywps_version, client_for
 
@@ -45,7 +46,7 @@ class CapabilitiesTest(unittest.TestCase):
     def setUp(self):
         def pr1(): pass
         def pr2(): pass
-        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1'), Process(pr2, 'pr2', 'Process 2')]))
+        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1', metadata=[Metadata('pr1 metadata')]), Process(pr2, 'pr2', 'Process 2', metadata=[Metadata('pr2 metadata')])]))
 
     def check_capabilities_response(self, resp):
         assert resp.status_code == 200
@@ -59,6 +60,12 @@ class CapabilitiesTest(unittest.TestCase):
                                 '/wps:Process'
                                 '/ows:Identifier')
         assert sorted(names.split()) == ['pr1', 'pr2']
+
+        metadatas = resp.xpath('/wps:Capabilities'
+                               '/wps:ProcessOfferings'
+                               '/wps:Process'
+                               '/ows:Metadata')
+        assert len(metadatas) == 2
 
     def test_get_request(self):
         resp = self.client.get('?Request=GetCapabilities&service=WpS')


### PR DESCRIPTION
# Overview
This PR provides a proper class for `ows:Metadata` objects, and ensures all metadata class  properties are lists of `pywps.app.Common.Metadata` objects.
# Related Issue / Discussion
#189 
# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines