### PR TITLE
New feature: set HOME to pywps process tempdir

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -222,7 +222,7 @@ class Process(object):
             if config.get_config_value('server', 'sethomedir') is True:
                 os.environ['HOME'] = self.workdir
                 LOGGER.info('Setting HOME to current working directory: %s', os.environ['HOME'])
-            LOGGER.debug('ProcessID=%s, HOME=%s', self.uuid, os.environ['HOME'])
+            LOGGER.debug('ProcessID=%s, HOME=%s', self.uuid, os.environ.get('HOME'))
             wps_response.update_status('PyWPS Process started', 0)
             wps_response = self.handler(wps_request, wps_response)
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -218,6 +218,11 @@ class Process(object):
     def _run_process(self, wps_request, wps_response):
         try:
             self._set_grass()
+            # if required set HOME to the current working directory.
+            if config.get_config_value('server', 'sethomedir') is True:
+                os.environ['HOME'] = self.workdir
+                LOGGER.info('Setting HOME to current working directory: %s', os.environ['HOME'])
+            LOGGER.debug('ProcessID=%s, HOME=%s', self.uuid, os.environ['HOME'])
             wps_response.update_status('PyWPS Process started', 0)
             wps_response = self.handler(wps_request, wps_response)
 

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -86,6 +86,9 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('server', 'outputpath', outputpath)
     CONFIG.set('server', 'workdir', tempfile.gettempdir())
     CONFIG.set('server', 'parallelprocesses', '2')
+    # If this flag is enabled it will set the HOME environment
+    # for each process to its current workdir (a temp folder).
+    CONFIG.set('server', 'sethomedir', 'false')
 
     CONFIG.add_section('logging')
     CONFIG.set('logging', 'file', '')


### PR DESCRIPTION
# Overview

some tools used in a wps process like to have a ``HOME`` environment and might even write into the ``HOME`` folder (config, cache, ...).

With this new feature the ``HOME`` can be set to the current ``tempdir`` of the process. This feature is disabled by default and can be activated with the ``sethomedir=true`` flag in the pywps server configuration.

You are already using this in ``Process._set_grass``: 
https://github.com/geopython/pywps/blob/master/pywps/app/Process.py#L220

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
