### PR TITLE
Fix json datetime encoding exception

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -10,6 +10,7 @@ import lxml
 import lxml.etree
 from werkzeug.exceptions import MethodNotAllowed
 import base64
+import datetime
 from pywps import WPS
 from pywps._compat import text_type, PY2
 from pywps.app.basic import xpath_ns
@@ -303,6 +304,13 @@ class WPSRequest(object):
     def json(self):
         """Return JSON encoded representation of the request
         """
+        class ExtendedJSONEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, datetime.date) or isinstance(obj, datetime.time):
+                    encoded_object = obj.isoformat()
+                else:
+                    encoded_object = json.JSONEncoder.default(self, obj)
+                return encoded_object
 
         obj = {
             'operation': self.operation,
@@ -317,7 +325,7 @@ class WPSRequest(object):
             'raw': self.raw
         }
 
-        return json.dumps(obj, allow_nan=False)
+        return json.dumps(obj, allow_nan=False, cls=ExtendedJSONEncoder)
 
     @json.setter
     def json(self, value):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -321,7 +321,7 @@ class LiteralInputTest(unittest.TestCase):
             data_type='date')
         inpt.data = "2017-04-20"
         out = inpt.json
-        self.assertEqual(out['data'], datetime.date(2017, 4, 20), 'time set')
+        self.assertEqual(out['data'], datetime.date(2017, 4, 20), 'date set')
 
 
 class LiteralOutputTest(unittest.TestCase):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -8,6 +8,7 @@
 
 import os
 import tempfile
+import datetime
 import unittest
 from pywps import Format
 from pywps.validator import get_validator
@@ -294,6 +295,33 @@ class LiteralInputTest(unittest.TestCase):
         self.assertFalse(out['uom'], 'uom exists')
         self.assertEqual(len(out['allowed_values']), 3, '3 allowed values')
         self.assertEqual(out['allowed_values'][0]['value'], 1, 'allowed value 1')
+
+    def test_json_out_datetime(self):
+        inpt = LiteralInput(
+            identifier="datetime",
+            mode=2,
+            data_type='dateTime')
+        inpt.data = "2017-04-20T12:30:00"
+        out = inpt.json
+        self.assertEqual(out['data'], datetime.datetime(2017, 4, 20, 12, 30, 0), 'datetime set')
+
+    def test_json_out_time(self):
+        inpt = LiteralInput(
+            identifier="time",
+            mode=2,
+            data_type='time')
+        inpt.data = "12:30:00"
+        out = inpt.json
+        self.assertEqual(out['data'], datetime.time(12, 30, 0), 'time set')
+
+    def test_json_out_date(self):
+        inpt = LiteralInput(
+            identifier="date",
+            mode=2,
+            data_type='date')
+        inpt.data = "2017-04-20"
+        out = inpt.json
+        self.assertEqual(out['data'], datetime.date(2017, 4, 20), 'time set')
 
 
 class LiteralOutputTest(unittest.TestCase):

--- a/tests/test_wpsrequest.py
+++ b/tests/test_wpsrequest.py
@@ -8,6 +8,8 @@ import unittest
 import lxml.etree
 from pywps.app import WPSRequest
 import tempfile
+import datetime
+import json
 
 
 class WPSRequestTest(unittest.TestCase):
@@ -20,7 +22,6 @@ class WPSRequestTest(unittest.TestCase):
         x = open(self.tempfile, 'w')
         x.write("ahoj")
         x.close()
-
 
     def test_json_in(self):
 
@@ -46,7 +47,7 @@ class WPSRequestTest(unittest.TestCase):
                     'identifier': 'myliteral',
                     'type': 'literal',
                     'data_type': 'integer',
-                    'allowed_values': [ {'type':'anyvalue'} ],
+                    'allowed_values': [{'type': 'anyvalue'}],
                     'data': 1
                 }]
             },
@@ -61,6 +62,57 @@ class WPSRequestTest(unittest.TestCase):
         self.assertEqual(self.request.inputs['myin'][0].data, 'ahoj', 'Data are in the file')
         self.assertListEqual(self.request.inputs['myliteral'][0].allowed_values, [], 'Any value set')
         self.assertTrue(self.request.inputs['myliteral'][0].any_value, 'Any value set')
+
+    def test_json_inout_datetime(self):
+        obj = {
+            'operation': 'getcapabilities',
+            'version': '1.0.0',
+            'language': 'eng',
+            'identifiers': 'moinmoin',
+            'store_execute': True,
+            'status': True,
+            'lineage': True,
+            'inputs': {
+                'datetime': [{
+                    'identifier': 'datetime',
+                    'type': 'literal',
+                    'data_type': 'dateTime',
+                    'data': '2017-04-20T12:00:00',
+                    'allowed_values': [{'type': 'anyvalue'}],
+                }],
+                'date': [{
+                    'identifier': 'date',
+                    'type': 'literal',
+                    'data_type': 'date',
+                    'data': '2017-04-20',
+                    'allowed_values': [{'type': 'anyvalue'}],
+                }],
+                'time': [{
+                    'identifier': 'time',
+                    'type': 'literal',
+                    'data_type': 'time',
+                    'data': '09:00:00',
+                    'allowed_values': [{'type': 'anyvalue'}],
+                }],
+            },
+            'outputs': {},
+            'raw': False
+        }
+
+        self.request = WPSRequest()
+        self.request.json = obj
+
+        self.assertEqual(self.request.inputs['datetime'][0].data, datetime.datetime(2017, 4, 20, 12), 'Datatime set')
+        self.assertEqual(self.request.inputs['date'][0].data, datetime.date(2017, 4, 20), 'Data set')
+        self.assertEqual(self.request.inputs['time'][0].data, datetime.time(9, 0, 0), 'Time set')
+
+        # dump to json and reload
+        dump = self.request.json
+        self.request.json = json.loads(dump)
+
+        self.assertEqual(self.request.inputs['datetime'][0].data, datetime.datetime(2017, 4, 20, 12), 'Datatime set')
+        self.assertEqual(self.request.inputs['date'][0].data, datetime.date(2017, 4, 20), 'Data set')
+        self.assertEqual(self.request.inputs['time'][0].data, datetime.time(9, 0, 0), 'Time set')
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

the json dump method of  ``WPSRequest`` was not able to handle ``LiteralInput`` with ``datetime`` objects. See error message below.

This patch extends the json encoder to handle datetime objects. Tests are added for ``WPSRequest`` and ``LiteralInput`` to check json dump/load with datetime objects.

# Additional Information

Error message:

```
 File "/home/pingu/.conda/envs/malleefowl/lib/python2.7/site-packages/pywps/app/WPSRequest.py", line 320, in json
    return json.dumps(obj, allow_nan=False)
  File "/home/pingu/.conda/envs/malleefowl/lib/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/home/pingu/.conda/envs/malleefowl/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/home/pingu/.conda/envs/malleefowl/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/home/pingu/.conda/envs/malleefowl/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2005, 12, 31, 0, 0) is not JSON serializable
```

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
