### PR TITLE
connect_args only for sqlite and memory db closes #286

### DIFF
--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -182,7 +182,10 @@ def get_session():
     if level in ['INFO']:
         echo = False
     try:
-        engine = sqlalchemy.create_engine(database, connect_args={'check_same_thread': False}, echo=echo)
+        if database.startswith("sqlite") or database.startswith("memory"):
+            engine = sqlalchemy.create_engine(database, connect_args={'check_same_thread': False}, echo=echo)
+        else:
+            engine = sqlalchemy.create_engine(database, echo=echo)
     except sqlalchemy.exc.SQLAlchemyError as e:
         raise NoApplicableCode("Could not connect to database: {}".format(e.message))
 


### PR DESCRIPTION
# Overview
The patch injects the necessary connect_args for sqlite only, allowing for normal connection to the remaining DB. The connect_args are also used for memory, since SQLALchemy uses a sqlite in memory and therefore could have the same problems 

# Related Issue / Discussion

#285 and discussion in mailing list

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
