### PR TITLE
New feature: use os.symlink for file:// urls

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -396,13 +396,10 @@ class Service(object):
         def href_handler(complexinput, datain):
             """<wps:Reference /> handler"""
             # save the reference input in workdir
-            extension = None
-            if complexinput.data_format:
-                extension = complexinput.data_format.extension
             tmp_file = _build_input_file_name(
                 href=datain.get('href'),
                 workdir=complexinput.workdir,
-                extension=extension)
+                extension=_extension(complexinput))
 
             try:
                 (reference_file, reference_file_data) = _openurl(datain)
@@ -438,13 +435,10 @@ class Service(object):
             """<wps:Reference /> handler.
             Used when href is a file url."""
             # save the file reference input in workdir
-            extension = None
-            if complexinput.data_format:
-                extension = complexinput.data_format.extension
             tmp_file = _build_input_file_name(
                 href=datain.get('href'),
                 workdir=complexinput.workdir,
-                extension=extension)
+                extension=_extension(complexinput))
             try:
                 inpt_file = urlparse(datain.get('href')).path
                 os.symlink(inpt_file, tmp_file)
@@ -699,3 +693,10 @@ def _build_input_file_name(href, workdir, extension=None):
             suffix=suffix, prefix=prefix + '_',
             dir=workdir)[1]
     return input_file_name
+
+
+def _extension(complexinput):
+    extension = None
+    if complexinput.data_format:
+        extension = complexinput.data_format.extension
+    return extension


### PR DESCRIPTION
# Overview

In our use-case we are working with climate data netcdf files which can be easily a few GBs large. In a chained process we use file urls as input to a process (data is already available on local filesystem). In the current implementation pywps would **copy** all files to the workdir. We want to avoid that and use **symlinks** instead.

This patch adds a ``file_handler`` to handle complex inputs with file urls and creates symlinks in the workdir to the local file location.

# Related Issue / Discussion

# Additional Information

* This was patched in pywps-3 before.
* ``os.symlink`` works only on unix. One could skip the ``file_handler`` on windows.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
