### PR TITLE
Keyword support in Process, Inputs and Outputs

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -32,7 +32,10 @@ class Process(object):
                     request. It should accept a single
                     :class:`pywps.app.WPSRequest` argument and return a
                     :class:`pywps.app.WPSResponse` object.
-    :param identifier: Name of this process.
+    :param string identifier: Name of this process.
+    :param string title: Human readable title of process.
+    :param string abstract: Brief narrative description of the process.
+    :param list keywords: Keywords that characterize a process.
     :param inputs: List of inputs accepted by this process. They
                    should be :class:`~LiteralInput` and :class:`~ComplexInput`
                    and :class:`~BoundingBoxInput`
@@ -45,12 +48,13 @@ class Process(object):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, handler, identifier, title, abstract='', profile=[], metadata=[], inputs=[],
+    def __init__(self, handler, identifier, title, abstract='', keywords=[], profile=[], metadata=[], inputs=[],
                  outputs=[], version='None', store_supported=False, status_supported=False, grass_location=None):
         self.identifier = identifier
         self.handler = handler
         self.title = title
         self.abstract = abstract
+        self.keywords = keywords
         self.metadata = metadata
         self.profile = profile
         self.version = version
@@ -80,6 +84,9 @@ class Process(object):
         )
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
         if self.profile:
@@ -109,6 +116,10 @@ class Process(object):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -284,16 +284,17 @@ class SimpleHandler(IOHandler):
 
 
 class BasicIO:
-    """Basic Input or Ouput class
+    """Basic Input/Output class
     """
-    def __init__(self, identifier, title=None, abstract=None):
+    def __init__(self, identifier, title=None, abstract=None, keywords=None):
         self.identifier = identifier
         self.title = title
         self.abstract = abstract
+        self.keywords = keywords
 
 
 class BasicLiteral:
-    """Basic literal input/output class
+    """Basic literal Input/Output class
     """
 
     def __init__(self, data_type="integer", uoms=None):
@@ -421,11 +422,11 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
     """LiteralInput input abstract class
     """
 
-    def __init__(self, identifier, title=None, abstract=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  data_type="integer", workdir=None, allowed_values=None,
                  uoms=None, mode=MODE.NONE,
                  default=None, default_type=SOURCE_TYPE.DATA):
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir, data_type, mode=mode)
 
@@ -455,6 +456,7 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
             'identifier': self.identifier,
             'title': self.title,
             'abstract': self.abstract,
+            'keywords': self.keywords,
             'type': 'literal',
             'data_type': self.data_type,
             'workdir': self.workdir,
@@ -470,10 +472,10 @@ class LiteralOutput(BasicIO, BasicLiteral, SimpleHandler):
     """Basic LiteralOutput class
     """
 
-    def __init__(self, identifier, title=None, abstract=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  data_type=None, workdir=None, uoms=None, validate=None,
                  mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir=None, data_type=data_type,
                                mode=mode)
@@ -500,11 +502,11 @@ class BBoxInput(BasicIO, BasicBoundingBox, IOHandler):
     """Basic Bounding box input abstract class
     """
 
-    def __init__(self, identifier, title=None, abstract=None, crss=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=[], crss=None,
                  dimensions=None, workdir=None,
                  mode=MODE.SIMPLE,
                  default=None, default_type=SOURCE_TYPE.DATA):
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         BasicBoundingBox.__init__(self, crss, dimensions)
         IOHandler.__init__(self, workdir=None, mode=mode)
 
@@ -529,6 +531,7 @@ class BBoxInput(BasicIO, BasicBoundingBox, IOHandler):
             'identifier': self.identifier,
             'title': self.title,
             'abstract': self.abstract,
+            'keywords': self.keywords,
             'type': 'bbox',
             'crs': self.crss,
             'bbox': (self.ll, self.ur),
@@ -542,9 +545,9 @@ class BBoxOutput(BasicIO, BasicBoundingBox, SimpleHandler):
     """Basic BoundingBox output class
     """
 
-    def __init__(self, identifier, title=None, abstract=None, crss=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=None, crss=None,
                  dimensions=None, workdir=None, mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         BasicBoundingBox.__init__(self, crss, dimensions)
         SimpleHandler.__init__(self, workdir=None, mode=mode)
         self._storage = None
@@ -567,12 +570,12 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
     1
     """
 
-    def __init__(self, identifier, title=None, abstract=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  workdir=None, data_format=None, supported_formats=None,
                  mode=MODE.NONE,
                  default=None, default_type=SOURCE_TYPE.DATA):
 
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
 
@@ -586,6 +589,7 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
             'identifier': self.identifier,
             'title': self.title,
             'abstract': self.abstract,
+            'keywords': self.keywords,
             'type': 'complex',
             'data_format': self.data_format.json,
             'supported_formats': [frmt.json for frmt in self.supported_formats],
@@ -623,10 +627,10 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     'AA'
     """
 
-    def __init__(self, identifier, title=None, abstract=None,
+    def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  workdir=None, data_format=None, supported_formats=None,
                  mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract)
+        BasicIO.__init__(self, identifier, title, abstract, keywords)
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -18,13 +18,9 @@ class BoundingBoxInput(basic.BBoxInput):
     :param string identifier: The name of this input.
     :param string title: Human readable title
     :param string abstract: Longer text description
-<<<<<<< HEAD
     :param crss: List of supported coordinate reference
                  system (e.g. ['EPSG:4326'])
-=======
     :param list keywords: Keywords that characterize this input.
-    :param crss: List of supported coordinate reference system (e.g. ['EPSG:4326'])
->>>>>>> 1f1da73... added keyword support to inputs and outputs
     :param int dimensions: 2 or 3
     :param list metadata: TODO
     :param int min_occurs: how many times this input occurs
@@ -138,13 +134,9 @@ class ComplexInput(basic.ComplexInput):
 
     :param str identifier: The name of this input.
     :param str title: Title of the input
-<<<<<<< HEAD
     :param pywps.inout.formats.Format supported_formats: List of supported
                                                           formats
     :param pywps.inout.formats.Format data_format: default data format
-=======
-    :param pywps.inout.formats.Format supported_formats: List of supported formats
->>>>>>> 1f1da73... added keyword support to inputs and outputs
     :param str abstract: Input abstract
     :param list keywords: Keywords that characterize this input.
     :param list metadata: TODO

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -18,23 +18,29 @@ class BoundingBoxInput(basic.BBoxInput):
     :param string identifier: The name of this input.
     :param string title: Human readable title
     :param string abstract: Longer text description
+<<<<<<< HEAD
     :param crss: List of supported coordinate reference
                  system (e.g. ['EPSG:4326'])
+=======
+    :param list keywords: Keywords that characterize this input.
+    :param crss: List of supported coordinate reference system (e.g. ['EPSG:4326'])
+>>>>>>> 1f1da73... added keyword support to inputs and outputs
     :param int dimensions: 2 or 3
+    :param list metadata: TODO
     :param int min_occurs: how many times this input occurs
     :param int max_occurs: how many times this input occurs
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title, crss, abstract='',
+    def __init__(self, identifier, title, crss, abstract='', keywords=[],
                  dimensions=2, metadata=[], min_occurs=1,
                  max_occurs=1,
                  mode=MODE.NONE,
                  default=None, default_type=basic.SOURCE_TYPE.DATA):
 
         basic.BBoxInput.__init__(self, identifier, title=title,
-                                 abstract=abstract, crss=crss,
+                                 abstract=abstract, keywords=keywords, crss=crss,
                                  dimensions=dimensions, mode=mode,
                                  default=default, default_type=default_type)
 
@@ -57,6 +63,10 @@ class BoundingBoxInput(basic.BBoxInput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
@@ -89,6 +99,10 @@ class BoundingBoxInput(basic.BBoxInput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         doc.append(node)
 
@@ -124,24 +138,29 @@ class ComplexInput(basic.ComplexInput):
 
     :param str identifier: The name of this input.
     :param str title: Title of the input
+<<<<<<< HEAD
     :param pywps.inout.formats.Format supported_formats: List of supported
                                                           formats
     :param pywps.inout.formats.Format data_format: default data format
+=======
+    :param pywps.inout.formats.Format supported_formats: List of supported formats
+>>>>>>> 1f1da73... added keyword support to inputs and outputs
     :param str abstract: Input abstract
-    :param list metada: TODO
-    :param int min_occurs: minimum occurence
-    :param int max_occurs: maximum occurence
+    :param list keywords: Keywords that characterize this input.
+    :param list metadata: TODO
+    :param int min_occurs: minimum occurrence
+    :param int max_occurs: maximum occurrence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     """
 
     def __init__(self, identifier, title, supported_formats,
-                 data_format=None, abstract='', metadata=[], min_occurs=1,
+                 data_format=None, abstract='', keywords=[], metadata=[], min_occurs=1,
                  max_occurs=1, mode=MODE.NONE,
                  default=None, default_type=basic.SOURCE_TYPE.DATA):
         """constructor"""
 
         basic.ComplexInput.__init__(self, identifier=identifier, title=title,
-                                    abstract=abstract,
+                                    abstract=abstract, keywords=keywords,
                                     supported_formats=supported_formats,
                                     mode=mode,
                                     default=default, default_type=default_type)
@@ -182,6 +201,10 @@ class ComplexInput(basic.ComplexInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
+
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
 
@@ -211,8 +234,14 @@ class ComplexInput(basic.ComplexInput):
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
         )
+
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
+
         doc.append(node)
 
         return doc
@@ -261,6 +290,7 @@ class LiteralInput(basic.LiteralInput):
     :param str title: Title of the input
     :param pywps.inout.literaltypes.LITERAL_DATA_TYPES data_type: data type
     :param str abstract: Input abstract
+    :param list keywords: Keywords that characterize this input.
     :param list metadata: TODO
     :param str uoms: units
     :param int min_occurs: minimum occurence
@@ -271,7 +301,8 @@ class LiteralInput(basic.LiteralInput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title, data_type='integer', abstract='',
+
+    def __init__(self, identifier, title, data_type='integer', abstract='', keywords=[],
                  metadata=[], uoms=None,
                  min_occurs=1, max_occurs=1,
                  mode=MODE.SIMPLE, allowed_values=AnyValue,
@@ -281,7 +312,7 @@ class LiteralInput(basic.LiteralInput):
         """
 
         basic.LiteralInput.__init__(self, identifier=identifier, title=title,
-                                    abstract=abstract, data_type=data_type,
+                                    abstract=abstract, keywords=keywords, data_type=data_type,
                                     uoms=uoms, mode=mode,
                                     allowed_values=allowed_values,
                                     default=default, default_type=default_type)
@@ -303,6 +334,10 @@ class LiteralInput(basic.LiteralInput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
@@ -356,8 +391,14 @@ class LiteralInput(basic.LiteralInput):
             OWS.Identifier(self.identifier),
             OWS.Title(self.title)
         )
+
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
+
         doc.append(node)
 
         return doc

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -29,12 +29,12 @@ class BoundingBoxOutput(basic.BBoxInput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title, crss, abstract='',
+    def __init__(self, identifier, title, crss, abstract='', keywords=[],
                  dimensions=2, metadata=[], min_occurs='1',
                  max_occurs='1', as_reference=False,
                  mode=MODE.NONE):
         basic.BBoxInput.__init__(self, identifier, title=title,
-                                 abstract=abstract, crss=crss,
+                                 abstract=abstract, keywords=keywords, crss=crss,
                                  dimensions=dimensions, mode=mode)
 
         self.metadata = metadata
@@ -50,6 +50,10 @@ class BoundingBoxOutput(basic.BBoxInput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
@@ -78,6 +82,10 @@ class BoundingBoxOutput(basic.BBoxInput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
+
         return doc
 
     def execute_xml(self):
@@ -88,6 +96,10 @@ class BoundingBoxOutput(basic.BBoxInput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         data_doc = WPS.Data()
         bbox_data_doc = OWS.BoundingBox()
@@ -116,13 +128,13 @@ class ComplexOutput(basic.ComplexOutput):
     """
 
     def __init__(self, identifier, title, supported_formats=None,
-                 abstract='', metadata=None,
+                 abstract='', keywords=[], metadata=None,
                  as_reference=False, mode=MODE.NONE):
         if metadata is None:
             metadata = []
 
         basic.ComplexOutput.__init__(self, identifier, title=title,
-                                     abstract=abstract,
+                                     abstract=abstract, keywords=keywords,
                                      supported_formats=supported_formats,
                                      mode=mode)
         self.metadata = metadata
@@ -143,6 +155,10 @@ class ComplexOutput(basic.ComplexOutput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
@@ -252,13 +268,12 @@ class LiteralOutput(basic.LiteralOutput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title, data_type='string', abstract='',
+    def __init__(self, identifier, title, data_type='string', abstract='', keywords=[],
                  metadata=[], uoms=[], mode=MODE.SIMPLE):
         if uoms is None:
             uoms = []
-        basic.LiteralOutput.__init__(self, identifier, title=title,
+        basic.LiteralOutput.__init__(self, identifier, title=title, abstract=abstract, keywords=keywords,
                                      data_type=data_type, uoms=uoms, mode=mode)
-        self.abstract = abstract
         self.metadata = metadata
 
     def describe_xml(self):
@@ -269,6 +284,10 @@ class LiteralOutput(basic.LiteralOutput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         for m in self.metadata:
             doc.append(OWS.Metadata(dict(m)))
@@ -304,6 +323,10 @@ class LiteralOutput(basic.LiteralOutput):
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
 
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
+
         return doc
 
     def execute_xml(self):
@@ -314,6 +337,10 @@ class LiteralOutput(basic.LiteralOutput):
 
         if self.abstract:
             doc.append(OWS.Abstract(self.abstract))
+
+        if self.keywords:
+            kws = map(OWS.Keyword, self.keywords)
+            doc.append(OWS.Keywords(*kws))
 
         data_doc = WPS.Data()
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -46,7 +46,7 @@ class CapabilitiesTest(unittest.TestCase):
     def setUp(self):
         def pr1(): pass
         def pr2(): pass
-        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1', metadata=[Metadata('pr1 metadata')]), Process(pr2, 'pr2', 'Process 2', metadata=[Metadata('pr2 metadata')])]))
+        self.client = client_for(Service(processes=[Process(pr1, 'pr1', 'Process 1', abstract='Process 1', keywords=['kw1a','kw1b'], metadata=[Metadata('pr1 metadata')]), Process(pr2, 'pr2', 'Process 2', keywords=['kw2a'], metadata=[Metadata('pr2 metadata')])]))
 
     def check_capabilities_response(self, resp):
         assert resp.status_code == 200
@@ -61,6 +61,13 @@ class CapabilitiesTest(unittest.TestCase):
                                 '/ows:Identifier')
         assert sorted(names.split()) == ['pr1', 'pr2']
 
+        keywords = resp.xpath('/wps:Capabilities'
+                                  '/wps:ProcessOfferings'
+                                  '/wps:Process'
+                                  '/ows:Keywords'
+                                  '/ows:Keyword')
+        assert len(keywords) == 3
+        
         metadatas = resp.xpath('/wps:Capabilities'
                                '/wps:ProcessOfferings'
                                '/wps:Process'

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -175,11 +175,13 @@ class DescribeProcessInputTest(unittest.TestCase):
 class InputDescriptionTest(unittest.TestCase):
 
     def test_literal_integer_input(self):
-        literal = LiteralInput('foo', 'Literal foo', data_type='positiveInteger', uoms=['metre'])
+        literal = LiteralInput('foo', 'Literal foo', data_type='positiveInteger', keywords=['kw1', 'kw2'], uoms=['metre'])
         doc = literal.describe_xml()
         self.assertEqual(doc.tag, E.Input().tag)
         [identifier_el] = xpath_ns(doc, './ows:Identifier')
         self.assertEqual(identifier_el.text, 'foo')
+        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
+        self.assertEqual(len(kws), 2)
         [type_el] = xpath_ns(doc, './LiteralData/ows:DataType')
         self.assertEqual(type_el.text, 'positiveInteger')
         self.assertEqual(type_el.attrib['{%s}reference' % NAMESPACES['ows']],
@@ -218,11 +220,13 @@ class InputDescriptionTest(unittest.TestCase):
         self.assertEqual(len(ranges), 3)
 
     def test_complex_input_identifier(self):
-        complex_in = ComplexInput('foo', 'Complex foo', supported_formats=[Format('bar/baz')])
+        complex_in = ComplexInput('foo', 'Complex foo', keywords=['kw1', 'kw2'], supported_formats=[Format('bar/baz')])
         doc = complex_in.describe_xml()
         self.assertEqual(doc.tag, E.Input().tag)
         [identifier_el] = xpath_ns(doc, './ows:Identifier')
         self.assertEqual(identifier_el.text, 'foo')
+        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
+        self.assertEqual(len(kws), 2)
 
     def test_complex_input_default_and_supported(self):
         complex_in = ComplexInput(
@@ -244,7 +248,7 @@ class InputDescriptionTest(unittest.TestCase):
         self.assertEqual(supported_mime_types, ['a/b', 'c/d'])
 
     def test_bbox_input(self):
-        bbox = BoundingBoxInput('bbox', 'BBox foo',
+        bbox = BoundingBoxInput('bbox', 'BBox foo', keywords=['kw1', 'kw2'],
                                 crss=["EPSG:4326", "EPSG:3035"])
         doc = bbox.describe_xml()
         [inpt] = xpath_ns(doc, '/Input')
@@ -253,15 +257,19 @@ class InputDescriptionTest(unittest.TestCase):
         self.assertEqual(inpt.attrib['minOccurs'], '1')
         self.assertEqual(default_crs.text, 'EPSG:4326')
         self.assertEqual(len(supported), 2)
-
+        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
+        self.assertEqual(len(kws), 2)
 
 class OutputDescriptionTest(unittest.TestCase):
 
     def test_literal_output(self):
-        literal = LiteralOutput('literal', 'Literal foo', uoms=['metre'])
+        literal = LiteralOutput('literal', 'Literal foo', abstract='Description', keywords=['kw1', 'kw2'], uoms=['metre'])
         doc = literal.describe_xml()
         [output] = xpath_ns(doc, '/Output')
         [identifier] = xpath_ns(doc, '/Output/ows:Identifier')
+        [abstract] = xpath_ns(doc, '/Output/ows:Abstract')
+        [keywords] = xpath_ns(doc, '/Output/ows:Keywords')
+        kws = xpath_ns(keywords, './ows:Keyword')
         [data_type] = xpath_ns(doc, '/Output/LiteralOutput/ows:DataType')
         [uoms] = xpath_ns(doc, '/Output/LiteralOutput/UOMs')
         [default_uom] = xpath_ns(uoms, './Default/ows:UOM')
@@ -269,6 +277,9 @@ class OutputDescriptionTest(unittest.TestCase):
 
         assert output is not None
         assert identifier.text == 'literal'
+        assert abstract.text == 'Description'
+        assert keywords is not None
+        assert len(kws) == 2
         assert data_type.attrib['{%s}reference' % NAMESPACES['ows']] == OGCTYPE['string']
         assert uoms is not None
         assert default_uom.text == 'metre'
@@ -276,7 +287,7 @@ class OutputDescriptionTest(unittest.TestCase):
         assert len(supported_uoms) == 1
 
     def test_complex_output(self):
-        complexo = ComplexOutput('complex', 'Complex foo', [Format('GML')])
+        complexo = ComplexOutput('complex', 'Complex foo', [Format('GML')], keywords=['kw1', 'kw2'])
         doc = complexo.describe_xml()
         [outpt] = xpath_ns(doc, '/Output')
         [default] = xpath_ns(doc, '/Output/ComplexOutput/Default/Format/MimeType')
@@ -285,9 +296,13 @@ class OutputDescriptionTest(unittest.TestCase):
 
         assert default.text == 'application/gml+xml'
         assert len(supported) == 1
+        [keywords] = xpath_ns(doc, '/Output/ows:Keywords')
+        kws = xpath_ns(keywords, './ows:Keyword')
+        assert keywords is not None
+        assert len(kws) == 2
 
     def test_bbox_output(self):
-        bbox = BoundingBoxOutput('bbox', 'BBox foo',
+        bbox = BoundingBoxOutput('bbox', 'BBox foo', keywords=['kw1', 'kw2'],
                                  crss=["EPSG:4326"])
         doc = bbox.describe_xml()
         [outpt] = xpath_ns(doc, '/Output')
@@ -295,6 +310,10 @@ class OutputDescriptionTest(unittest.TestCase):
         supported = xpath_ns(doc, './BoundingBoxOutput/Supported/CRS')
         assert default_crs.text == 'EPSG:4326'
         assert len(supported) == 1
+        [keywords] = xpath_ns(doc, '/Output/ows:Keywords')
+        kws = xpath_ns(keywords, './ows:Keyword')
+        assert keywords is not None
+        assert len(kws) == 2
 
 
 def load_tests(loader=None, tests=None, pattern=None):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -156,6 +156,7 @@ class ComplexInputTest(unittest.TestCase):
         self.complex_in = ComplexInput(identifier="complexinput",
                                        title='MyComplex',
                                        abstract='My complex input',
+                                       keywords=['kw1', 'kw2'],
                                        workdir=self.tmp_dir,
                                        supported_formats=[data_format])
 
@@ -187,6 +188,7 @@ class ComplexInputTest(unittest.TestCase):
         self.assertEqual(len(out['supported_formats']), 1, 'There is one formats')
         self.assertEqual(out['title'], 'MyComplex', 'Title not set but existing')
         self.assertEqual(out['abstract'], 'My complex input', 'Abstract not set but existing')
+        self.assertEqual(out['keywords'], ['kw1', 'kw2'], 'Keywords not set but existing')
         self.assertEqual(out['identifier'], 'complexinput', 'identifier set')
         self.assertEqual(out['type'], 'complex', 'it is complex input')
         self.assertTrue(out['data_format'], 'data_format set')
@@ -282,6 +284,7 @@ class LiteralInputTest(unittest.TestCase):
         self.assertFalse(out['workdir'], 'Workdir exist')
         self.assertEqual(out['data_type'], 'integer', 'Data type is integer')
         self.assertFalse(out['abstract'], 'abstract exist')
+        self.assertFalse(out['keywords'], 'keywords exist')
         self.assertFalse(out['title'], 'title exist')
         self.assertEqual(out['data'], 9, 'data set')
         self.assertEqual(out['mode'], MODE.STRICT, 'Mode set')


### PR DESCRIPTION
# Overview
Add ows:Keyword support to individual processes, inputs and outputs. That is, when instantiating a Process, Inputs or Outputs, a list of keywords can be provided and will be part of the xml description. The intent is to facilitate automated search mechanisms. 

# Related Issue / Discussion
Fix for #293 

# Additional Information
The OGC WPS 2.0 standard: http://docs.opengeospatial.org/is/14-065/14-065.html

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute a feature allowing keyword support to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.

