### PR TITLE
Fix issue #297: output format

### DIFF
--- a/docs/demobuffer.py
+++ b/docs/demobuffer.py
@@ -48,6 +48,7 @@ out_output = ComplexOutput(
 inputs = [inpt_vector, inpt_size]
 outputs = [out_output]
 
+
 class DemoBuffer(Process):
     def __init__(self):
 
@@ -57,12 +58,14 @@ class DemoBuffer(Process):
             version='1.0.0',
             title='Buffer',
             abstract='This process demonstrates, how to create any process in PyWPS environment',
-            metadata=[Metadata('process metadata 1', 'http://example.org/1'), Metadata('process metadata 2', 'http://example.org/2')]
+            metadata=[Metadata('process metadata 1', 'http://example.org/1'),
+                      Metadata('process metadata 2', 'http://example.org/2')]
             inputs=inputs,
             outputs=outputs,
             store_supported=True,
             status_supported=True
         )
+
 
 @staticmethod
 def _handler(request, response):
@@ -85,7 +88,8 @@ def _handler(request, response):
 
     # create output file
     driver = ogr.GetDriverByName('GML')
-    output_source = driver.CreateDataSource(layer_name,
+    output_source = driver.CreateDataSource(
+        layer_name,
         ["XSISCHEMAURI=http://schemas.opengis.net/gml/2.1.2/feature.xsd"])
     output_layer = output_source.CreateLayer(layer_name, None, ogr.wkbUnknown)
 
@@ -96,16 +100,14 @@ def _handler(request, response):
     # make buffer for each feature
     while index < count:
 
-        response.update_status('Buffering feature %s' % index, float(index)/count)
+        response.update_status('Buffering feature %s' % index, float(index) / count)
 
         # get the geometry
         input_feature = input_layer.GetNextFeature()
         input_geometry = input_feature.GetGeometryRef()
 
         # make the buffer
-        buffer_geometry = input_geometry.Buffer(
-                float(size)
-        )
+        buffer_geometry = input_geometry.Buffer(float(size))
 
         # create output feature to the file
         output_feature = ogr.Feature(feature_def=output_layer.GetLayerDefn())
@@ -115,7 +117,7 @@ def _handler(request, response):
         index += 1
 
     # set output format
-    response.outputs['output'].output_format = FORMATS.GML
+    response.outputs['output'].data_format = FORMATS.GML
 
     # set output data as file name
     response.outputs['output'].file = layer_name

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -114,7 +114,7 @@ class FileStorage(StorageAbstract):
         # build output name
         (prefix, suffix) = os.path.splitext(file_name)
         if not suffix:
-            suffix = output.output_format.extension
+            suffix = output.data_format.extension
         (file_dir, file_name) = os.path.split(prefix)
         output_name = file_name + suffix
         # build tempfile in case of duplicates

--- a/tests/test_ows.py
+++ b/tests/test_ows.py
@@ -19,8 +19,8 @@ from pywps import WPS, OWS
 from pywps.wpsserver import temp_dir
 from pywps.tests import client_for, assert_response_success
 
-wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'
-wcsResource = 'http://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'
+wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'  # noqa
+wcsResource = 'http://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'  # noqa
 
 
 def create_feature():
@@ -28,7 +28,7 @@ def create_feature():
     def feature(request, response):
         input = request.inputs['input'][0].file
         # What do we need to assert a Complex input?
-        #assert type(input) is text_type
+        # assert type(input) is text_type
 
         # open the input file
         try:
@@ -58,7 +58,7 @@ def create_feature():
         outLayer.CreateFeature(outFeature)
         outFeature.Destroy()
 
-        response.outputs['output'].output_format = Format(**FORMATS.GML._asdict())
+        response.outputs['output'].data_format = FORMATS.GML
         response.outputs['output'].file = outPath
         return response
 
@@ -67,14 +67,14 @@ def create_feature():
                    title='Process Feature',
                    inputs=[ComplexInput('input', 'Input', supported_formats=[get_format('GML')])],
                    outputs=[ComplexOutput('output', 'Output', supported_formats=[get_format('GML')])])
-    
-    
+
+
 def create_sum_one():
-    
+
     def sum_one(request, response):
         input = request.inputs['input']
         # What do we need to assert a Complex input?
-        #assert type(input) is text_type
+        # assert type(input) is text_type
 
         sys.path.append("/usr/lib/grass64/etc/python/")
         import grass.script as grass
@@ -135,7 +135,7 @@ class ExecuteTests(unittest.TestCase):
         try:
             sys.path.append("/usr/lib/grass64/etc/python/")
             import grass.script as grass
-        except:
+        except Exception:
             self.skipTest('GRASS lib not found')
         client = client_for(Service(processes=[create_sum_one()]))
         request_doc = WPS.Execute(


### PR DESCRIPTION
# Overview

The method to set the output format of an output parameter has changed from `output_format` to `data_format`. But these changes weren't made consistently . This patch fixes the following:

* `output_format` was still used in the `storage` module:
https://github.com/geopython/pywps/blob/3f2e6c63e6cf9d9cd0ad6e690271259205e57ae6/pywps/inout/storage.py#L117

... also in `test_ows.py`.

* In addition the pre-defined `FORMATS` for mime-types were defined as `namedtuple` but within the pywps code it is always assumed that these Formats are `Format` objects (to set and use a validator). This has been fixed by this patch as well.

* It handles also the case when the `extension` attribute of a `Format` object is `None` ... an empty string will be returned then, like for `schema` etc, to avoid exceptions on string concatenation.

* pep8 formatting in the changed files.

# Related Issue / Discussion

#297 

# Additional Information

The `FORMATS` definition works after applying this patch but I suppose we should refactor it later on.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
