### PR TITLE
Make it possible to specify suffix for temp files

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -142,7 +142,11 @@ class IOHandler(object):
             if self._tempfile:
                 return self._tempfile
             else:
-                (opening, stream_file_name) = tempfile.mkstemp(dir=self.workdir)
+                suffix = ''
+                if hasattr(self, 'data_format') and self.data_format.extension:
+                    suffix = self.data_format.extension
+                (opening, stream_file_name) = tempfile.mkstemp(
+                    dir=self.workdir, suffix=suffix)
                 stream_file = open(stream_file_name, 'w')
 
                 if self.source_type == SOURCE_TYPE.STREAM:

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -48,7 +48,7 @@ class IOHandlerTest(unittest.TestCase):
         """
         self.assertEqual(self.iohandler.validator, emptyvalidator)
 
-    def _test_outout(self, source_type):
+    def _test_outout(self, source_type, suffix=''):
         """Test all outputs"""
 
         self.assertEqual(source_type, self.iohandler.source_type,
@@ -60,7 +60,9 @@ class IOHandlerTest(unittest.TestCase):
             source = StringIO(text_type(self._value))
             self.iohandler.stream = source
 
-        file_handler = open(self.iohandler.file)
+        file_path = self.iohandler.file
+        self.assertTrue(file_path.endswith(suffix))
+        file_handler = open(file_path)
         self.assertEqual(self._value, file_handler.read(), 'File obtained')
         file_handler.close()
 
@@ -90,7 +92,8 @@ class IOHandlerTest(unittest.TestCase):
     def test_data(self):
         """Test data input IOHandler"""
         self.iohandler.data = self._value
-        self._test_outout(SOURCE_TYPE.DATA)
+        self.iohandler.data_format = Format('foo', extension='.foo')
+        self._test_outout(SOURCE_TYPE.DATA, '.foo')
 
     def test_stream(self):
         """Test stream input IOHandler"""


### PR DESCRIPTION
# Overview

This PR suggests adding a `tempfile_suffix` argument to `ComplexInput`. This is useful when the program wrapped in a WPS Process requires specific file extensions.

# Related Issue / Discussion

See https://github.com/geopython/pywps/issues/242.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
