### PR TITLE
Fix input file name for urls with "?"

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -12,6 +12,7 @@ from werkzeug.wrappers import Request, Response
 from pywps import WPS, OWS
 from pywps._compat import PY2
 from pywps._compat import urlopen
+from pywps._compat import urlparse
 from pywps.app.basic import xml_response
 from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
@@ -662,7 +663,8 @@ def _get_datasize(reference_file_data):
 
 def _build_input_file_name(href, workdir, extension=None):
     href = href or ''
-    file_name = os.path.basename(href).strip() or 'input'
+    url_path = urlparse(href).path or ''
+    file_name = os.path.basename(url_path).strip() or 'input'
     (prefix, suffix) = os.path.splitext(file_name)
     suffix = suffix or extension
     if prefix and suffix:

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -385,6 +385,9 @@ class ExecuteXmlParserTest(unittest.TestCase):
             _build_input_file_name('http://path/to/test', workdir=workdir),
             os.path.join(workdir, 'test'))
         self.assertEqual(
+            _build_input_file_name('https://path/to/test.txt?token=abc&expires_at=1234567', workdir=workdir),
+            os.path.join(workdir, 'test.txt'))
+        self.assertEqual(
             _build_input_file_name('file://path/to/.config', workdir=workdir),
             os.path.join(workdir, '.config'))
         open(os.path.join(workdir, 'duplicate.html'), 'a').close()


### PR DESCRIPTION
# Overview

Uses urlparse to get only the path of input href (skips "?" part).

# Related Issue / Discussion

Update of PR #259

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
