### PR TITLE
keep output file names and use request uuid in file storage path

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -149,10 +149,15 @@ class Process(object):
         return wps_response
 
     def _set_uuid(self, uuid):
-        """Set uuid and status ocation apth and url
+        """Set uuid and status location path and url
         """
 
         self.uuid = uuid
+        for inpt in self.inputs:
+            inpt.uuid = uuid
+
+        for outpt in self.outputs:
+            outpt.uuid = uuid
 
         file_path = config.get_config_value('server', 'outputpath')
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -84,6 +84,7 @@ class IOHandler(object):
         self.source = None
         self._tempfile = None
         self.workdir = workdir
+        self.uuid = None  # request identifier
         self._stream = None
 
         self.valid_mode = mode


### PR DESCRIPTION
# Overview

with this patch the original output filenames will be kept in the ``FileStorage``, if possible:

* an output folder is created using the request uuid.
* the output file name will be kept (only a suffix accoding to the format is added if missing, like before)
* in case of a filename collision a tempfile is generated (this was the standard case before)  

Example:
```
temp/workdir-123/result.html -> outputs/d5b5ac8e-162e-11e7-b1ef-68f72837e1a3/result.html
```

# Related Issue / Discussion

See also issue #242 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
