### PR TITLE
fixed boundingbox lineage

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -76,6 +76,8 @@ class BoundingBoxInput(basic.BBoxInput):
         """
         :return: execute response element
         """
+        node = self._execute_xml_data()
+
         doc = WPS.Input(
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
@@ -84,18 +86,26 @@ class BoundingBoxInput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
+        doc.append(node)
+
+        return doc
+
+    def _execute_xml_data(self):
+        """Return Data node
+        """
+        doc = WPS.Data()
         bbox_data_doc = WPS.BoundingBoxData()
 
-        bbox_data_doc.attrib['crs'] = self.crs
-        bbox_data_doc.attrib['dimensions'] = str(self.dimensions)
+        if self.crs:
+            bbox_data_doc.attrib['crs'] = self.crs
+        if self.dimensions:
+            bbox_data_doc.attrib['dimensions'] = str(self.dimensions)
 
         bbox_data_doc.append(
             OWS.LowerCorner('{0[0]} {0[1]}'.format(self.data)))
         bbox_data_doc.append(
             OWS.UpperCorner('{0[2]} {0[3]}'.format(self.data)))
-
         doc.append(bbox_data_doc)
-
         return doc
 
     def clone(self):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -84,7 +84,7 @@ class BoundingBoxInput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
-        bbox_data_doc = OWS.BoundingBox()
+        bbox_data_doc = WPS.BoundingBoxData()
 
         bbox_data_doc.attrib['crs'] = self.crs
         bbox_data_doc.attrib['dimensions'] = str(self.dimensions)


### PR DESCRIPTION
# Overview

Fixed the ``execute_xml`` method of a ``BoundingBoxInput``. 

The WPS 1.0.0 spec is very confusing on bbox parameters. For a execute request (and as such also in the data-input lineage) one uses ``wps:BoundingBoxData`` of type ``ows:BoundingBox``.

See WPS 1.0.0 doc Table 46 and wps schema (BoundingBoxData element):

http://geoprocessing.info/schemas/wps/1.0/wpsExecute_request.xsd

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
