### PR TITLE
Fix default output url

### DIFF
--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -82,7 +82,7 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('server', 'temp_path', tempfile.gettempdir())
     CONFIG.set('server', 'processes_path', '')
     outputpath = tempfile.gettempdir()
-    CONFIG.set('server', 'outputurl', 'file:///%s' % outputpath)
+    CONFIG.set('server', 'outputurl', 'file://%s' % outputpath)
     CONFIG.set('server', 'outputpath', outputpath)
     CONFIG.set('server', 'workdir', tempfile.gettempdir())
     CONFIG.set('server', 'parallelprocesses', '2')

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -117,7 +117,9 @@ class FileStorage(StorageAbstract):
 
         just_file_name = os.path.basename(output_name)
 
-        url = urljoin(self.output_url, just_file_name)
+        # make sure base url ends with '/'
+        baseurl = self.output_url.rstrip('/') + '/'
+        url = urljoin(baseurl, just_file_name)
         LOGGER.info('File output URI: %s', url)
 
         return (STORE_TYPE.PATH, output_name, url)


### PR DESCRIPTION
# Overview

the default settings for ``outputurl`` would result in a broken url builded with ``urljoin`` in the storage module. This is fixed with this pull request.

Before:
```
urljoin('file:////tmp/T', 'output.txt') -> file://tmp/output.txt
``` 

Now:
```
urljoin('file:///tmp/T/', 'output.txt') -> file:///tmp/T/output.txt
```


# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
