### PR TITLE
making logging format configurable

### DIFF
--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -36,6 +36,7 @@ parallelprocesses=2
 level=INFO
 file=logs/pywps.log
 database=sqlite:///logs/pywps-logs.sqlite3
+format=%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s
 
 
 [grass]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,15 +15,15 @@ The configuration file has 3 sections:
 
     * `metadata:main` for the server metadata inputs
     * `server` for server configuration
-    * `loggging` for logging configuration
+    * `logging` for logging configuration
     * `grass` for *optional* configuration to support `GRASS GIS
       <http://grass.osgeo.org>`_
 
-PyWPS ships with a sample configuration file (``default-sample.cfg``). 
+PyWPS ships with a sample configuration file (``default-sample.cfg``).
 A similar file is also available in the `demo` service as
 described in :ref:`demo` section.
 
-Copy the file to ``default.cfg`` and edit the following: 
+Copy the file to ``default.cfg`` and edit the following:
 
 [metadata:main]
 ---------------
@@ -100,20 +100,20 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
 
 :parallelprocesses:
     maximum number of parallel running processes - set this number carefully.
-    The effective number of parallel running processes is limited by the number 
-    of cores  in the processor of the hosting machine. As well, speed and 
-    response time of hard drives impact ultimate processing performance. A 
-    reasonable number of parallel running processes is not higher than the 
+    The effective number of parallel running processes is limited by the number
+    of cores  in the processor of the hosting machine. As well, speed and
+    response time of hard drives impact ultimate processing performance. A
+    reasonable number of parallel running processes is not higher than the
     number of processor cores.
 
 :maxrequestsize:
-    maximal request size. 0 for no limit 
-    
-:workdir: 
-    a directory to store all temporary files (which should be always deleted, 
+    maximal request size. 0 for no limit
+
+:workdir:
+    a directory to store all temporary files (which should be always deleted,
     once the process is finished).
-    
-:outputpath: 
+
+:outputpath:
     server path where to store output files.
 
 :outputurl:
@@ -121,7 +121,7 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
 
 .. note:: `outputpath` and `outputurl` must corespond. `outputpath` is the name
         of the resulting target directory, where all output data files are
-        stored (with unique names). `outputurl` is the corresponding full URL, 
+        stored (with unique names). `outputurl` is the corresponding full URL,
         which is targeting to `outputpath` directory.
 
         Example: `outputpath=/var/www/wps/outputs` shall correspond with
@@ -133,6 +133,11 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
 :level:
     the logging level (see
     http://docs.python.org/library/logging.html#logging-levels)
+
+:format:
+    the format string used by the logging `:Formatter:` (see
+    https://docs.python.org/3/library/logging.html#logging.Formatter).
+    For example: ``%(asctime)s] [%(levelname)s] %(message)s``.
 
 :file:
     the full file path to the log file for being able to see possible error
@@ -167,11 +172,8 @@ Sample file
   processes_path=
   outputurl=/data/
   outputpath=/tmp/outputs/
-  logfile=
-  loglevel=INFO
-  logdatabase=
   workdir=
-  
+
   [metadata:main]
   identification_title=PyWPS Processing Service
   identification_abstract=PyWPS is an implementation of the Web Processing Service standard from the Open Geospatial Consortium. PyWPS is written in Python.
@@ -195,6 +197,12 @@ Sample file
   contact_hours=Hours of Service
   contact_instructions=During hours of service.  Off on weekends.
   contact_role=pointOfContact
+
+  [logging]
+  level=INFO
+  file=logs/pywps.log
+  database=sqlite:///logs/pywps-logs.sqlite3
+  format=%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s
 
   [grass]
   gisbase=/usr/local/grass-7.3.svn/

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -48,9 +48,8 @@ class Service(object):
 
         if config.get_config_value('logging', 'file') and config.get_config_value('logging', 'level'):
             LOGGER.setLevel(getattr(logging, config.get_config_value('logging', 'level')))
-            msg_fmt = '%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s'  # noqa
             fh = logging.FileHandler(config.get_config_value('logging', 'file'))
-            fh.setFormatter(logging.Formatter(msg_fmt))
+            fh.setFormatter(logging.Formatter(config.get_config_value('logging', 'format')))
             LOGGER.addHandler(fh)
         else:  # NullHandler
             LOGGER.addHandler(logging.NullHandler())

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -22,6 +22,7 @@ else:
 
 __author__ = "Calin Ciociu"
 
+RAW_OPTIONS = [('logging', 'format'), ]
 
 CONFIG = None
 LOGGER = logging.getLogger("PYWPS")
@@ -44,7 +45,8 @@ def get_config_value(section, option):
 
     if CONFIG.has_section(section):
         if CONFIG.has_option(section, option):
-            value = CONFIG.get(section, option)
+            raw = (section, option) in RAW_OPTIONS
+            value = CONFIG.get(section, option, raw=raw)
 
             # Convert Boolean string to real Boolean values
             if value.lower() == "false":
@@ -95,6 +97,7 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('logging', 'level', 'DEBUG')
     CONFIG.set('logging', 'database', 'sqlite:///:memory:')
     CONFIG.set('logging', 'prefix', 'pywps_')
+    CONFIG.set('logging', 'format', '%(asctime)s] [%(levelname)s] file=%(pathname)s line=%(lineno)s module=%(module)s function=%(funcName)s %(message)s')  # noqa
 
     CONFIG.add_section('metadata:main')
     CONFIG.set('metadata:main', 'identification_title', 'PyWPS Processing Service')


### PR DESCRIPTION
# Overview

The default logging format is very detailed. This makes it hard to read the logs when debugging user processes. With this patch it is possible to overwrite the default logging format, example:

```
[logging]
format=%(message)s
```

The ``raw=True`` parameter will be used to avoid interpolation by the ``configparser`` for the format option.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
