### PR TITLE
Fix #327: install gdal=2 from ubuntugis repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,18 @@ dist: trusty
 
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 
 git:
   submodules: false
 
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ppa'
     packages:
       - gdal-bin
       - libgdal-dev
-      - libgdal1h
-      - libgdal1-dev
-      - libgeos-dev
-      - devscripts
-      - debhelper
-      - python-setuptools
 
 # Handle Git submodules yourself
 git:
@@ -28,7 +24,7 @@ git:
 
 install:
   - pip install pip --upgrade
-  - pip install .
+  - pip install -r requirements.txt
   - pip install -r requirements-gdal.txt
   - pip install -r requirements-dev.txt
   - pip install coveralls
@@ -43,11 +39,11 @@ after_success:
   - debuild -b -uc -us
 
 # whitelist
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
 
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#geopython"
+# notifications:
+#  irc:
+#    channels:
+#      - "irc.freenode.org#geopython"


### PR DESCRIPTION
# Overview
This PR fixes #327.

Travis test suite was failing because `gdal=2.x` was not available. 

Changes:
* install gdal=2.1 from ubuntu repository `ubuntugis`.
* removed unused dependencies from `apt-get` installation.
* run tests on Python 3.6 (before 3.5).
* disabled irc notifications (should configure it when test-suite is working again).
* disabled branch filter, was **master** only (can be configured later again).

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
