### PR TITLE
SQLAlchemy set to ignore thread check (solves issue #284 )

### DIFF
--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -182,7 +182,7 @@ def get_session():
     if level in ['INFO']:
         echo = False
     try:
-        engine = sqlalchemy.create_engine(database, echo=echo)
+        engine = sqlalchemy.create_engine(database, connect_args={'check_same_thread': False}, echo=echo)
     except sqlalchemy.exc.SQLAlchemyError as e:
         raise NoApplicableCode("Could not connect to database: {}".format(e.message))
 


### PR DESCRIPTION
# Overview

Need to disable the thread check, sqlite3 in sqlalchemy uses a a NullPooll (each time it wants to write it opens and closes). It could be best to have StaticPool or SingletonThreadPool if the there is any problems when connecting from a different thread to the sqlite

# Related Issue / Discussion

#284 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
