### PR TITLE
New feature: validate complex input file url (PR with squashed commit)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,13 +119,21 @@ configuration file <http://docs.pycsw.org/en/latest/configuration.html>`_.
 :outputurl:
     corresponding URL
 
-.. note:: `outputpath` and `outputurl` must corespond. `outputpath` is the name
+.. note:: `outputpath` and `outputurl` must correspond. `outputpath` is the name
         of the resulting target directory, where all output data files are
         stored (with unique names). `outputurl` is the corresponding full URL,
         which is targeting to `outputpath` directory.
 
         Example: `outputpath=/var/www/wps/outputs` shall correspond with
         `outputurl=http://foo.bar/wps/outputs`
+
+:allowedinputpaths:
+     server paths which are allowed to be used by file URLs. A list of paths
+     must be seperated by `:`.
+
+     Example: `/var/lib/pywps/downloads:/var/lib/pywps/public`
+
+     By default no input paths are allowed.
 
 [logging]
 ---------

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -17,7 +17,7 @@ from pywps.app.basic import xml_response
 from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
 from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
-    StorageNotSupported
+    StorageNotSupported, FileURLNotSupported
 from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, update_response
 
@@ -438,6 +438,8 @@ class Service(object):
         def file_handler(complexinput, datain):
             """<wps:Reference /> handler.
             Used when href is a file url."""
+            # check if file url is allowed
+            _validate_file_input(href=datain.get('href'))
             # save the file reference input in workdir
             tmp_file = _build_input_file_name(
                 href=datain.get('href'),
@@ -445,6 +447,7 @@ class Service(object):
                 extension=_extension(complexinput))
             try:
                 inpt_file = urlparse(datain.get('href')).path
+                inpt_file = os.path.abspath(inpt_file)
                 os.symlink(inpt_file, tmp_file)
                 LOGGER.debug("Linked input file %s to %s.", inpt_file, tmp_file)
             except Exception as e:
@@ -698,6 +701,25 @@ def _build_input_file_name(href, workdir, extension=None):
             suffix=suffix, prefix=prefix + '_',
             dir=workdir)[1]
     return input_file_name
+
+
+def _validate_file_input(href):
+    href = href or ''
+    parsed_url = urlparse(href)
+    if parsed_url.scheme != 'file':
+        raise FileURLNotSupported('Invalid URL scheme')
+    file_path = parsed_url.path
+    if not file_path:
+        raise FileURLNotSupported('Invalid URL path')
+    file_path = os.path.abspath(file_path)
+    # build allowed paths list
+    inputpaths = config.get_config_value('server', 'allowedinputpaths')
+    allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
+    for allowed_path in allowed_paths:
+        if file_path.startswith(allowed_path):
+            LOGGER.debug("Accepted file url as input.")
+            return
+    raise FileURLNotSupported()
 
 
 def _extension(complexinput):

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -86,6 +86,8 @@ def load_configuration(cfgfiles=None):
     outputpath = tempfile.gettempdir()
     CONFIG.set('server', 'outputurl', 'file://%s' % outputpath)
     CONFIG.set('server', 'outputpath', outputpath)
+    # list of allowed input paths (file url input) seperated by ':'
+    CONFIG.set('server', 'allowedinputpaths', '')
     CONFIG.set('server', 'workdir', tempfile.gettempdir())
     CONFIG.set('server', 'parallelprocesses', '2')
     # If this flag is enabled it will set the HOME environment

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -144,3 +144,14 @@ class ServerBusy(NoApplicableCode):
             'description': self.get_description(environ)
             }
         )
+
+
+class FileURLNotSupported(NoApplicableCode):
+    """File URL not supported exception implementation
+    """
+    code = 400
+    description = 'File URL not supported as input.'
+
+    def __init__(self, description="", locator="", code=400):
+        description = description or self.description
+        NoApplicableCode.__init__(self, description=description, locator=locator, code=code)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,8 +18,10 @@ from tests import test_ows
 from tests import test_formats
 from tests import test_dblog
 from tests import test_wpsrequest
+from tests import test_service
 from tests.validator import test_complexvalidators
 from tests.validator import test_literalvalidators
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     """Load tests
@@ -36,7 +38,8 @@ def load_tests(loader=None, tests=None, pattern=None):
         test_literalvalidators.load_tests(),
         test_formats.load_tests(),
         test_dblog.load_tests(),
-        test_wpsrequest.load_tests()
+        test_wpsrequest.load_tests(),
+        test_service.load_tests(),
     ])
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pywps.app.Service import _validate_file_input
+from pywps.exceptions import FileURLNotSupported
+
+
+class ServiceTest(unittest.TestCase):
+
+    def test_validate_file_input(self):
+        try:
+            _validate_file_input(href="file:///private/space/test.txt")
+        except FileURLNotSupported:
+            self.assertTrue(True)
+        else:
+            self.assertTrue(False, 'should raise exception FileURLNotSupported')
+
+
+def load_tests(loader=None, tests=None, pattern=None):
+    if not loader:
+        loader = unittest.TestLoader()
+    suite_list = [
+        loader.loadTestsFromTestCase(ServiceTest),
+    ]
+    return unittest.TestSuite(suite_list)


### PR DESCRIPTION
# Overview

PyWPS allows file URLs as complex inputs. This could be used to access files on the PyWPS server which the processes should not have access to.

With this PR one can configure a list of allowed path locations on the server which are allowed to be used by processes. The path list is configured with the allowedinputpaths config option, paths can be separated by :. By default no input paths are allowed.

In case of an invalid file URL a FileURLNotAllowed exception is thrown.

# Related Issue / Discussion

This is the squashed commit of PR #274 

# Additional Information

Maybe this could be implemented as a PyWPS validator ... but it should be enabled for all complex inputs.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
