### PR TITLE
Disabled connection pooling to make pywps fork()/clone() safe

### DIFF
--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -21,6 +21,7 @@ import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, VARCHAR, Float, DateTime, LargeBinary
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 
 LOGGER = logging.getLogger('PYWPS')
 _SESSION_MAKER = None
@@ -183,7 +184,7 @@ def get_session():
         if database.startswith("sqlite") or database.startswith("memory"):
             engine = sqlalchemy.create_engine(database, connect_args={'check_same_thread': False}, echo=echo)
         else:
-            engine = sqlalchemy.create_engine(database, echo=echo)
+            engine = sqlalchemy.create_engine(database, echo=echo, poolclass=NullPool)
     except sqlalchemy.exc.SQLAlchemyError as e:
         raise NoApplicableCode("Could not connect to database: {}".format(e.message))
 


### PR DESCRIPTION
# Overview

The following commit solves random errors when using pywps with postgresql+psycopg2 as database backend for the dblog module, along with the multiprocessing processing mode. The default SQLAlchemy creates a connection pool by default, and must not be shared with child processes.

Disabling pooling fixes errors occurring randomly such as:
> ResourceClosedError: This result object does not return rows. It has been closed automatically.

> (psycopg2.DatabaseError) error with status PGRES_TUPLES_OK and no message from the libpq 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute bugfix to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
