### PR TITLE
Fix boundingbox parameter

### DIFF
--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -43,7 +43,7 @@ class BoundingBoxOutput(basic.BBoxInput):
         self.as_reference = as_reference
 
     def describe_xml(self):
-        doc = WPS.Output(
+        doc = E.Output(
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
         )
@@ -90,8 +90,7 @@ class BoundingBoxOutput(basic.BBoxInput):
             doc.append(OWS.Abstract(self.abstract))
 
         data_doc = WPS.Data()
-
-        bbox_data_doc = OWS.BoundingBoxData()
+        bbox_data_doc = OWS.BoundingBox()
 
         bbox_data_doc.attrib['crs'] = self.crs
         bbox_data_doc.attrib['dimensions'] = str(self.dimensions)

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -43,7 +43,7 @@ class BoundingBoxOutput(basic.BBoxInput):
         self.as_reference = as_reference
 
     def describe_xml(self):
-        doc = E.Output(
+        doc = WPS.Output(
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
         )
@@ -69,8 +69,19 @@ class BoundingBoxOutput(basic.BBoxInput):
 
         return doc
 
+    def execute_xml_lineage(self):
+        doc = WPS.Output(
+            OWS.Identifier(self.identifier),
+            OWS.Title(self.title)
+        )
+
+        if self.abstract:
+            doc.append(OWS.Abstract(self.abstract))
+
+        return doc
+
     def execute_xml(self):
-        doc = E.Output(
+        doc = WPS.Output(
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
         )

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -89,7 +89,9 @@ class BoundingBoxOutput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        bbox_data_doc = OWS.BoundingBox()
+        data_doc = WPS.Data()
+
+        bbox_data_doc = OWS.BoundingBoxData()
 
         bbox_data_doc.attrib['crs'] = self.crs
         bbox_data_doc.attrib['dimensions'] = str(self.dimensions)
@@ -97,8 +99,8 @@ class BoundingBoxOutput(basic.BBoxInput):
         bbox_data_doc.append(OWS.LowerCorner('{0[0]} {0[1]}'.format(self.data)))
         bbox_data_doc.append(OWS.UpperCorner('{0[2]} {0[3]}'.format(self.data)))
 
-        doc.append(bbox_data_doc)
-
+        data_doc.append(bbox_data_doc)
+        doc.append(data_doc)
         return doc
 
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -48,10 +48,11 @@ def create_greeter():
                    inputs=[LiteralInput('name', 'Input name', data_type='string')],
                    outputs=[LiteralOutput('message', 'Output message', data_type='string')])
 
+
 def create_bbox_process():
     def bbox_process(request, response):
         coords = request.inputs['mybbox'][0].data
-        assert type(coords) == type([])
+        assert isinstance(coords, list)
         assert len(coords) == 4
         assert coords[0] == '15'
         response.outputs['outbbox'].data = coords
@@ -62,6 +63,7 @@ def create_bbox_process():
                    title='Bbox process',
                    inputs=[BoundingBoxInput('mybbox', 'Input name', ["EPSG:4326"])],
                    outputs=[BoundingBoxOutput('outbbox', 'Output message', ["EPSG:4326"])])
+
 
 def create_complex_proces():
     def complex_proces(request, response):
@@ -205,7 +207,7 @@ class ExecuteTest(unittest.TestCase):
                     WPS.Data(WPS.BoundingBoxData(
                         OWS.LowerCorner('15 50'),
                         OWS.UpperCorner('16 51'),
-                        ))
+                    ))
                 )
             ),
             version='1.0.0'
@@ -214,11 +216,14 @@ class ExecuteTest(unittest.TestCase):
         assert_response_success(resp)
 
         [output] = xpath_ns(resp.xml, '/wps:ExecuteResponse'
-                                   '/wps:ProcessOutputs/Output')
-        self.assertEqual('outbbox', xpath_ns(output,
+                                      '/wps:ProcessOutputs/wps:Output')
+        self.assertEqual('outbbox', xpath_ns(
+            output,
             './ows:Identifier')[0].text)
-        self.assertEqual('15 50', xpath_ns(output,
-            './ows:BoundingBox/ows:LowerCorner')[0].text)
+        self.assertEqual('15 50', xpath_ns(
+            output,
+            './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
+
 
 class ExecuteXmlParserTest(unittest.TestCase):
     """Tests for Execute request XML Parser


### PR DESCRIPTION
# Overview

Fixes for the BoundingBox paramter:

* lineage for ``BoundingBoxOutput`` added.
* namespace fix (``wps:``).
* added missing ``wps:Data`` element for execute request.
* updated ``test_bbox`` test.
* pep8 where code was changed.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
