### PR TITLE
Feature keep inputnames

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -396,10 +396,12 @@ class Service(object):
             """<wps:Reference /> handler"""
             # save the reference input in workdir
             extension = None
-            if hasattr(complexinput, 'data_format') and complexinput.data_format.extension:
+            if complexinput.data_format:
                 extension = complexinput.data_format.extension
             tmp_file = _build_input_file_name(
-                href=datain.get('href'), workdir=complexinput.workdir, extension=extension)
+                href=datain.get('href'),
+                workdir=complexinput.workdir,
+                extension=extension)
 
             try:
                 (reference_file, reference_file_data) = _openurl(datain)

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -664,7 +664,8 @@ def _build_input_file_name(href, workdir, extension=None):
     file_name = os.path.basename(href).strip() or 'input'
     (prefix, suffix) = os.path.splitext(file_name)
     suffix = suffix or extension
-    file_name = prefix + suffix
+    if prefix and suffix:
+        file_name = prefix + suffix
     input_file_name = os.path.join(workdir, file_name)
     # build tempfile in case of duplicates
     if os.path.exists(input_file_name):

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -395,8 +395,11 @@ class Service(object):
         def href_handler(complexinput, datain):
             """<wps:Reference /> handler"""
             # save the reference input in workdir
+            extension = None
+            if hasattr(complexinput, 'data_format') and complexinput.data_format.extension:
+                extension = complexinput.data_format.extension
             tmp_file = _build_input_file_name(
-                datain.get('href'), complexinput.workdir)
+                href=datain.get('href'), workdir=complexinput.workdir, extension=extension)
 
             try:
                 (reference_file, reference_file_data) = _openurl(datain)
@@ -654,14 +657,11 @@ def _get_datasize(reference_file_data):
     return data_size
 
 
-def _build_input_file_name(href, workdir):
+def _build_input_file_name(href, workdir, extension=None):
     href = href or ''
     file_name = os.path.basename(href).strip() or 'input'
     (prefix, suffix) = os.path.splitext(file_name)
-    if not suffix:
-        suffix = ''
-        if hasattr(complexinput, 'data_format') and complexinput.data_format.extension:
-            suffix = complexinput.data_format.extension
+    suffix = suffix or extension
     file_name = prefix + suffix
     input_file_name = os.path.join(workdir, file_name)
     # build tempfile in case of duplicates

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -395,7 +395,8 @@ class Service(object):
         def href_handler(complexinput, datain):
             """<wps:Reference /> handler"""
             # save the reference input in workdir
-            tmp_file = tempfile.mkstemp(dir=complexinput.workdir)[1]
+            tmp_file = _build_input_file_name(
+                datain.get('href'), complexinput.workdir)
 
             try:
                 (reference_file, reference_file_data) = _openurl(datain)
@@ -606,6 +607,7 @@ class Service(object):
             e = NoApplicableCode(str(e), code=500)
             return e
 
+
 def _openurl(inpt):
     """use urllib to open given href
     """
@@ -650,3 +652,21 @@ def _get_datasize(reference_file_data):
     tmp_sio.close()
 
     return data_size
+
+
+def _build_input_file_name(href, workdir):
+    href = href or ''
+    file_name = os.path.basename(href).strip() or 'input'
+    (prefix, suffix) = os.path.splitext(file_name)
+    if not suffix:
+        suffix = ''
+        if hasattr(complexinput, 'data_format') and complexinput.data_format.extension:
+            suffix = complexinput.data_format.extension
+    file_name = prefix + suffix
+    input_file_name = os.path.join(workdir, file_name)
+    # build tempfile in case of duplicates
+    if os.path.exists(input_file_name):
+        input_file_name = tempfile.mkstemp(
+            suffix=suffix, prefix=prefix + '_',
+            dir=workdir)[1]
+    return input_file_name

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -381,6 +381,12 @@ class ExecuteXmlParserTest(unittest.TestCase):
         self.assertEqual(
             _build_input_file_name('http://path/to/test', workdir=workdir, extension='.txt'),
             os.path.join(workdir, 'test.txt'))
+        self.assertEqual(
+            _build_input_file_name('http://path/to/test', workdir=workdir),
+            os.path.join(workdir, 'test'))
+        self.assertEqual(
+            _build_input_file_name('file://path/to/.config', workdir=workdir),
+            os.path.join(workdir, '.config'))
         open(os.path.join(workdir, 'duplicate.html'), 'a').close()
         inpt_filename = _build_input_file_name('http://path/to/duplicate.html', workdir=workdir, extension='.txt')
         self.assertTrue(inpt_filename.startswith(os.path.join(workdir, 'duplicate_')))

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -7,6 +7,8 @@
 import unittest
 import lxml.etree
 import json
+import tempfile
+import os.path
 from pywps import Service, Process, LiteralOutput, LiteralInput,\
     BoundingBoxOutput, BoundingBoxInput, Format, ComplexInput, ComplexOutput
 from pywps.validator.base import emptyvalidator
@@ -369,6 +371,20 @@ class ExecuteXmlParserTest(unittest.TestCase):
         rv = get_inputs_from_xml(request_doc)
         self.assertEqual(rv['name'][0]['href'], 'http://foo/bar/service')
         self.assertEqual(rv['name'][0]['bodyreference'], 'http://foo/bar/reference')
+
+    def test_build_input_file_name(self):
+        from pywps.app.Service import _build_input_file_name
+        workdir = tempfile.mkdtemp()
+        self.assertEqual(
+            _build_input_file_name('http://path/to/test.txt', workdir=workdir),
+            os.path.join(workdir, 'test.txt'))
+        self.assertEqual(
+            _build_input_file_name('http://path/to/test', workdir=workdir, extension='.txt'),
+            os.path.join(workdir, 'test.txt'))
+        open(os.path.join(workdir, 'duplicate.html'), 'a').close()
+        inpt_filename = _build_input_file_name('http://path/to/duplicate.html', workdir=workdir, extension='.txt')
+        self.assertTrue(inpt_filename.startswith(os.path.join(workdir, 'duplicate_')))
+        self.assertTrue(inpt_filename.endswith('.html'))
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

With this patch the ``ComplexInput`` reference inputs will use a temp filename derived from the href. In case of duplicate names a tempfile will be generated.

Example:
```
http://path/to/input.txt    ->   my/workdir-234/input.txt
```

# Related Issue / Discussion

See also #242

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
