### PR TITLE
using OrderedDict for processes

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -21,6 +21,7 @@ from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, update_response
 
 from collections import deque
+from collections import OrderedDict
 import os
 import sys
 import uuid
@@ -41,7 +42,8 @@ class Service(object):
     """
 
     def __init__(self, processes=[], cfgfiles=None):
-        self.processes = {p.identifier: p for p in processes}
+        # ordered dict of processes
+        self.processes = OrderedDict([(p.identifier, p) for p in processes])
 
         if cfgfiles:
             config.load_configuration(cfgfiles)

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -20,8 +20,7 @@ from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidPar
 from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, update_response
 
-from collections import deque
-from collections import OrderedDict
+from collections import deque, OrderedDict
 import os
 import sys
 import uuid
@@ -43,7 +42,7 @@ class Service(object):
 
     def __init__(self, processes=[], cfgfiles=None):
         # ordered dict of processes
-        self.processes = OrderedDict([(p.identifier, p) for p in processes])
+        self.processes = OrderedDict((p.identifier, p) for p in processes)
 
         if cfgfiles:
             config.load_configuration(cfgfiles)


### PR DESCRIPTION
# Overview

Using ``collections.OrderedDict`` (Python > 2.7) the order of the processes will be kept in the GetCapabilities document.

# Additional Information

... was also fixed in pywps 3.x

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
