### PR TITLE
ResponseDocument: read attributes mimetype, encoding, schema and uom

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -510,6 +510,10 @@ def get_output_from_xml(doc):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
             outpt = {}
             outpt[identifier_el.text] = ''
+            outpt['mimetype'] = output_el.attrib.get('mimeType', '')
+            outpt['encoding'] = output_el.attrib.get('encoding', '')
+            outpt['schema'] = output_el.attrib.get('schema', '')
+            outpt['uom'] = output_el.attrib.get('uom', '')
             outpt['asReference'] = output_el.attrib.get('asReference', 'false')
             the_output[identifier_el.text] = outpt
 


### PR DESCRIPTION
This patch update the function that parse request to read possible
attribute of /wps:Execute/wps:ResponseForm/wps:ResponseDocument/wps:Output
comming from the request. Those attributes are usefull to generate the
appropiate WPS output.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
