### PR TITLE
The BLOB type requires bytes on Python 3

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -258,6 +258,8 @@ class Process(object):
         stored_request = dblog.get_first_stored()
         if stored_request:
             (uuid, request_json) = (stored_request.uuid, stored_request.request)
+            if not PY2:
+                request_json = request_json.decode('utf-8')
             new_wps_request = WPSRequest()
             new_wps_request.json = json.loads(request_json)
             new_wps_response = WPSResponse(self, new_wps_request, uuid)

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -12,6 +12,7 @@ Implementation of logging for PyWPS-4
 import logging
 from pywps import configuration
 from pywps.exceptions import NoApplicableCode
+from pywps._compat import PY2
 import sqlite3
 import datetime
 import pickle
@@ -187,7 +188,11 @@ def store_process(uuid, request):
     """
 
     session = get_session()
-    request = RequestInstance(uuid=str(uuid), request=request.json)
+    request_json = request.json
+    if not PY2:
+        # the BLOB type requires bytes on Python 3
+        request_json = request_json.encode('utf-8')
+    request = RequestInstance(uuid=str(uuid), request=request_json)
     session.add(request)
     session.commit()
     session.close()


### PR DESCRIPTION
# Overview

Requests are stored in a column of type BLOB. With Python 3 this column type requires "bytes" data as opposed to "str" data. So on Python 3 this change encodes the data using the "utf-8" encoder before passing it to the database layer.

# Related Issue / Discussion

None

# Additional Information

None

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
