### PR TITLE
Adds an autoprocess Sphinx directive

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,7 +63,7 @@ BoundingBoxData
 Request and response objects
 ----------------------------
 
-.. autodata:: pywps.app.WPSResponse.STATUS
+.. autodata:: pywps.response.status.STATUS
     :annotation:
 
     Process status information
@@ -89,13 +89,13 @@ Request and response objects
       A MultiDict object containing input values sent by the client.
 
 
-.. autoclass:: pywps.app.WPSResponse
+.. autoclass:: pywps.response.WPSResponse
     :members:
 
     .. attribute:: status
 
         Information about currently running process status
-        :class:`pywps.app.WPSResponse.STATUS`
+        :class:`pywps.response.status.STATUS`
 
 Processing
 ----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,9 @@ extensions = ['sphinx.ext.extlinks',
               'sphinx.ext.autodoc',
               'sphinx.ext.todo',
               'sphinx.ext.mathjax',
-              'sphinx.ext.viewcode'
+              'sphinx.ext.viewcode',
+              'sphinx.ext.napoleon',
+              'pywps.ext_autodoc',
             ]
 exclude_patterns = ['_build']
 source_suffix = '.rst'

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -385,8 +385,35 @@ Use the `run` method to start the server::
     ...
 
 To make the server visible from another computer, replace ``localhost`` with ``0.0.0.0``.
-    
+
+
+Automated process documentation
+===============================
+
+WPS :class:`Processes` can be automatically documented with `Sphinx`_ using the
+`autoprocess` directive. The :class:`Process` object is instantiated and its
+content examined to create, behind the scenes, a docstring in the Numpy format. This
+lets developers embed the documentation directly in the code instead of having to
+describe each process in a separate file. For example::
+
+  .. autoprocess:: pywps.tests.DocExampleProcess
+
+would yield
+
+.. autoprocess:: pywps.tests.DocExampleProcess
+
+To use the `autoprocess` directive, first add `'sphinx.ext.napoleon'` and
+`'pywps.ext_autodoc'` to the list of extensions in the Sphinx configuration file
+:file:`conf.py`. Then, insert `autoprocess` directives in your documentation
+source files, just as you would use an `autoclass` directive, and build the
+documentation.
+
+Note that for input and output parameters, the `title` is displayed only if no `abstract`
+is defined. In other words, if both `title` and `abstract` are given, only the `abstract`
+will be included in the documentation to avoid redundancy.
+
+
 .. _Flask: http://flask.pocoo.org
 .. _PyWPS-Flask: http://github.com/geopython/pywps-flask
-
+.. _Sphinx: http://sphinx-doc.org
 

--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from sphinx.ext.autodoc import ClassDocumenter
+from sphinx.ext.napoleon.docstring import NumpyDocstring
+from sphinx.util.docstrings import prepare_docstring
+from sphinx.util import force_decode
+from pywps import Process
+from pywps.app.Common import Metadata
+
+
+class ProcessDocumenter(ClassDocumenter):
+    """Sphinx autodoc ClassDocumenter subclass that understands the
+    pywps.Process class.
+
+    The Process description, its inputs and docputs are converted to a
+    numpy style docstring. Additional sections (Notes, References,
+    Examples, etc.) can be added in the Process subclass docstring.
+    """
+    directivetype = 'class'
+    objtype = 'process'
+    priority = ClassDocumenter.priority + 1
+
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        from six import class_types
+        return isinstance(member, class_types) and issubclass(member, Process)
+
+    def fmt_type(self, obj):
+        """Input and output type formatting (type, default and allowed
+        values).
+        """
+        nmax = 10
+
+        doc = ''
+        try:
+            if getattr(obj, 'allowed_values', None):
+                av = ', '.join(["'{}'".format(i.value) for i in obj.allowed_values[:nmax]])
+                if len(obj.allowed_values) > nmax:
+                    av += ', ...'
+
+                doc += "{" + av + "}"
+
+            elif getattr(obj, 'data_type', None):
+                doc += obj.data_type
+
+            elif getattr(obj, 'supported_formats', None):
+                doc += ', '.join([':mimetype:`{}`'.format(f.mime_type) for f in obj.supported_formats])
+
+            elif getattr(obj, 'crss', None):
+                doc += "[" + ', '.join(obj.crss[:nmax])
+                if len(obj.crss) > nmax:
+                    doc += ', ...'
+                doc += "]"
+
+            if getattr(obj, 'min_occurs', None) is not None:
+                if obj.min_occurs == 0:
+                    doc += ', optional'
+                    if getattr(obj, 'default', None):
+                        doc += ', default:{0}'.format(obj.default)
+
+            if getattr(obj, 'uoms', None):
+                doc += ', units:[{}]'.format(', '.join([u.uom for u in obj.uoms]))
+
+        except Exception as e:
+            raise type(e)(e.message + ' in {0} docstring'.format(self.object().identifier))
+        return doc
+
+    def make_numpy_doc(self):
+        """Numpy style docstring where meta data is scraped from the
+        class instance.
+
+        The numpy style is used because it supports multiple outputs.
+        """
+
+        obj = self.object()
+
+        # Description
+        doc = list()
+        doc.append(u":program:`{}` {} (v{})".format(obj.identifier, obj.title, obj.version or '', ))
+        doc.append('')
+        doc.append(obj.abstract)
+        doc.append('')
+
+        # Inputs
+        doc.append('Parameters')
+        doc.append('----------')
+        for i in obj.inputs:
+            doc.append("{} : {}".format(i.identifier, self.fmt_type(i)))
+            doc.append("    {}".format(i.abstract or i.title))
+            if i.metadata:
+                doc[-1] += " ({})".format(', '.join(['`{} <{}>`_'.format(m.title, m.href) for m in i.metadata]))
+        doc.append('')
+
+        # Outputs
+        doc.append("Returns")
+        doc.append("-------")
+        for i in obj.outputs:
+            doc.append("{} : {}".format(i.identifier, self.fmt_type(i)))
+            doc.append("    {}".format(i.abstract or i.title))
+        doc.append('')
+
+        # Metadata
+        hasref = False
+        ref = list()
+        ref.append("References")
+        ref.append("----------")
+        ref.append('')
+        for m in obj.metadata:
+            if isinstance(m, Metadata):
+                title, href = m.title, m.href
+            elif type(m) == dict:
+                title, href = m['title'], m['href']
+            else:
+                title, href = None, None
+            if title and href:
+                ref.append(u" - `{} <{}>`_".format(title, href))
+                hasref = True
+
+        ref.append('')
+
+        if hasref:
+            doc += ref
+
+        return doc
+
+    def get_doc(self, encoding=None, ignore=1):
+        """Overrides ClassDocumenter.get_doc to create the doc scraped from the Process object, then adds additional
+        content from the class docstring.
+        """
+        from six import text_type
+        # Get the class docstring. This is a copy of the ClassDocumenter.get_doc method. Using "super" does weird stuff.
+        docstring = self.get_attr(self.object, '__doc__', None)
+        # make sure we have Unicode docstrings, then sanitize and split
+        # into lines
+        if isinstance(docstring, text_type):
+            docstring = prepare_docstring(docstring, ignore)
+        elif isinstance(docstring, str):  # this will not trigger on Py3
+            docstring = prepare_docstring(force_decode(docstring, encoding), ignore)
+
+        # Create the docstring by scraping info from the Process instance.
+        pdocstrings = self.make_numpy_doc()
+
+        # Add the sections from the class itself.
+        pdocstrings.extend(docstring)
+
+        # Parse using the Numpy docstring format.
+        docstrings = NumpyDocstring(pdocstrings, self.env.config, self.env.app, what='class', obj=self.object,
+                                    options=self.options)
+
+        return [docstrings.lines()]
+
+
+def setup(app):
+    app.add_autodocumenter(ProcessDocumenter)

--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -140,7 +140,8 @@ class ProcessDocumenter(ClassDocumenter):
         pdocstrings = self.make_numpy_doc()
 
         # Add the sections from the class itself.
-        pdocstrings.extend(docstring)
+        if docstring is not None:
+            pdocstrings.extend(docstring)
 
         # Parse using the Numpy docstring format.
         docstrings = NumpyDocstring(pdocstrings, self.env.config, self.env.app, what='class', obj=self.object,

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -8,10 +8,53 @@ import lxml.etree
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 from pywps import __version__, NAMESPACES
+from pywps import Process
+from pywps.inout import LiteralInput, LiteralOutput, ComplexInput, ComplexOutput, BoundingBoxInput, BoundingBoxOutput
+from pywps.inout import Format
+from pywps.app.Common import Metadata
+
 
 import logging
 
 logging.disable(logging.CRITICAL)
+
+class DocExampleProcess(Process):
+    """
+    Notes
+    -----
+
+    This is additional documentation that can be added following the numpy docstring convention.
+    """
+
+    def __init__(self):
+        inputs = [LiteralInput('literal_input', "Literal input title", 'integer', "Literal input value abstract.",
+                                    min_occurs=0, max_occurs=1, uoms=['meters', 'feet'], default=1),
+                  LiteralInput('date_input', 'The title is shown when no abstract is provided.', 'date',
+                               allowed_values=['2000-01-01', '2018-01-01']),
+                  ComplexInput('complex_input', 'Complex input title', [Format('application/json'),Format('application/x-netcdf')],
+                               abstract="Complex input abstract.",),
+                  BoundingBoxInput('bb_input', 'BoundingBox input title', ['EPSG:4326',],
+                                   metadata=[Metadata('EPSG.io', 'http://epsg.io/'),]),
+                  ]
+        outputs = [LiteralOutput('literal_output', 'Literal output title', 'boolean', 'Boolean output abstract.',),
+                   ComplexOutput('complex_output', 'Complex output', [Format('text/plain'),], ),
+                   BoundingBoxOutput('bb_output', 'BoundingBox output title', ['EPSG:4326',])]
+
+        super(DocExampleProcess, self).__init__(
+            self._handler,
+            identifier='doc_example_process_identifier',
+            title="Process title",
+            abstract="Multiline process abstract.",
+            version="4.0",
+            metadata=[Metadata('PyWPS docs', 'http://pywps.org'),
+                      Metadata('NumPy docstring conventions', 'https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt')],
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+    def _handler(self, request, response):
+        pass
+
 
 
 class WpsClient(Client):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ coverage
 flake8
 pylint
 Sphinx
+six


### PR DESCRIPTION
Adds an autoprocess Sphinx directive allowing pywps Processes to be documented automatically.

# Overview

This PR registers a Sphinx directive called autoprocess that allows developers to automate the documentation of pywps processes. To see how this works, simply run `make html` and browse in the built documentation to the bottom of the Processes page. A test process exercising all the possible inputs and outputs is included, as well as instructions on how to use it for third-party packages. 

# Related Issue / Discussion

Currently, pywps developers have to manually write documentation for their processes, while all the information is available within the Process subclasses. 

# Additional Information

- Adds "six" to the dev requirements. Could possibly be removed.
- Requires minor changes to the Sphinx conf.py file. 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
