### PR TITLE
Define the correct mime type of the RawDataOutput

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -174,7 +174,7 @@ class Service(object):
             for outpt in wps_request.outputs:
                 for proc_outpt in process.outputs:
                     if outpt == proc_outpt.identifier:
-                        resp = Response(proc_outpt.data)
+                        resp = Response(proc_outpt.data, mimetype=proc_outpt.data_format.mime_type)
                         resp.call_on_close(process.clean)
                         return resp
 


### PR DESCRIPTION
# Overview

Use the output mimeType when RawDataOutput. Currently RawDataOutput has a given default mimeType.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
