### PR TITLE
fix issue #303: RawDataOutput on Python 3.x

### DIFF
--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -14,7 +14,7 @@ from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
 from pywps.inout.basic import IOHandler, SOURCE_TYPE, SimpleHandler, BBoxInput, BBoxOutput, \
-    ComplexInput, ComplexOutput, LiteralOutput, LiteralInput
+    ComplexInput, ComplexOutput, LiteralOutput, LiteralInput, _is_textfile
 from pywps.inout import BoundingBoxInput as BoundingBoxInputXML
 from pywps.inout.literaltypes import convert, AllowedValue
 from pywps._compat import StringIO, text_type
@@ -23,6 +23,8 @@ from pywps.exceptions import InvalidParameterValue
 from pywps.validator.mode import MODE
 
 from lxml import etree
+
+DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
 
 
 def get_data_format(mime_type):
@@ -145,6 +147,14 @@ class IOHandlerTest(unittest.TestCase):
         stream_data = self.iohandler.stream.read()
         self.iohandler.stream.close()
         self.assertEqual(self._value, stream_data, 'Stream obtained')
+
+    def test_is_textfile(self):
+        geotiff = os.path.join(DATA_DIR, 'geotiff', 'dem.tiff')
+        self.assertFalse(_is_textfile(geotiff))
+        gml = os.path.join(DATA_DIR, 'gml', 'point.gml')
+        self.assertTrue(_is_textfile(gml))
+        geojson = os.path.join(DATA_DIR, 'json', 'point.geojson')
+        self.assertTrue(_is_textfile(geojson))
 
 
 class ComplexInputTest(unittest.TestCase):


### PR DESCRIPTION
# Overview

Fixes the issue #303 for RawDataOuput on Python 3.x.

# Related Issue / Discussion

issue #303 

# Additional Information

The patch can optionally use the [python-magic](https://github.com/ahupp/python-magic) library to check if a file is *text* or *binary*.

In PyWPS we already know the mimetype of an output parameter, but I don't know if there is an easy way to identify the mimetype as *text* or *binary*. In this patch all mimetypes with ``text/`` are assumed to be *text*. But mimetype groups can be mixed with both *text* and *binary*,  like ``application/json``  (text) and ``application/x-netcdf`` (binary).

Maybe you have a better idea for dealing with this problem. Python 3.x makes this a bit complicated here.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
