### PR TITLE
Fix syntax errors causing sphinx-build to fail. (#213)

### DIFF
--- a/docs/demobuffer.py
+++ b/docs/demobuffer.py
@@ -57,7 +57,7 @@ class DemoBuffer(Process):
             version='1.0.0',
             title='Buffer',
             abstract='This process demonstrates, how to create any process in PyWPS environment',
-            metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')])
+            metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]
             inputs=inputs,
             outputs=outputs,
             store_supported=True,

--- a/tests/process.py
+++ b/tests/process.py
@@ -38,7 +38,7 @@ class ProcessTestCase(unittest.TestCase):
                               ComplexInput("vector", title="Vector")
                           ],
                           outputs=[],
-                          metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]) 
+                          metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]
         )
         inputs = {
             input.identifier: input.title


### PR DESCRIPTION
# Overview
Commit 98681813c75d0662a3928e0168603e420b331c70 introduced syntax errors which caused sphinx-build to fail with:
```
PycodeError: tokenizing failed (exception was: TokenError('EOF in multi-line statement', (124, 0)))
```

# Related Issue / Discussion
#213 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines

