### PR TITLE
Fix bug where status and status_percentage may be 0

### DIFF
--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -42,10 +42,10 @@ class WPSResponse(object):
         if message:
             self.message = message
 
-        if status:
+        if status is not None:
             self.status = status
 
-        if status_percentage:
+        if status_percentage is not None:
             self.status_percentage = status_percentage
 
         update_response(self.uuid, self)

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -52,10 +52,10 @@ class ExecuteResponse(WPSResponse):
         if message:
             self.message = message
 
-        if status:
+        if status is not None:
             self.status = status
 
-        if status_percentage:
+        if status_percentage is not None:
             self.status_percentage = status_percentage
 
         # check if storing of the status is requested


### PR DESCRIPTION
# Overview

Fix bug where status and status_percentage may be 0. STATUS.ERROR_STATUS is 0, making update_status fail to update the response status when changing to the error status.

# Related Issue / Discussion

None

# Additional Information

None

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
