### PR TITLE
Fixes #226 missing default value handler

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -312,36 +312,39 @@ class Service(object):
     def _parse_and_execute(self, process, wps_request, uuid):
         """Parse and execute request
         """
-        LOGGER.debug('Checking if datainputs is required and has been passed')
-        if process.inputs:
-            if wps_request.inputs is None:
-                raise MissingParameterValue('Missing "datainputs" parameter', 'datainputs')
 
         LOGGER.debug('Checking if all mandatory inputs have been passed')
         data_inputs = {}
         for inpt in process.inputs:
-            if inpt.identifier not in wps_request.inputs:
+            # Replace the dicts with the dict of Literal/Complex inputs
+            # set the input to the type defined in the process.
+
+            request_inputs = None
+            if inpt.identifier in wps_request.inputs:
+                request_inputs = wps_request.inputs[inpt.identifier]
+
+            if not request_inputs:
+                if inpt.data_set:
+                    data_inputs[inpt.identifier] = [inpt.clone()]
+            else:
+
+                if isinstance(inpt, ComplexInput):
+                    data_inputs[inpt.identifier] = self.create_complex_inputs(
+                        inpt, request_inputs)
+                elif isinstance(inpt, LiteralInput):
+                    data_inputs[inpt.identifier] = self.create_literal_inputs(
+                        inpt, request_inputs)
+                elif isinstance(inpt, BoundingBoxInput):
+                    data_inputs[inpt.identifier] = self.create_bbox_inputs(
+                        inpt, request_inputs)
+
+        for inpt in process.inputs:
+
+            if inpt.identifier not in data_inputs:
                 if inpt.min_occurs > 0:
                     LOGGER.error('Missing parameter value: %s', inpt.identifier)
                     raise MissingParameterValue(
                         inpt.identifier, inpt.identifier)
-                else:
-                    # inputs = deque(maxlen=inpt.max_occurs)
-                    # inputs.append(inpt.clone())
-                    # data_inputs[inpt.identifier] = inputs
-                    pass
-            else:
-                # Replace the dicts with the dict of Literal/Complex inputs
-                # set the input to the type defined in the process.
-                if isinstance(inpt, ComplexInput):
-                    data_inputs[inpt.identifier] = self.create_complex_inputs(
-                        inpt, wps_request.inputs[inpt.identifier])
-                elif isinstance(inpt, LiteralInput):
-                    data_inputs[inpt.identifier] = self.create_literal_inputs(
-                        inpt, wps_request.inputs[inpt.identifier])
-                elif isinstance(inpt, BoundingBoxInput):
-                    data_inputs[inpt.identifier] = self.create_bbox_inputs(
-                        inpt, wps_request.inputs[inpt.identifier])
 
         wps_request.inputs = data_inputs
 

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -39,8 +39,8 @@ class WPSRequest(object):
         self.store_execute = None
         self.status = None
         self.lineage = None
-        self.inputs = None
-        self.outputs = None
+        self.inputs = {}
+        self.outputs = {}
         self.raw = None
 
         if self.http_request:

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -28,6 +28,10 @@ class IOHandler(object):
     """Basic IO class. Provides functions, to accept input data in file,
     memory object and stream object and give them out in all three types
 
+    :param workdir: working directory, to save temporal file objects in
+    :param mode: :var:`MODE` validation mode
+
+
     >>> # setting up
     >>> import os
     >>> from io import RawIOBase
@@ -62,19 +66,6 @@ class IOHandler(object):
     >>>
     >>> assert open(file).read() == ioh_file.stream.read()
     >>> assert isinstance(stream, RawIOBase)
-    >>> # skipped assert isinstance(ioh_stream.memory_object, POSH)
-    >>>
-    >>> # testing in memory object object on input
-    >>> # skipped ioh_mo = IOHandler(workdir=tmp)
-    >>> # skipped ioh_mo.memory_object = POSH
-    >>> # skipped assert ioh_mo.source_type == SOURCE_TYPE.MEMORY
-    >>> # skipped file = ioh_mo.file
-    >>> # skipped stream = ioh_mo.stream
-    >>> # skipped posh = ioh_mo.memory_object
-    >>> #
-    >>> # skipped assert open(file).read() == ioh_file.stream.read()
-    >>> # skipped assert isinstance(ioh_mo.stream, RawIOBase)
-    >>> # skipped assert isinstance(ioh_mo.memory_object, POSH)
     """
 
     def __init__(self, workdir=None, mode=MODE.NONE):
@@ -83,6 +74,7 @@ class IOHandler(object):
         self._tempfile = None
         self.workdir = workdir
         self._stream = None
+        self.data_set = False
 
         self.valid_mode = mode
 
@@ -93,8 +85,10 @@ class IOHandler(object):
         validate = self.validator
         _valid = validate(self, self.valid_mode)
         if not _valid:
+            self.data_set = False
             raise InvalidParameterValue('Input data not valid using '
                                         'mode %s' % (self.valid_mode))
+        self.data_set = True
 
     def set_file(self, filename):
         """Set source as file name"""
@@ -210,6 +204,20 @@ class IOHandler(object):
     base64 = property(fget=get_base64, fset=set_base64)
     workdir = property(fget=get_workdir, fset=set_workdir)
 
+    def _set_default_value(self, value, value_type):
+        """Set default value based on input data type
+        """
+
+        if value:
+            if value_type == SOURCE_TYPE.DATA:
+                self.data = value
+            elif value_type == SOURCE_TYPE.MEMORY:
+                self.memory_object = value
+            elif value_type == SOURCE_TYPE.FILE:
+                self.file = value
+            elif value_type == SOURCE_TYPE.STREAM:
+                self.stream = value
+
 
 class SimpleHandler(IOHandler):
     """Data handler for Literal In- and Outputs
@@ -248,6 +256,8 @@ class SimpleHandler(IOHandler):
             data = convert(self.data_type, data)
 
         IOHandler.set_data(self, data)
+
+
 
     data = property(fget=get_data, fset=set_data)
 
@@ -392,7 +402,8 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
 
     def __init__(self, identifier, title=None, abstract=None,
                  data_type="integer", workdir=None, allowed_values=None,
-                 uoms=None, mode=MODE.NONE):
+                 uoms=None, mode=MODE.NONE,
+                 default=None, default_type=SOURCE_TYPE.DATA):
         BasicIO.__init__(self, identifier, title, abstract)
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir, data_type, mode=mode)
@@ -401,6 +412,8 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
         self.allowed_values = []
         if not self.any_value:
             self.allowed_values = make_allowedvalues(allowed_values)
+
+        self._set_default_value(default, default_type)
 
     @property
     def validator(self):
@@ -467,10 +480,14 @@ class BBoxInput(BasicIO, BasicBoundingBox, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None, crss=None,
-                 dimensions=None, workdir=None, mode=MODE.NONE):
+                 dimensions=None, workdir=None,
+                 mode=MODE.SIMPLE,
+                 default=None, default_type=SOURCE_TYPE.DATA):
         BasicIO.__init__(self, identifier, title, abstract)
         BasicBoundingBox.__init__(self, crss, dimensions)
         IOHandler.__init__(self, workdir=None, mode=mode)
+
+        self._set_default_value(default, default_type)
 
     @property
     def json(self):
@@ -531,10 +548,14 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
 
     def __init__(self, identifier, title=None, abstract=None,
                  workdir=None, data_format=None, supported_formats=None,
-                 mode=MODE.NONE):
+                 mode=MODE.NONE,
+                 default=None, default_type=SOURCE_TYPE.DATA):
+
         BasicIO.__init__(self, identifier, title, abstract)
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
+
+        self._set_default_value(default, default_type)
 
     @property
     def json(self):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -18,7 +18,8 @@ class BoundingBoxInput(basic.BBoxInput):
     :param string identifier: The name of this input.
     :param string title: Human readable title
     :param string abstract: Longer text description
-    :param crss: List of supported coordinate reference system (e.g. ['EPSG:4326'])
+    :param crss: List of supported coordinate reference
+                 system (e.g. ['EPSG:4326'])
     :param int dimensions: 2 or 3
     :param int min_occurs: how many times this input occurs
     :param int max_occurs: how many times this input occurs
@@ -29,10 +30,13 @@ class BoundingBoxInput(basic.BBoxInput):
     def __init__(self, identifier, title, crss, abstract='',
                  dimensions=2, metadata=[], min_occurs=1,
                  max_occurs=1,
-                 mode=MODE.NONE):
+                 mode=MODE.NONE,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
-                                 dimensions=dimensions, mode=mode)
+                                 dimensions=dimensions, mode=mode,
+                                 default=default, default_type=default_type)
 
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
@@ -110,7 +114,8 @@ class ComplexInput(basic.ComplexInput):
 
     :param str identifier: The name of this input.
     :param str title: Title of the input
-    :param  pywps.inout.formats.Format supported_formats: List of supported formats
+    :param  pywps.inout.formats.Format supported_formats: List of supported
+                                                          formats
     :param pywps.inout.formats.Format data_format: default data format
     :param str abstract: Input abstract
     :param list metada: TODO
@@ -121,13 +126,16 @@ class ComplexInput(basic.ComplexInput):
 
     def __init__(self, identifier, title, supported_formats=None,
                  data_format=None, abstract='', metadata=[], min_occurs=1,
-                 max_occurs=1, mode=MODE.NONE):
+                 max_occurs=1, mode=MODE.NONE,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
         """constructor"""
 
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
                                     supported_formats=supported_formats,
-                                    mode=mode)
+                                    mode=mode,
+                                    default=default, default_type=default_type)
+
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
@@ -254,18 +262,20 @@ class LiteralInput(basic.LiteralInput):
     """
 
     def __init__(self, identifier, title, data_type='integer', abstract='',
-                 metadata=[], uoms=None, default=None,
+                 metadata=[], uoms=None,
                  min_occurs=1, max_occurs=1,
-                 mode=MODE.SIMPLE, allowed_values=AnyValue):
+                 mode=MODE.SIMPLE, allowed_values=AnyValue,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+
         """Constructor
         """
 
         basic.LiteralInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract, data_type=data_type,
                                     uoms=uoms, mode=mode,
-                                    allowed_values=allowed_values)
+                                    allowed_values=allowed_values,
+                                    default=default, default_type=default_type)
         self.metadata = metadata
-        self.default = default
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
         self.as_reference = False

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -68,7 +68,7 @@ def create_complex_proces():
         response.outputs['complex'].data = request.inputs['complex'][0].data
         return response
 
-    frmt = Format(mime_type='application/gml') # this is unknown mimetype
+    frmt = Format(mime_type='application/gml', extension=".gml") # this is unknown mimetype
 
     return Process(handler=complex_proces,
             identifier='my_complex_process',
@@ -77,6 +77,7 @@ def create_complex_proces():
                 ComplexInput(
                     'complex',
                     'Complex input',
+                    default="DEFAULT COMPLEX DATA",
                     supported_formats=[frmt])
             ],
             outputs=[
@@ -154,6 +155,27 @@ class ExecuteTest(unittest.TestCase):
 
         self.assertEqual(parsed_inputs[0].data_format.validate, validategml)
 
+    def test_input_default(self):
+        """Test input parsing
+        """
+        my_process = create_complex_proces()
+        service = Service(processes=[my_process])
+        self.assertEqual(len(service.processes.keys()), 1)
+        self.assertTrue(service.processes['my_complex_process'])
+
+        class FakeRequest():
+            identifier = 'complex_process'
+            service = 'wps'
+            version = '1.0.0'
+            inputs = {}
+            raw = False
+            outputs = {}
+            store_execute = False
+            lineage = False
+
+        request = FakeRequest()
+        response = service.execute('my_complex_process', request, 'fakeuuid')
+        self.assertEqual(response.outputs['complex'].data, 'DEFAULT COMPLEX DATA')
 
     def test_missing_process_error(self):
         client = client_for(Service(processes=[create_ultimate_question()]))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -13,7 +13,7 @@ from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
 from pywps.inout.basic import IOHandler, SOURCE_TYPE, SimpleHandler, BBoxInput, BBoxOutput, \
-    ComplexInput, ComplexOutput, LiteralInput, LiteralOutput
+    ComplexInput, ComplexOutput, LiteralOutput, LiteralInput
 from pywps.inout import BoundingBoxInput as BoundingBoxInputXML
 from pywps.inout.literaltypes import convert, AllowedValue
 from pywps._compat import StringIO, text_type
@@ -221,7 +221,8 @@ class LiteralInputTest(unittest.TestCase):
         self.literal_input = LiteralInput(
                 identifier="literalinput",
                 mode=2,
-                allowed_values=(1, 2, (3, 3, 12)))
+                allowed_values=(1, 2, (3, 3, 12)),
+                default=6)
 
 
     def test_contruct(self):
@@ -231,27 +232,21 @@ class LiteralInputTest(unittest.TestCase):
         self.assertIsInstance(self.literal_input.allowed_values[2], AllowedValue)
         self.assertEqual(self.literal_input.allowed_values[2].spacing, 3)
         self.assertEqual(self.literal_input.allowed_values[2].minval, 3)
+        self.assertEqual(self.literal_input.data, 6, "Default value set to 6")
 
     def test_valid(self):
+        self.assertEqual(self.literal_input.data, 6)
         self.literal_input.data = 1
         self.assertEqual(self.literal_input.data, 1)
-        try:
+
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = 5
-            self.assertTrue(False, '5 does not work for spacing')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
-        try:
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = "a"
-            self.assertTrue(False, '"a" should not be allowed to be set')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
-        try:
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = 15
-            self.assertTrue(False, '11 should not be allowed to be set')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
         self.literal_input.data = 6
         self.assertEqual(self.literal_input.data, 6)
@@ -272,6 +267,7 @@ class LiteralInputTest(unittest.TestCase):
         self.assertFalse(out['uom'], 'uom exists')
         self.assertEqual(len(out['allowed_values']), 3, '3 allowed values')
         self.assertEqual(out['allowed_values'][0]['value'], 1, 'allowed value 1')
+
 
 
 class LiteralOutputTest(unittest.TestCase):


### PR DESCRIPTION
# Overview
Fixes #226 missing default value handler

Introduces default and default_type input parameters. Works for Literal, BoundingBox and Complex inputs

# Related Issue / Discussion

#226 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
