### PR TITLE
Adds docstring and skiplines options to ext_autodoc

### DIFF
--- a/docs/demobuffer.py
+++ b/docs/demobuffer.py
@@ -59,7 +59,7 @@ class DemoBuffer(Process):
             title='Buffer',
             abstract='This process demonstrates, how to create any process in PyWPS environment',
             metadata=[Metadata('process metadata 1', 'http://example.org/1'),
-                      Metadata('process metadata 2', 'http://example.org/2')]
+                      Metadata('process metadata 2', 'http://example.org/2')],
             inputs=inputs,
             outputs=outputs,
             store_supported=True,

--- a/docs/external-tools.rst
+++ b/docs/external-tools.rst
@@ -47,7 +47,7 @@ ZOO-Project
 client (JavaScript) framework.
 
 QGIS WPS Client
---------------
+---------------
 
 The `QGIS WPS <https://plugins.qgis.org/plugins/wps/>`_ client provides a
 plugin with WPS support for the QGIS Desktop GIS.

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -405,7 +405,7 @@ would yield
    :docstring:
    :skiplines: 1
 
-The :option:`docstring` fetches the :class:`Process` docstring and appends it after the
+The :option:`docstring` option fetches the :class:`Process` docstring and appends it after the
 Reference section. The first lines of this docstring can be skipped using the
 :option:`skiplines` option.
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -389,17 +389,25 @@ To make the server visible from another computer, replace ``localhost`` with ``0
 Automated process documentation
 ===============================
 
-WPS :class:`Processes` can be automatically documented with `Sphinx`_ using the
+A :class:`Process` can be automatically documented with `Sphinx`_ using the
 `autoprocess` directive. The :class:`Process` object is instantiated and its
 content examined to create, behind the scenes, a docstring in the Numpy format. This
 lets developers embed the documentation directly in the code instead of having to
-describe each process in a separate file. For example::
+describe each process manually. For example::
 
   .. autoprocess:: pywps.tests.DocExampleProcess
+     :docstring:
+     :skiplines: 1
 
 would yield
 
 .. autoprocess:: pywps.tests.DocExampleProcess
+   :docstring:
+   :skiplines: 1
+
+The :option:`docstring` fetches the :class:`Process` docstring and appends it after the
+Reference section. The first lines of this docstring can be skipped using the
+:option:`skiplines` option.
 
 To use the `autoprocess` directive, first add `'sphinx.ext.napoleon'` and
 `'pywps.ext_autodoc'` to the list of extensions in the Sphinx configuration file

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -19,11 +19,12 @@ import logging
 logging.disable(logging.CRITICAL)
 
 class DocExampleProcess(Process):
-    """
+    """This first line is going to be skipped by the :skiplines:1 option.
+
     Notes
     -----
 
-    This is additional documentation that can be added following the numpy docstring convention.
+    This is additional documentation that can be added following the Numpy docstring convention.
     """
 
     def __init__(self):


### PR DESCRIPTION
# Overview
The current pywps autodoc extension automatically appends the class docstring to the documentation. This might not always be the desired behavior. This PR provides two directive options to control this behavior: 
1. :docstring: boolean that if present in the autoprocess directive will trigger the inclusion of the class docstring. 
2. :skiplines: integer that specifies the number of lines from this docstring to be skipped. 

It also fixes an issue occurring when appending a class docstring to a process with no metadata, resulting in the first line of the class docstring being interpreted as an output value. 

# Related Issue / Discussion
Pull request #313 

# Additional Information
Also fixes minor typos affecting the documentation build. 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute ext_autodoc options to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
