### PR TITLE
fix issue #301: binary input files not handled on python 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml
 werkzeug
 SQLAlchemy
 python-dateutil
+requests


### PR DESCRIPTION
# Overview

This pull request fixes issue #301:

* explicitly adds `requests` library to requirements ... it was already a requirement by using `owslib`.
* It uses the `requests` library to stream the input files (necessary when having large files).
* `requests` handles text/binary files, using `Response.iter_content()`. Works both on Python 2.7 and Python 3.x.
* file size calculation is not necessary ... download stream will stop when max size is exceeded.
* fixes also `os.symlink` on windows in `file_handler`.

# Related Issue / Discussion

See issue #301 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
