### PR TITLE
Fix remove stored

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -267,16 +267,19 @@ class Process(object):
         # tr
         stored_request = dblog.get_first_stored()
         if stored_request:
-            (uuid, request_json) = (stored_request.uuid, stored_request.request)
-            if not PY2:
-                request_json = request_json.decode('utf-8')
-            new_wps_request = WPSRequest()
-            new_wps_request.json = json.loads(request_json)
-            new_wps_response = WPSResponse(self, new_wps_request, uuid)
-            new_wps_response.status = STATUS.STORE_AND_UPDATE_STATUS
-            self._set_uuid(uuid)
-            self._run_async(new_wps_request, new_wps_response)
-            dblog.remove_stored(uuid)
+            try:
+                (uuid, request_json) = (stored_request.uuid, stored_request.request)
+                if not PY2:
+                    request_json = request_json.decode('utf-8')
+                new_wps_request = WPSRequest()
+                new_wps_request.json = json.loads(request_json)
+                new_wps_response = WPSResponse(self, new_wps_request, uuid)
+                new_wps_response.status = STATUS.STORE_AND_UPDATE_STATUS
+                self._set_uuid(uuid)
+                self._run_async(new_wps_request, new_wps_response)
+                dblog.remove_stored(uuid)
+            except Exception as e:
+                LOGGER.error("Could not run stored process. %s", e)
 
         return wps_response
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -214,7 +214,9 @@ class Process(object):
         maxprocesses = int(config.get_config_value('server', 'maxprocesses'))
 
         if stored < maxprocesses:
+            LOGGER.debug("Store process in job queue, uuid=%s", self.uuid)
             dblog.store_process(self.uuid, wps_request)
+            wps_response.update_status('PyWPS Process stored in job queue', 0)
         else:
             raise ServerBusy('Maximum number of parallel running processes reached. Please try later.')
 

--- a/pywps/app/WPSResponse.py
+++ b/pywps/app/WPSResponse.py
@@ -193,6 +193,8 @@ class WPSResponse(object):
             # DataInputs and DataOutputs definition XML if lineage=true
             if self.wps_request.lineage == 'true':
                 try:
+                    # TODO: stored process has ``pywps.inout.basic.LiteralInput``
+                    # instead of a ``pywps.inout.inputs.LiteralInput``.
                     data_inputs = [self.wps_request.inputs[i][0].execute_xml() for i in self.wps_request.inputs]
                     doc.append(WPS.DataInputs(*data_inputs))
                 except Exception as e:

--- a/pywps/app/WPSResponse.py
+++ b/pywps/app/WPSResponse.py
@@ -5,6 +5,7 @@
 ##################################################################
 
 
+import logging
 import os
 from lxml import etree
 import time
@@ -21,6 +22,8 @@ _STATUS = namedtuple('Status', 'ERROR_STATUS, NO_STATUS, STORE_STATUS,'
                      'STORE_AND_UPDATE_STATUS, DONE_STATUS')
 
 STATUS = _STATUS(0, 10, 20, 30, 40)
+
+LOGGER = logging.getLogger("PYWPS")
 
 
 class WPSResponse(object):
@@ -189,8 +192,11 @@ class WPSResponse(object):
 
             # DataInputs and DataOutputs definition XML if lineage=true
             if self.wps_request.lineage == 'true':
-                data_inputs = [self.wps_request.inputs[i][0].execute_xml() for i in self.wps_request.inputs]
-                doc.append(WPS.DataInputs(*data_inputs))
+                try:
+                    data_inputs = [self.wps_request.inputs[i][0].execute_xml() for i in self.wps_request.inputs]
+                    doc.append(WPS.DataInputs(*data_inputs))
+                except Exception as e:
+                    LOGGER.error("Failed to update lineage for input parameter. %s", e)
 
                 output_definitions = [self.outputs[o].execute_xml_lineage() for o in self.outputs]
                 doc.append(WPS.OutputDefinitions(*output_definitions))

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -216,7 +216,7 @@ def remove_stored(uuid):
     """
 
     session = get_session()
-    request = session.query(RequestInstance).filter_by(name='uuid').first()
+    request = session.query(RequestInstance).filter_by(uuid=str(uuid)).first()
     session.delete(request)
     session.commit()
     session.close()


### PR DESCRIPTION
# Overview

I'm using sqlite database with a datastore file.

This patch fixes the following:
* the ``dblog.remove_stored`` used a wrong argument in ``filter_by``.
* when a process was stored in the queue a status document update was missing.
* capture error when writing lineage of a stored process.
* comments and a try-except block add for running a stored process.  

# Related Issue / Discussion

See also #245 

# Additional Information

Lineage still does not work for stored processes. A stored process is initiated from a json object. This object is used to inititate ``pywps.inout.basic`` input objects but not ``pywps.inout.inputs`` objects which handle the lineage information. See TODO in ``WPSResponse``.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
