### PR TITLE
Fix #329: fix test-suite ... pep8 ... test failures

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -631,7 +631,7 @@ def _get_rawvalue_value(data, encoding=None):
         elif encoding == 'base64':
             return base64.b64decode(data)
         return base64.b64decode(data)
-    except:
+    except Exception:
         return data
 
 

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -199,7 +199,7 @@ def convert_boolean(inpt):
                 val = False
             else:
                 val = True
-        except:
+        except Exception:
             val = True
     return val
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -238,7 +238,7 @@ class ComplexOutput(basic.ComplexOutput):
             try:
                 data_doc = etree.parse(self.file)
                 complex_doc.append(data_doc.getroot())
-            except:
+            except Exception:
 
                 if isinstance(self.data, six.string_types):
                     complex_doc.text = self.data

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -114,6 +114,14 @@ def assert_response_success(resp):
     assert len(success) == 1
 
 
+def assert_process_exception(resp, code=None):
+    assert resp.status_code == 400
+    assert resp.headers['Content-Type'] == 'text/xml'
+    elem = resp.xpath('/ows:ExceptionReport'
+                      '/ows:Exception')
+    assert elem[0].attrib['exceptionCode'] == code
+
+
 def assert_pywps_version(resp):
     # get first child of root element
     root_firstchild = resp.xpath('/*')[0].getprevious()

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -19,6 +19,7 @@ from pywps.exceptions import InvalidParameterValue
 from pywps.exceptions import MissingParameterValue
 
 from pywps.tests import assert_pywps_version, client_for
+from pywps.tests import assert_process_exception
 
 ProcessDescription = namedtuple('ProcessDescription', ['identifier', 'inputs', 'metadata'])
 
@@ -90,14 +91,15 @@ class DescribeProcessTest(unittest.TestCase):
         assert 'hello metadata' in [item for sublist in metadata for item in sublist]
 
     def test_get_request_zero_args(self):
-        with self.assertRaises(MissingParameterValue) as e:
-            resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps')
-            assert resp.status_code == 400  # bad request, identifier is missing
+        # with self.assertRaises(MissingParameterValue) as e:
+        resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps')
+        # bad request, identifier is missing
+        assert_process_exception(resp, code='MissingParameterValue')
 
     def test_get_request_nonexisting_process_args(self):
-        with self.assertRaises(InvalidParameterValue) as e:
-            resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps&identifier=NONEXISTINGPROCESS')
-            assert resp.status_code == 400
+        resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps&identifier=NONEXISTINGPROCESS')
+        # bad request, identifier does not exist
+        assert_process_exception(resp, code='InvalidParameterValue')
 
     def test_post_request_zero_args(self):
         request_doc = WPS.DescribeProcess()

--- a/tests/test_wpsrequest.py
+++ b/tests/test_wpsrequest.py
@@ -29,7 +29,8 @@ class WPSRequestTest(unittest.TestCase):
             'operation': 'getcapabilities',
             'version': '1.0.0',
             'language': 'eng',
-            'identifiers': 'ahoj',
+            'identifier': 'ahoj',
+            'identifiers': 'ahoj',  # TODO: why identifierS?
             'store_execute': True,
             'status': True,
             'lineage': True,
@@ -68,7 +69,8 @@ class WPSRequestTest(unittest.TestCase):
             'operation': 'getcapabilities',
             'version': '1.0.0',
             'language': 'eng',
-            'identifiers': 'moinmoin',
+            'identifier': 'moinmoin',
+            'identifiers': 'moinmoin',  # TODO: why identifierS?
             'store_execute': True,
             'status': True,
             'lineage': True,


### PR DESCRIPTION
# Overview

This PR fixes #329.

Changes:
* pep8 fixes.
* fixed WPSRequest tests.
* fixed DescribeProcess tests.
* using `assert_process_exception()` test helper.


# Related Issue / Discussion

See #327.

# Additional Information

We need to check if `WPSRequests.identifiers` is still used:
https://github.com/geopython/pywps/blob/34b06f4355cce6eed7d057d17c76b001b4daf0c0/pywps/app/WPSRequest.py#L40

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
