### PR TITLE
New feature: validate complex input file url

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,7 +119,7 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
 :outputurl:
     corresponding URL
 
-.. note:: `outputpath` and `outputurl` must corespond. `outputpath` is the name
+.. note:: `outputpath` and `outputurl` must correspond. `outputpath` is the name
         of the resulting target directory, where all output data files are
         stored (with unique names). `outputurl` is the corresponding full URL,
         which is targeting to `outputpath` directory.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -127,6 +127,14 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
         Example: `outputpath=/var/www/wps/outputs` shall correspond with
         `outputurl=http://foo.bar/wps/outputs`
 
+:allowedinputpaths:
+     server paths which are allowed to be used by file URLs. A list of paths
+     must be seperated by `:`.
+
+     Example: `/var/lib/pywps/downloads:/var/lib/pywps/public`
+
+     By default no input paths are allowed.
+
 [logging]
 ---------
 

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -17,7 +17,7 @@ from pywps.app.basic import xml_response
 from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
 from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
-    StorageNotSupported
+    StorageNotSupported, FileURLNotSupported
 from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, update_response
 
@@ -438,6 +438,8 @@ class Service(object):
         def file_handler(complexinput, datain):
             """<wps:Reference /> handler.
             Used when href is a file url."""
+            # check if file url is allowed
+            _validate_file_input(href=datain.get('href'))
             # save the file reference input in workdir
             tmp_file = _build_input_file_name(
                 href=datain.get('href'),
@@ -445,6 +447,7 @@ class Service(object):
                 extension=_extension(complexinput))
             try:
                 inpt_file = urlparse(datain.get('href')).path
+                inpt_file = os.path.abspath(inpt_file)
                 os.symlink(inpt_file, tmp_file)
                 LOGGER.debug("Linked input file %s to %s.", inpt_file, tmp_file)
             except Exception as e:
@@ -698,6 +701,25 @@ def _build_input_file_name(href, workdir, extension=None):
             suffix=suffix, prefix=prefix + '_',
             dir=workdir)[1]
     return input_file_name
+
+
+def _validate_file_input(href):
+    href = href or ''
+    parsed_url = urlparse(href)
+    if parsed_url.scheme != 'file':
+        raise FileURLNotSupported('Invalid URL scheme')
+    file_path = parsed_url.path
+    if not file_path:
+        raise FileURLNotSupported('Invalid URL path')
+    file_path = os.path.abspath(file_path)
+    # build allowed paths list
+    inputpaths = config.get_config_value('server', 'allowedinputpaths')
+    allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
+    for allowed_path in allowed_paths:
+        if file_path.startswith(allowed_path):
+            LOGGER.debug("Accepted file url as input.")
+            return
+    raise FileURLNotSupported()
 
 
 def _extension(complexinput):

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -40,8 +40,8 @@ class WPSRequest(object):
         self.store_execute = None
         self.status = None
         self.lineage = None
-        self.inputs = None
-        self.outputs = None
+        self.inputs = {}
+        self.outputs = {}
         self.raw = None
 
         if self.http_request:

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -86,6 +86,8 @@ def load_configuration(cfgfiles=None):
     outputpath = tempfile.gettempdir()
     CONFIG.set('server', 'outputurl', 'file://%s' % outputpath)
     CONFIG.set('server', 'outputpath', outputpath)
+    # list of allowed input paths (file url input) seperated by ':'
+    CONFIG.set('server', 'allowedinputpaths', '')
     CONFIG.set('server', 'workdir', tempfile.gettempdir())
     CONFIG.set('server', 'parallelprocesses', '2')
     # If this flag is enabled it will set the HOME environment

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -144,3 +144,14 @@ class ServerBusy(NoApplicableCode):
             'description': self.get_description(environ)
             }
         )
+
+
+class FileURLNotSupported(NoApplicableCode):
+    """File URL not supported exception implementation
+    """
+    code = 400
+    description = 'File URL not supported as input.'
+
+    def __init__(self, description="", locator="", code=400):
+        description = description or self.description
+        NoApplicableCode.__init__(self, description=description, locator=locator, code=code)

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -18,7 +18,8 @@ class BoundingBoxInput(basic.BBoxInput):
     :param string identifier: The name of this input.
     :param string title: Human readable title
     :param string abstract: Longer text description
-    :param crss: List of supported coordinate reference system (e.g. ['EPSG:4326'])
+    :param crss: List of supported coordinate reference
+                 system (e.g. ['EPSG:4326'])
     :param int dimensions: 2 or 3
     :param int min_occurs: how many times this input occurs
     :param int max_occurs: how many times this input occurs
@@ -29,10 +30,13 @@ class BoundingBoxInput(basic.BBoxInput):
     def __init__(self, identifier, title, crss, abstract='',
                  dimensions=2, metadata=[], min_occurs=1,
                  max_occurs=1,
-                 mode=MODE.NONE):
+                 mode=MODE.NONE,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+
         basic.BBoxInput.__init__(self, identifier, title=title,
                                  abstract=abstract, crss=crss,
-                                 dimensions=dimensions, mode=mode)
+                                 dimensions=dimensions, mode=mode,
+                                 default=default, default_type=default_type)
 
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
@@ -120,7 +124,9 @@ class ComplexInput(basic.ComplexInput):
 
     :param str identifier: The name of this input.
     :param str title: Title of the input
-    :param  pywps.inout.formats.Format supported_formats: List of supported formats
+    :param pywps.inout.formats.Format supported_formats: List of supported
+                                                          formats
+    :param pywps.inout.formats.Format data_format: default data format
     :param str abstract: Input abstract
     :param list metada: TODO
     :param int min_occurs: minimum occurence
@@ -130,13 +136,16 @@ class ComplexInput(basic.ComplexInput):
 
     def __init__(self, identifier, title, supported_formats,
                  data_format=None, abstract='', metadata=[], min_occurs=1,
-                 max_occurs=1, mode=MODE.NONE):
+                 max_occurs=1, mode=MODE.NONE,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
         """constructor"""
 
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract,
                                     supported_formats=supported_formats,
-                                    mode=mode)
+                                    mode=mode,
+                                    default=default, default_type=default_type)
+
         self.metadata = metadata
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
@@ -263,18 +272,20 @@ class LiteralInput(basic.LiteralInput):
     """
 
     def __init__(self, identifier, title, data_type='integer', abstract='',
-                 metadata=[], uoms=None, default=None,
+                 metadata=[], uoms=None,
                  min_occurs=1, max_occurs=1,
-                 mode=MODE.SIMPLE, allowed_values=AnyValue):
+                 mode=MODE.SIMPLE, allowed_values=AnyValue,
+                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+
         """Constructor
         """
 
         basic.LiteralInput.__init__(self, identifier=identifier, title=title,
                                     abstract=abstract, data_type=data_type,
                                     uoms=uoms, mode=mode,
-                                    allowed_values=allowed_values)
+                                    allowed_values=allowed_values,
+                                    default=default, default_type=default_type)
         self.metadata = metadata
-        self.default = default
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
         self.as_reference = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,7 @@ from tests import test_ows
 from tests import test_formats
 from tests import test_dblog
 from tests import test_wpsrequest
+from tests import test_service
 from tests.validator import test_complexvalidators
 from tests.validator import test_literalvalidators
 
@@ -37,7 +38,8 @@ def load_tests(loader=None, tests=None, pattern=None):
         test_literalvalidators.load_tests(),
         test_formats.load_tests(),
         test_dblog.load_tests(),
-        test_wpsrequest.load_tests()
+        test_wpsrequest.load_tests(),
+        test_service.load_tests(),
     ])
 
 if __name__ == "__main__":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,6 +21,7 @@ from tests import test_wpsrequest
 from tests.validator import test_complexvalidators
 from tests.validator import test_literalvalidators
 
+
 def load_tests(loader=None, tests=None, pattern=None):
     """Load tests
     """

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -72,7 +72,7 @@ def create_complex_proces():
         response.outputs['complex'].data = request.inputs['complex'][0].data
         return response
 
-    frmt = Format(mime_type='application/gml') # this is unknown mimetype
+    frmt = Format(mime_type='application/gml', extension=".gml") # this is unknown mimetype
 
     return Process(handler=complex_proces,
             identifier='my_complex_process',
@@ -81,6 +81,7 @@ def create_complex_proces():
                 ComplexInput(
                     'complex',
                     'Complex input',
+                    default="DEFAULT COMPLEX DATA",
                     supported_formats=[frmt])
             ],
             outputs=[
@@ -158,6 +159,27 @@ class ExecuteTest(unittest.TestCase):
 
         self.assertEqual(parsed_inputs[0].data_format.validate, validategml)
 
+    def test_input_default(self):
+        """Test input parsing
+        """
+        my_process = create_complex_proces()
+        service = Service(processes=[my_process])
+        self.assertEqual(len(service.processes.keys()), 1)
+        self.assertTrue(service.processes['my_complex_process'])
+
+        class FakeRequest():
+            identifier = 'complex_process'
+            service = 'wps'
+            version = '1.0.0'
+            inputs = {}
+            raw = False
+            outputs = {}
+            store_execute = False
+            lineage = False
+
+        request = FakeRequest()
+        response = service.execute('my_complex_process', request, 'fakeuuid')
+        self.assertEqual(response.outputs['complex'].data, 'DEFAULT COMPLEX DATA')
 
     def test_missing_process_error(self):
         client = client_for(Service(processes=[create_ultimate_question()]))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -14,7 +14,7 @@ from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
 from pywps.inout.basic import IOHandler, SOURCE_TYPE, SimpleHandler, BBoxInput, BBoxOutput, \
-    ComplexInput, ComplexOutput, LiteralInput, LiteralOutput
+    ComplexInput, ComplexOutput, LiteralOutput, LiteralInput
 from pywps.inout import BoundingBoxInput as BoundingBoxInputXML
 from pywps.inout.literaltypes import convert, AllowedValue
 from pywps._compat import StringIO, text_type
@@ -244,7 +244,8 @@ class LiteralInputTest(unittest.TestCase):
         self.literal_input = LiteralInput(
                 identifier="literalinput",
                 mode=2,
-                allowed_values=(1, 2, (3, 3, 12)))
+                allowed_values=(1, 2, (3, 3, 12)),
+                default=6)
 
 
     def test_contruct(self):
@@ -254,27 +255,21 @@ class LiteralInputTest(unittest.TestCase):
         self.assertIsInstance(self.literal_input.allowed_values[2], AllowedValue)
         self.assertEqual(self.literal_input.allowed_values[2].spacing, 3)
         self.assertEqual(self.literal_input.allowed_values[2].minval, 3)
+        self.assertEqual(self.literal_input.data, 6, "Default value set to 6")
 
     def test_valid(self):
+        self.assertEqual(self.literal_input.data, 6)
         self.literal_input.data = 1
         self.assertEqual(self.literal_input.data, 1)
-        try:
+
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = 5
-            self.assertTrue(False, '5 does not work for spacing')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
-        try:
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = "a"
-            self.assertTrue(False, '"a" should not be allowed to be set')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
-        try:
+        with self.assertRaises(InvalidParameterValue):
             self.literal_input.data = 15
-            self.assertTrue(False, '11 should not be allowed to be set')
-        except InvalidParameterValue:
-            self.assertTrue(True)
 
         self.literal_input.data = 6
         self.assertEqual(self.literal_input.data, 6)
@@ -322,6 +317,7 @@ class LiteralInputTest(unittest.TestCase):
         inpt.data = "2017-04-20"
         out = inpt.json
         self.assertEqual(out['data'], datetime.date(2017, 4, 20), 'date set')
+
 
 
 class LiteralOutputTest(unittest.TestCase):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pywps.app.Service import _validate_file_input
+from pywps.exceptions import FileURLNotSupported
+
+
+class ServiceTest(unittest.TestCase):
+
+    def test_validate_file_input(self):
+        try:
+            _validate_file_input(href="file:///private/space/test.txt")
+        except FileURLNotSupported:
+            self.assertTrue(True)
+        else:
+            self.assertTrue(False, 'should raise exception FileURLNotSupported')
+
+
+def load_tests(loader=None, tests=None, pattern=None):
+    if not loader:
+        loader = unittest.TestLoader()
+    suite_list = [
+        loader.loadTestsFromTestCase(ServiceTest),
+    ]
+    return unittest.TestSuite(suite_list)


### PR DESCRIPTION
# Overview

PyWPS allows file URLs as complex inputs. This could be used to access files on the PyWPS server which the processes should not have access to.

With this PR one can configure a list of allowed path locations on the server which are allowed to be used by processes. The path list is configured with the ``allowedinputpaths`` config option, paths can be separated by ``:``. By default no input paths are allowed.

In case of an invalid file URL a ``FileURLNotAllowed`` exception is thrown.

# Related Issue / Discussion

# Additional Information

Maybe this could be implemented as a PyWPS validator ... but it should be enabled for all complex inputs.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
