### PR TITLE
fix default value in describe_xml

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -334,8 +334,9 @@ class LiteralInput(basic.LiteralInput):
         else:
             literal_data_doc.append(self._describe_xml_allowedvalues())
 
-        if self.default:
-            literal_data_doc.append(E.DefaultValue(self.default))
+        # TODO: is default value handled correctly here?
+        if self.data:
+            literal_data_doc.append(E.DefaultValue(str(self.data)))
 
         return doc
 


### PR DESCRIPTION
# Overview

`self.default` is referenced in `describe_xml` but does not exist anymore with patch #236.

See: 
https://github.com/geopython/pywps/blob/develop/pywps/inout/inputs.py#L337

With this fix `self.default` is replaced by `self.data` which is set to the default value by #236.

@tomkralidis @huard 
Please have a look at this fix.

# Related Issue / Discussion

#236 and #226 

# Additional Information

Probably there is more to do with default values ...

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
