### PR TITLE
Introduction of WPS 2.0.0 templates and tests

### DIFF
--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -18,15 +18,37 @@ PYWPS_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 
 NAMESPACES = {
     'xlink': "http://www.w3.org/1999/xlink",
-    'wps': "http://www.opengis.net/wps/1.0.0",
-    'ows': "http://www.opengis.net/ows/1.1",
+    'wps': "http://www.opengis.net/wps/{wps_version}",
+    'ows': "http://www.opengis.net/ows/{ows_version}",
     'gml': "http://www.opengis.net/gml",
     'xsi': "http://www.w3.org/2001/XMLSchema-instance"
 }
 
 E = ElementMaker()
-WPS = ElementMaker(namespace=NAMESPACES['wps'], nsmap=NAMESPACES)
-OWS = ElementMaker(namespace=NAMESPACES['ows'], nsmap=NAMESPACES)
+namespaces100 = {k: NAMESPACES[k].format(wps_version="1.0.0", ows_version="1.1") for k in NAMESPACES}
+namespaces200 = {k: NAMESPACES[k].format(wps_version="2.0", ows_version="2.0") for k in NAMESPACES}
+
+
+def get_ElementMakerForVersion(version):
+    WPS = OWS = None
+    if version == "1.0.0":
+        WPS = ElementMaker(namespace=namespaces100['wps'], nsmap=namespaces100)
+        OWS = ElementMaker(namespace=namespaces100['ows'], nsmap=namespaces100)
+    elif version == "2.0.0":
+        WPS = ElementMaker(namespace=namespaces200['wps'], nsmap=namespaces200)
+        OWS = ElementMaker(namespace=namespaces200['ows'], nsmap=namespaces200)
+
+    return WPS, OWS
+
+
+def get_version_from_ns(ns):
+    if ns == "http://www.opengis.net/wps/1.0.0":
+        return "1.0.0"
+    elif ns == "http://www.opengis.net/wps/2.0":
+        return "2.0.0"
+    else:
+        return None
+
 
 OGCTYPE = {
     'measure': 'urn:ogc:def:dataType:OGC:1.1:measure',

--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -25,9 +25,11 @@ class Metadata(object):
         self.type = type_
 
     def __iter__(self):
-        yield '{http://www.w3.org/1999/xlink}title', self.title
+        metadata = {"title": self.title}
+
         if self.href is not None:
-            yield '{http://www.w3.org/1999/xlink}href', self.href
+            metadata['href'] = self.href
         if self.role is not None:
-            yield '{http://www.w3.org/1999/xlink}role', self.role
-        yield '{http://www.w3.org/1999/xlink}type', self.type
+            metadata['role'] = self.role
+        metadata['type'] = self.type
+        yield metadata

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -7,19 +7,19 @@ import logging
 import lxml
 import lxml.etree
 from werkzeug.exceptions import MethodNotAllowed
+from pywps import get_ElementMakerForVersion
 import base64
 import datetime
-from pywps import WPS
 from pywps._compat import text_type, PY2
-from pywps.app.basic import xpath_ns
+from pywps.app.basic import get_xpath_ns
 from pywps.inout.basic import LiteralInput, ComplexInput, BBoxInput
 from pywps.exceptions import NoApplicableCode, OperationNotSupported, MissingParameterValue, VersionNegotiationFailed, \
     InvalidParameterValue, FileSizeExceeded
 from pywps import configuration
 from pywps.validator.mode import MODE
 from pywps.inout.literaltypes import AnyValue, NoValue, ValuesReference, AllowedValue
-
 from pywps.inout.formats import Format
+from pywps import get_version_from_ns
 
 import json
 
@@ -42,6 +42,9 @@ class WPSRequest(object):
         self.inputs = {}
         self.outputs = {}
         self.raw = None
+        self.WPS = None
+        self.OWS = None
+        self.xpath_ns = None
 
         if self.http_request:
             request_parser = self._get_request_parser_method(http_request.method)
@@ -93,6 +96,8 @@ class WPSRequest(object):
                 raise NoApplicableCode(e.msg)
 
         operation = doc.tag
+        version = get_version_from_ns(doc.nsmap[doc.prefix])
+        self.set_version(version)
         request_parser = self._post_request_parser(operation)
         request_parser(doc)
 
@@ -180,7 +185,7 @@ class WPSRequest(object):
         def parse_post_getcapabilities(doc):
             """Parse POST GetCapabilities request
             """
-            acceptedversions = xpath_ns(
+            acceptedversions = self.xpath_ns(
                 doc, '/wps:GetCapabilities/ows:AcceptVersions/ows:Version')
             acceptedversions = ','.join(
                 map(lambda v: v.text, acceptedversions))
@@ -198,7 +203,7 @@ class WPSRequest(object):
 
             wpsrequest.operation = 'describeprocess'
             wpsrequest.identifiers = [identifier_el.text for identifier_el in
-                                      xpath_ns(doc, './ows:Identifier')]
+                                      self.xpath_ns(doc, './ows:Identifier')]
 
         def parse_post_execute(doc):
             """Parse POST Execute request
@@ -212,7 +217,7 @@ class WPSRequest(object):
 
             wpsrequest.operation = 'execute'
 
-            identifier = xpath_ns(doc, './ows:Identifier')
+            identifier = self.xpath_ns(doc, './ows:Identifier')
 
             if not identifier:
                 raise MissingParameterValue(
@@ -225,13 +230,13 @@ class WPSRequest(object):
             wpsrequest.inputs = get_inputs_from_xml(doc)
             wpsrequest.outputs = get_output_from_xml(doc)
             wpsrequest.raw = False
-            if xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:RawDataOutput'):
+            if self.xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:RawDataOutput'):
                 wpsrequest.raw = True
                 # executeResponse XML will not be stored
                 wpsrequest.store_execute = 'false'
 
             # check if response document tag has been set then retrieve
-            response_document = xpath_ns(
+            response_document = self.xpath_ns(
                 doc, './wps:ResponseForm/wps:ResponseDocument')
             if len(response_document) > 0:
                 wpsrequest.lineage = response_document[
@@ -241,18 +246,23 @@ class WPSRequest(object):
                 wpsrequest.status = response_document[
                     0].attrib.get('status', 'false')
 
-        if tagname == WPS.GetCapabilities().tag:
+        if tagname == self.WPS.GetCapabilities().tag:
             self.operation = 'getcapabilities'
             return parse_post_getcapabilities
-        elif tagname == WPS.DescribeProcess().tag:
+        elif tagname == self.WPS.DescribeProcess().tag:
             self.operation = 'describeprocess'
             return parse_post_describeprocess
-        elif tagname == WPS.Execute().tag:
+        elif tagname == self.WPS.Execute().tag:
             self.operation = 'execute'
             return parse_post_execute
         else:
             raise InvalidParameterValue(
                 'Unknown request %r' % tagname, 'request')
+
+    def set_version(self, version):
+        self.version = version
+        self.xpath_ns = get_xpath_ns(version)
+        self.WPS, self.OWS = get_ElementMakerForVersion(self.version)
 
     def check_accepted_versions(self, acceptedversions):
         """
@@ -285,7 +295,7 @@ class WPSRequest(object):
             raise VersionNegotiationFailed(
                 'The requested version "%s" is not supported by this server' % version, 'version')
         else:
-            self.version = version
+            self.set_version(version)
 
     def check_and_set_language(self, language):
         """set this.language
@@ -429,6 +439,8 @@ class WPSRequest(object):
 
 def get_inputs_from_xml(doc):
     the_inputs = {}
+    version = get_version_from_ns(doc.nsmap[doc.prefix])
+    xpath_ns = get_xpath_ns(version)
     for input_el in xpath_ns(doc, '/wps:Execute/wps:DataInputs/wps:Input'):
         [identifier_el] = xpath_ns(input_el, './ows:Identifier')
         identifier = identifier_el.text
@@ -506,6 +518,9 @@ def get_inputs_from_xml(doc):
 def get_output_from_xml(doc):
     the_output = {}
 
+    version = get_version_from_ns(doc.nsmap[doc.prefix])
+    xpath_ns = get_xpath_ns(version)
+
     if xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:ResponseDocument'):
         for output_el in xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:ResponseDocument/wps:Output'):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
@@ -579,7 +594,7 @@ def get_data_from_kvp(data, part=None):
 def _check_version(version):
     """ check given version
     """
-    if version != '1.0.0':
+    if version not in ['1.0.0', '2.0.0']:
         return False
     else:
         return True

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -2,26 +2,39 @@
 # Copyright 2018 Open Source Geospatial Foundation and others    #
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
+"""
+XML tools
+"""
 
 import logging
-import lxml
 from werkzeug.wrappers import Response
-from pywps import __version__, NAMESPACES
+from pywps import __version__
 
 LOGGER = logging.getLogger('PYWPS')
 
 
-def xpath_ns(el, path):
-    return el.xpath(path, namespaces=NAMESPACES)
+def get_xpath_ns(version):
+    """Get xpath namespace for specified WPS version
+    currently 1.0.0 or 2.0.0 are supported
+    """
+
+    def xpath_ns(ele, path):
+        """Function, which will return xpath namespace for given
+        element and xpath
+        """
+        if version == "1.0.0":
+            from pywps import namespaces100
+            nsp = namespaces100
+        elif version == "2.0.0":
+            from pywps import namespaces200
+            nsp = namespaces200
+        return ele.xpath(path, namespaces=nsp)
+
+    return xpath_ns
 
 
 def xml_response(doc):
     """XML response serializer"""
-
-    LOGGER.debug('Serializing XML response')
-    pywps_version_comment = '<!-- PyWPS %s -->\n' % __version__
-    xml = lxml.etree.tostring(doc, pretty_print=True)
-    response = Response(pywps_version_comment.encode('utf8') + xml,
-                        content_type='text/xml')
+    response = Response(doc, content_type='text/xml')
     response.status_percentage = 100
     return response

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -137,7 +137,7 @@ def update_response(uuid, response, close=False):
     if requests.count():
         request = requests.one()
         request.time_end = datetime.datetime.now()
-        request.message = message
+        request.message = str(message)
         request.percent_done = status_percentage
         request.status = status
         session.commit()

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -11,7 +11,6 @@
 # based on Web Processing Service Best Practices Discussion Paper, OGC 12-029
 # http://opengeospatial.org/standards/wps
 
-from lxml.builder import ElementMaker
 from collections import namedtuple
 import mimetypes
 from pywps.validator.mode import MODE
@@ -134,23 +133,6 @@ class Format(object):
         return all([frmt.mime_type == self.mime_type,
                     frmt.encoding == self.encoding,
                     frmt.schema == self.schema])
-
-    def describe_xml(self):
-        """Return describe process response element
-        """
-
-        elmar = ElementMaker()
-        doc = elmar.Format(
-            elmar.MimeType(self.mime_type)
-        )
-
-        if self.encoding:
-            doc.append(elmar.Encoding(self.encoding))
-
-        if self.schema:
-            doc.append(elmar.Schema(self.schema))
-
-        return doc
 
     @property
     def json(self):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -3,7 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-from pywps import configuration, E, OWS, WPS, OGCTYPE, NAMESPACES
+from pywps import configuration
 from pywps.inout import basic
 from copy import deepcopy
 from pywps.validator.mode import MODE
@@ -33,92 +33,14 @@ class BoundingBoxInput(basic.BBoxInput):
                  mode=MODE.NONE,
                  default=None, default_type=basic.SOURCE_TYPE.DATA):
 
-        basic.BBoxInput.__init__(self, identifier, title=title,
-                                 abstract=abstract, keywords=keywords, crss=crss,
-                                 dimensions=dimensions, mode=mode,
-                                 default=default, default_type=default_type)
+        basic.BBoxInput.__init__(self, identifier, title=title, crss=crss,
+                                 abstract=abstract, keywords=keywords,
+                                 dimensions=dimensions, metadata=metadata,
+                                 min_occurs=min_occurs, max_occurs=max_occurs,
+                                 mode=mode, default=default,
+                                 default_type=default_type)
 
-        self.metadata = metadata
-        self.min_occurs = int(min_occurs)
-        self.max_occurs = int(max_occurs)
         self.as_reference = False
-
-    def describe_xml(self):
-        """
-        :return: describeprocess response xml element
-        """
-        doc = E.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        doc.attrib['minOccurs'] = str(self.min_occurs)
-        doc.attrib['maxOccurs'] = str(self.max_occurs)
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        for m in self.metadata:
-            doc.append(OWS.Metadata(dict(m)))
-
-        bbox_data_doc = E.BoundingBoxData()
-        doc.append(bbox_data_doc)
-
-        default_doc = E.Default()
-        default_doc.append(E.CRS(self.crss[0]))
-
-        supported_doc = E.Supported()
-        for c in self.crss:
-            supported_doc.append(E.CRS(c))
-
-        bbox_data_doc.append(default_doc)
-        bbox_data_doc.append(supported_doc)
-
-        return doc
-
-    def execute_xml(self):
-        """
-        :return: execute response element
-        """
-        node = self._execute_xml_data()
-
-        doc = WPS.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        doc.append(node)
-
-        return doc
-
-    def _execute_xml_data(self):
-        """Return Data node
-        """
-        doc = WPS.Data()
-        bbox_data_doc = WPS.BoundingBoxData()
-
-        if self.crs:
-            bbox_data_doc.attrib['crs'] = self.crs
-        if self.dimensions:
-            bbox_data_doc.attrib['dimensions'] = str(self.dimensions)
-
-        bbox_data_doc.append(
-            OWS.LowerCorner('{0[0]} {0[1]}'.format(self.data)))
-        bbox_data_doc.append(
-            OWS.UpperCorner('{0[2]} {0[3]}'.format(self.data)))
-        doc.append(bbox_data_doc)
-        return doc
 
     def clone(self):
         """Create copy of yourself
@@ -149,15 +71,14 @@ class ComplexInput(basic.ComplexInput):
                  default=None, default_type=basic.SOURCE_TYPE.DATA):
         """constructor"""
 
-        basic.ComplexInput.__init__(self, identifier=identifier, title=title,
-                                    abstract=abstract, keywords=keywords,
+        basic.ComplexInput.__init__(self, identifier, title=title,
                                     supported_formats=supported_formats,
-                                    mode=mode,
+                                    data_format=data_format, abstract=abstract,
+                                    keywords=keywords, metadata=metadata,
+                                    min_occurs=min_occurs,
+                                    max_occurs=max_occurs, mode=mode,
                                     default=default, default_type=default_type)
 
-        self.metadata = metadata
-        self.min_occurs = int(min_occurs)
-        self.max_occurs = int(max_occurs)
         self.as_reference = False
         self.url = ''
         self.method = ''
@@ -172,101 +93,6 @@ class ComplexInput(basic.ComplexInput):
         max_size = configuration.get_config_value(
             'server', 'maxsingleinputsize')
         self.max_size = configuration.get_size_mb(max_size)
-
-    def describe_xml(self):
-        """Return Describe process element
-        """
-        default_format_el = self.supported_formats[0].describe_xml()
-        supported_format_elements = [f.describe_xml()
-                                     for f in self.supported_formats]
-
-        doc = E.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        doc.attrib['minOccurs'] = str(self.min_occurs)
-        doc.attrib['maxOccurs'] = str(self.max_occurs)
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        for m in self.metadata:
-            doc.append(OWS.Metadata(dict(m)))
-
-        doc.append(
-            E.ComplexData(
-                E.Default(default_format_el),
-                E.Supported(*supported_format_elements)
-            )
-        )
-
-        return doc
-
-    def execute_xml(self):
-        """Render Execute response XML node
-
-
-        :return: node
-        :rtype: ElementMaker
-        """
-        node = None
-        if self.as_reference:
-            node = self._execute_xml_reference()
-        else:
-            node = self._execute_xml_data()
-
-        doc = WPS.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        doc.append(node)
-
-        return doc
-
-    def _execute_xml_reference(self):
-        """Return Reference node
-        """
-        doc = WPS.Reference()
-        doc.attrib['{http://www.w3.org/1999/xlink}href'] = self.url
-        if self.data_format:
-            if self.data_format.mime_type:
-                doc.attrib['mimeType'] = self.data_format.mime_type
-            if self.data_format.encoding:
-                doc.attrib['encoding'] = self.data_format.encoding
-            if self.data_format.schema:
-                doc.attrib['schema'] = self.data_format.schema
-        if self.method.upper() == 'POST' or self.method.upper() == 'GET':
-            doc.attrib['method'] = self.method.upper()
-        return doc
-
-    def _execute_xml_data(self):
-        """Return Data node
-        """
-        doc = WPS.Data()
-        complex_doc = WPS.ComplexData(self.data)
-
-        if self.data_format:
-            if self.data_format.mime_type:
-                complex_doc.attrib['mimeType'] = self.data_format.mime_type
-            if self.data_format.encoding:
-                complex_doc.attrib['encoding'] = self.data_format.encoding
-            if self.data_format.schema:
-                complex_doc.attrib['schema'] = self.data_format.schema
-        doc.append(complex_doc)
-        return doc
 
     def clone(self):
         """Create copy of yourself
@@ -300,127 +126,15 @@ class LiteralInput(basic.LiteralInput):
         """Constructor
         """
 
-        basic.LiteralInput.__init__(self, identifier=identifier, title=title,
-                                    abstract=abstract, keywords=keywords, data_type=data_type,
-                                    uoms=uoms, mode=mode,
+        basic.LiteralInput.__init__(self, identifier, title=title,
+                                    data_type=data_type, abstract=abstract,
+                                    keywords=keywords, metadata=metadata,
+                                    uoms=uoms, min_occurs=min_occurs,
+                                    max_occurs=max_occurs, mode=mode,
                                     allowed_values=allowed_values,
                                     default=default, default_type=default_type)
-        self.metadata = metadata
-        self.min_occurs = int(min_occurs)
-        self.max_occurs = int(max_occurs)
+
         self.as_reference = False
-
-    def describe_xml(self):
-        """Return DescribeProcess Output element
-        """
-        doc = E.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        doc.attrib['minOccurs'] = str(self.min_occurs)
-        doc.attrib['maxOccurs'] = str(self.max_occurs)
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        for m in self.metadata:
-            doc.append(OWS.Metadata(dict(m)))
-
-        literal_data_doc = E.LiteralData()
-
-        if self.data_type:
-            data_type = OWS.DataType(self.data_type)
-            data_type.attrib['{%s}reference' %
-                             NAMESPACES['ows']] = OGCTYPE[self.data_type]
-            literal_data_doc.append(data_type)
-
-        if self.uoms:
-            default_uom_element = self.uoms[0].describe_xml()
-            supported_uom_elements = [u.describe_xml() for u in self.uoms]
-
-            literal_data_doc.append(
-                E.UOMs(
-                    E.Default(default_uom_element),
-                    E.Supported(*supported_uom_elements)
-                )
-            )
-
-        doc.append(literal_data_doc)
-
-        # TODO: refer to table 29 and 30
-        if self.any_value:
-            literal_data_doc.append(OWS.AnyValue())
-        else:
-            literal_data_doc.append(self._describe_xml_allowedvalues())
-
-        # TODO: is default value handled correctly here?
-        if self.data:
-            literal_data_doc.append(E.DefaultValue(str(self.data)))
-
-        return doc
-
-    def execute_xml(self):
-        """Render Execute response XML node
-
-        :return: node
-        :rtype: ElementMaker
-        """
-        node = None
-        if self.as_reference:
-            node = self._execute_xml_reference()
-        else:
-            node = self._execute_xml_data()
-
-        doc = WPS.Input(
-            OWS.Identifier(self.identifier),
-            OWS.Title(self.title)
-        )
-
-        if self.abstract:
-            doc.append(OWS.Abstract(self.abstract))
-
-        if self.keywords:
-            kws = map(OWS.Keyword, self.keywords)
-            doc.append(OWS.Keywords(*kws))
-
-        doc.append(node)
-
-        return doc
-
-    def _describe_xml_allowedvalues(self):
-        """Return AllowedValues node
-        """
-        doc = OWS.AllowedValues()
-        for value in self.allowed_values:
-            doc.append(value.describe_xml())
-        return doc
-
-    def _execute_xml_reference(self):
-        """Return Reference node
-        """
-        doc = WPS.Reference()
-        doc.attrib['{http://www.w3.org/1999/xlink}href'] = self.stream
-        if self.method.upper() == 'POST' or self.method.upper() == 'GET':
-            doc.attrib['method'] = self.method.upper()
-        return doc
-
-    def _execute_xml_data(self):
-        """Return Data node
-        """
-        doc = WPS.Data()
-        literal_doc = WPS.LiteralData(str(self.data))
-
-        if self.data_type:
-            literal_doc.attrib['dataType'] = self.data_type
-        if self.uom:
-            literal_doc.attrib['uom'] = self.uom
-        doc.append(literal_doc)
-        return doc
 
     def clone(self):
         """Create copy of yourself

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -14,7 +14,7 @@ from pywps.exceptions import InvalidParameterValue
 from pywps.validator.allowed_value import RANGECLOSURETYPE
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE
 from pywps._compat import PY2
-from pywps import OWS, NAMESPACES
+from pywps import get_ElementMakerForVersion
 
 import logging
 LOGGER = logging.getLogger('PYWPS')
@@ -88,21 +88,6 @@ class AllowedValue(AnyValue):
         self.maxval = maxval
         self.spacing = spacing
         self.range_closure = range_closure
-
-    def describe_xml(self):
-        """Return back Element for DescribeProcess response
-        """
-        doc = None
-        if self.allowed_type == ALLOWEDVALUETYPE.VALUE:
-            doc = OWS.Value(str(self.value))
-        else:
-            doc = OWS.Range()
-            doc.set('{%s}rangeClosure' % NAMESPACES['ows'], self.range_closure)
-            doc.append(OWS.MinimumValue(str(self.minval)))
-            doc.append(OWS.MaximumValue(str(self.maxval)))
-            if self.spacing:
-                doc.append(OWS.Spacing(str(self.spacing)))
-        return doc
 
     @property
     def json(self):

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -91,6 +91,7 @@ class FileStorage(StorageAbstract):
         import uuid
 
         file_name = output.file
+
         request_uuid = output.uuid or uuid.uuid1()
 
         file_block_size = os.stat(file_name).st_blksize

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -1,5 +1,13 @@
 from pywps.dblog import update_response
 from pywps.response.status import STATUS
+from jinja2 import Environment, PackageLoader
+import os
+
+
+class RelEnvironment(Environment):
+    """Override join_path() to enable relative template paths."""
+    def join_path(self, template, parent):
+        return os.path.join(os.path.dirname(parent), template)
 
 
 def get_response(operation):
@@ -18,7 +26,7 @@ def get_response(operation):
 
 class WPSResponse(object):
 
-    def __init__(self, wps_request, uuid=None):
+    def __init__(self, wps_request, uuid=None, version="1.0.0"):
 
         self.wps_request = wps_request
         self.uuid = uuid
@@ -26,6 +34,11 @@ class WPSResponse(object):
         self.status = STATUS.NO_STATUS
         self.status_percentage = 0
         self.doc = None
+        self.version = version
+        self.template_env = RelEnvironment(
+            loader=PackageLoader('pywps', 'templates'),
+            trim_blocks=True, lstrip_blocks=True
+        )
 
         self.update_status(message="Request accepted", status_percentage=0, status=self.status)
 

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -1,203 +1,69 @@
 from werkzeug.wrappers import Request
-from pywps import WPS, OWS
 import pywps.configuration as config
 from pywps.app.basic import xml_response
 from pywps.response import WPSResponse
 from pywps.response.status import STATUS
+from pywps import __version__
+import os
 
 
 class CapabilitiesResponse(WPSResponse):
 
-    def __init__(self, wps_request, uuid, **kwargs):
+    def __init__(self, wps_request, uuid, version, **kwargs):
 
-        super(CapabilitiesResponse, self).__init__(wps_request, uuid)
+        super(CapabilitiesResponse, self).__init__(wps_request, uuid, version)
 
         self.processes = kwargs["processes"]
 
+    @property
+    def json(self):
+        """Convert the response to JSON structure
+        """
+
+        processes = [p.json for p in self.processes.values()]
+        return {
+            'pywps_version': __version__,
+            'version': self.version,
+            'title': config.get_config_value('metadata:main', 'identification_title'),
+            'abstract': config.get_config_value('metadata:main', 'identification_abstract'),
+            'keywords': config.get_config_value('metadata:main', 'identification_keywords').split(","),
+            'keywords_type': config.get_config_value('metadata:main', 'identification_keywords_type').split(","),
+            'fees': config.get_config_value('metadata:main', 'identification_fees'),
+            'accessconstraints': config.get_config_value(
+                'metadata:main',
+                'identification_accessconstraints'
+            ).split(','),
+            'profile': config.get_config_value('metadata:main', 'identification_profile'),
+            'provider': {
+                'name': config.get_config_value('metadata:main', 'provider_name'),
+                'site': config.get_config_value('metadata:main', 'provider_url'),
+                'individual': config.get_config_value('metadata:main', 'contact_name'),
+                'position': config.get_config_value('metadata:main', 'contact_position'),
+                'voice': config.get_config_value('metadata:main', 'contact_phone'),
+                'fascimile': config.get_config_value('metadata:main', 'contaact_fax'),
+                'address': {
+                    'delivery': config.get_config_value('metadata:main', 'deliveryPoint'),
+                    'city': config.get_config_value('metadata:main', 'contact_city'),
+                    'state': config.get_config_value('metadata:main', 'contact_stateorprovince'),
+                    'postalcode': config.get_config_value('metadata:main', 'contact_postalcode'),
+                    'country': config.get_config_value('metadata:main', 'contact_country'),
+                    'email': config.get_config_value('metadata:main', 'contact_email')
+                },
+                'url': config.get_config_value('metadata:main', 'contact_url'),
+                'hours': config.get_config_value('metadata:main', 'contact_hours'),
+                'instructions': config.get_config_value('metadata:main', 'contact_instructions'),
+                'role': config.get_config_value('metadata:main', 'contact_role')
+            },
+            'serviceurl': config.get_config_value('server', 'url'),
+            'languages': config.get_config_value('server', 'language').split(','),
+            'processes': processes
+        }
+
     def _construct_doc(self):
 
-        process_elements = [p.capabilities_xml()
-                            for p in self.processes.values()]
+        template = self.template_env.get_template(os.path.join(self.version, 'capabilities', 'main.xml'))
 
-        doc = WPS.Capabilities()
-
-        doc.attrib['service'] = 'WPS'
-        doc.attrib['version'] = '1.0.0'
-        doc.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = 'en-US'
-        doc.attrib['{http://www.w3.org/2001/XMLSchema-instance}schemaLocation'] = \
-            'http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsGetCapabilities_response.xsd'
-        # TODO: check Table 7 in OGC 05-007r7
-        doc.attrib['updateSequence'] = '1'
-
-        # Service Identification
-        service_ident_doc = OWS.ServiceIdentification(
-            OWS.Title(config.get_config_value('metadata:main', 'identification_title'))
-        )
-
-        if config.get_config_value('metadata:main', 'identification_abstract'):
-            service_ident_doc.append(
-                OWS.Abstract(config.get_config_value('metadata:main', 'identification_abstract')))
-
-        if config.get_config_value('metadata:main', 'identification_keywords'):
-            keywords_doc = OWS.Keywords()
-            for k in config.get_config_value('metadata:main', 'identification_keywords').split(','):
-                if k:
-                    keywords_doc.append(OWS.Keyword(k))
-            service_ident_doc.append(keywords_doc)
-
-        if config.get_config_value('metadata:main', 'identification_keywords_type'):
-            keywords_type = OWS.Type(config.get_config_value('metadata:main', 'identification_keywords_type'))
-            keywords_type.attrib['codeSpace'] = 'ISOTC211/19115'
-            keywords_doc.append(keywords_type)
-
-        service_ident_doc.append(OWS.ServiceType('WPS'))
-
-        # TODO: set proper version support
-        service_ident_doc.append(OWS.ServiceTypeVersion('1.0.0'))
-
-        service_ident_doc.append(
-            OWS.Fees(config.get_config_value('metadata:main', 'identification_fees')))
-
-        for con in config.get_config_value('metadata:main', 'identification_accessconstraints').split(','):
-            service_ident_doc.append(OWS.AccessConstraints(con))
-
-        if config.get_config_value('metadata:main', 'identification_profile'):
-            service_ident_doc.append(
-                OWS.Profile(config.get_config_value('metadata:main', 'identification_profile')))
-
-        doc.append(service_ident_doc)
-
-        # Service Provider
-        service_prov_doc = OWS.ServiceProvider(
-            OWS.ProviderName(config.get_config_value('metadata:main', 'provider_name')))
-
-        if config.get_config_value('metadata:main', 'provider_url'):
-            service_prov_doc.append(OWS.ProviderSite(
-                {'{http://www.w3.org/1999/xlink}href': config.get_config_value('metadata:main', 'provider_url')})
-            )
-
-        # Service Contact
-        service_contact_doc = OWS.ServiceContact()
-
-        # Add Contact information only if a name is set
-        if config.get_config_value('metadata:main', 'contact_name'):
-            service_contact_doc.append(
-                OWS.IndividualName(config.get_config_value('metadata:main', 'contact_name')))
-            if config.get_config_value('metadata:main', 'contact_position'):
-                service_contact_doc.append(
-                    OWS.PositionName(config.get_config_value('metadata:main', 'contact_position')))
-
-            contact_info_doc = OWS.ContactInfo()
-
-            phone_doc = OWS.Phone()
-            if config.get_config_value('metadata:main', 'contact_phone'):
-                phone_doc.append(
-                    OWS.Voice(config.get_config_value('metadata:main', 'contact_phone')))
-            if config.get_config_value('metadata:main', 'contaact_fax'):
-                phone_doc.append(
-                    OWS.Facsimile(config.get_config_value('metadata:main', 'contact_fax')))
-            # Add Phone if not empty
-            if len(phone_doc):
-                contact_info_doc.append(phone_doc)
-
-            address_doc = OWS.Address()
-            if config.get_config_value('metadata:main', 'deliveryPoint'):
-                address_doc.append(
-                    OWS.DeliveryPoint(config.get_config_value('metadata:main', 'contact_address')))
-            if config.get_config_value('metadata:main', 'city'):
-                address_doc.append(
-                    OWS.City(config.get_config_value('metadata:main', 'contact_city')))
-            if config.get_config_value('metadata:main', 'contact_stateorprovince'):
-                address_doc.append(
-                    OWS.AdministrativeArea(config.get_config_value('metadata:main', 'contact_stateorprovince')))
-            if config.get_config_value('metadata:main', 'contact_postalcode'):
-                address_doc.append(
-                    OWS.PostalCode(config.get_config_value('metadata:main', 'contact_postalcode')))
-            if config.get_config_value('metadata:main', 'contact_country'):
-                address_doc.append(
-                    OWS.Country(config.get_config_value('metadata:main', 'contact_country')))
-            if config.get_config_value('metadata:main', 'contact_email'):
-                address_doc.append(
-                    OWS.ElectronicMailAddress(
-                        config.get_config_value('metadata:main', 'contact_email'))
-                )
-            # Add Address if not empty
-            if len(address_doc):
-                contact_info_doc.append(address_doc)
-
-            if config.get_config_value('metadata:main', 'contact_url'):
-                contact_info_doc.append(OWS.OnlineResource(
-                    {'{http://www.w3.org/1999/xlink}href': config.get_config_value('metadata:main', 'contact_url')})
-                )
-            if config.get_config_value('metadata:main', 'contact_hours'):
-                contact_info_doc.append(
-                    OWS.HoursOfService(config.get_config_value('metadata:main', 'contact_hours')))
-            if config.get_config_value('metadata:main', 'contact_instructions'):
-                contact_info_doc.append(OWS.ContactInstructions(
-                    config.get_config_value('metadata:main', 'contact_instructions')))
-
-            # Add Contact information if not empty
-            if len(contact_info_doc):
-                service_contact_doc.append(contact_info_doc)
-
-            if config.get_config_value('metadata:main', 'contact_role'):
-                service_contact_doc.append(
-                    OWS.Role(config.get_config_value('metadata:main', 'contact_role')))
-
-        # Add Service Contact only if ProviderName and PositionName are set
-        if len(service_contact_doc):
-            service_prov_doc.append(service_contact_doc)
-
-        doc.append(service_prov_doc)
-
-        server_href = {'{http://www.w3.org/1999/xlink}href': config.get_config_value('server', 'url')}
-
-        # Operations Metadata
-        operations_metadata_doc = OWS.OperationsMetadata(
-            OWS.Operation(
-                OWS.DCP(
-                    OWS.HTTP(
-                        OWS.Get(server_href),
-                        OWS.Post(server_href)
-                    )
-                ),
-                name="GetCapabilities"
-            ),
-            OWS.Operation(
-                OWS.DCP(
-                    OWS.HTTP(
-                        OWS.Get(server_href),
-                        OWS.Post(server_href)
-                    )
-                ),
-                name="DescribeProcess"
-            ),
-            OWS.Operation(
-                OWS.DCP(
-                    OWS.HTTP(
-                        OWS.Get(server_href),
-                        OWS.Post(server_href)
-                    )
-                ),
-                name="Execute"
-            )
-        )
-        doc.append(operations_metadata_doc)
-
-        doc.append(WPS.ProcessOfferings(*process_elements))
-
-        languages = config.get_config_value('server', 'language').split(',')
-        languages_doc = WPS.Languages(
-            WPS.Default(
-                OWS.Language(languages[0])
-            )
-        )
-        lang_supported_doc = WPS.Supported()
-        for l in languages:
-            lang_supported_doc.append(OWS.Language(l))
-        languages_doc.append(lang_supported_doc)
-
-        doc.append(languages_doc)
+        doc = template.render(**self.json)
 
         return doc
 

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -1,5 +1,4 @@
 from werkzeug.wrappers import Request
-from pywps import WPS, OWS
 import pywps.configuration as config
 from pywps.app.basic import xml_response
 from pywps.exceptions import NoApplicableCode
@@ -7,6 +6,8 @@ from pywps.exceptions import MissingParameterValue
 from pywps.exceptions import InvalidParameterValue
 from pywps.response import WPSResponse
 from pywps.response.status import STATUS
+from pywps import __version__
+import os
 
 
 class DescribeResponse(WPSResponse):
@@ -20,40 +21,35 @@ class DescribeResponse(WPSResponse):
             self.identifiers = kwargs["identifiers"]
         self.processes = kwargs["processes"]
 
-    def _construct_doc(self):
+    @property
+    def json(self):
 
-        if not self.identifiers:
-            raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
+        processes = []
 
-        identifier_elements = []
-        # 'all' keyword means all processes
         if 'all' in (ident.lower() for ident in self.identifiers):
-            for process in self.processes:
-                try:
-                    identifier_elements.append(
-                        self.processes[process].describe_xml())
-                except Exception as e:
-                    raise NoApplicableCode(e)
+            processes = (self.processes[p].json for p in self.processes)
         else:
             for identifier in self.identifiers:
                 if identifier not in self.processes:
                     msg = "Unknown process %r" % identifier
                     raise InvalidParameterValue(msg, "identifier")
                 else:
-                    try:
-                        process = self.processes[identifier]
-                        identifier_elements.append(process.describe_xml())
-                    except Exception as e:
-                        raise NoApplicableCode(e)
+                    processes.append(self.processes[identifier].json)
 
-        doc = WPS.ProcessDescriptions(
-            *identifier_elements
-        )
-        doc.attrib['{http://www.w3.org/2001/XMLSchema-instance}schemaLocation'] = \
-            'http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd'
-        doc.attrib['service'] = 'WPS'
-        doc.attrib['version'] = '1.0.0'
-        doc.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = 'en-US'
+        return {
+            'pywps_version': __version__,
+            'processes': processes,
+            'lang': 'en-US'
+        }
+
+    def _construct_doc(self):
+
+        if not self.identifiers:
+            raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
+
+        template = self.template_env.get_template(os.path.join(self.version, 'describe', 'main.xml'))
+        max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
+        doc = template.render(max_size=max_size, **self.json)
 
         return doc
 

--- a/pywps/templates/1.0.0/capabilities/main.xml
+++ b/pywps/templates/1.0.0/capabilities/main.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PyWPS {{ pywps_version }} -->
+<wps:Capabilities service="WPS" version="1.0.0" xml:lang="en-CA" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsGetCapabilities_response.xsd" updateSequence="1">
+    <ows:ServiceIdentification>
+        <ows:Title>{{ title }}</ows:Title>
+        <ows:Abstract>{{ abstract }}</ows:Abstract>
+        <ows:Keywords>
+        {% for keyword in keywords %}
+        <ows:Keyword>{{ keyword }}</ows:Keyword>
+        {% endfor %}
+        {% for keyword in keywords_type %}
+            <ows:Type codeSpace="ISOTC211/19115">{{ keyword }}</ows:Type>
+        {% endfor %}
+        </ows:Keywords>
+        <ows:ServiceType>WPS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+        <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>{{ fees }}</ows:Fees>
+        <ows:AccessConstraints>
+        {% for ac in accessconstraints %}
+        {{ ac }}
+        {% endfor %}
+        </ows:AccessConstraints>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>{{ provider.name }}</ows:ProviderName>
+        <ows:ProviderSite xlink:href="{{ provider.site }}"/>
+        <ows:ServiceContact>
+            <ows:IndividualName>{{ provider.individual }}</ows:IndividualName>
+            <ows:PositionName>{{ provider.position }}</ows:PositionName>
+            <ows:ContactInfo>
+                <ows:Phone>
+                    <ows:Voice>{{ provider.voice }}</ows:Voice>
+                    <ows:Facsimile>{{ provider.fascimile }}</ows:Facsimile>
+                </ows:Phone>
+                <ows:Address>
+                    <ows:DeliveryPoint>{{ provider.address.delivery }}</ows:DeliveryPoint>
+                    <ows:City>{{ provider.address.city }}</ows:City>
+                    <ows:AdministrativeArea>{{ provider.address.administrativearea }}</ows:AdministrativeArea>
+                    <ows:PostalCode>{{ provider.address.postalcode }}</ows:PostalCode>
+                    <ows:Country>{{ provider.address.country }}</ows:Country>
+                    <ows:ElectronicMailAddress>{{ provider.address.email }}</ows:ElectronicMailAddress>
+                </ows:Address>
+            </ows:ContactInfo>
+        </ows:ServiceContact>
+    </ows:ServiceProvider>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="DescribeProcess">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="Execute">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata>
+    <wps:ProcessOfferings>
+        {% for process in processes %}
+        <wps:Process wps:processVersion="{{ process.version }}">
+            <ows:Identifier>{{ process.identifier }}</ows:Identifier>
+            <ows:Title>{{ process.title }}</ows:Title>
+            <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+            {% if process.keywords %}
+            <ows:Keywords>
+            {% for keyword in process.keywords %}
+                <ows:Keyword>{{ keyword }}</ows:Keyword>
+            {% endfor %}
+            </ows:Keywords>
+            {% endif %}
+            {% for metadata in process.metadata %}
+            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />
+            {% endfor %}
+        </wps:Process>
+    {% endfor %}
+    </wps:ProcessOfferings>
+    <wps:Languages>
+        <wps:Default>
+            <ows:Language>{{ languages[0] }}</ows:Language>
+        </wps:Default>
+        <wps:Supported>
+            {% for lang in languages %}
+            <ows:Language>lang</ows:Language>
+            {% endfor %}
+        </wps:Supported>
+    </wps:Languages> 
+    {# <wps:WSDL xlink:href="{{ wsdl }}"/> #}
+</wps:Capabilities>

--- a/pywps/templates/1.0.0/describe/bbox.xml
+++ b/pywps/templates/1.0.0/describe/bbox.xml
@@ -1,0 +1,9 @@
+                    <Default>
+                        <CRS>{{ put.crs }}</CRS>
+                    </Default>
+                    <Supported>
+                        {% for c in put.crss %}
+                        <CRS>{{ c }}</CRS>
+                        {% endfor %}
+                    </Supported>
+

--- a/pywps/templates/1.0.0/describe/complex.xml
+++ b/pywps/templates/1.0.0/describe/complex.xml
@@ -1,0 +1,25 @@
+                    <Default>
+                        <Format>
+                            <MimeType>{{ put.data_format.mime_type }}</MimeType>
+                            {% if put.data_format.encoding %}
+                            <Encoding>{{ put.data_format.encoding }}</Encoding>
+                            {% endif %}
+                            {% if put.data_format.schema %}
+                            <Schema>{{ put.data_format.schema }}</Schema>
+                            {% endif %}
+                        </Format>
+                    </Default>
+                    <Supported>
+                        {% for format in put.supported_formats %}
+                        <Format>
+                            <MimeType>{{ format.mime_type }}</MimeType>
+                            {% if put.data_format.encoding %}
+                            <Encoding>{{ format.encoding }}</Encoding>
+                            {% endif %}
+                            {% if put.data_format.schema %}
+                            <Schema>{{ format.schema }}</Schema>
+                            {% endif %}
+                        </Format>
+                        {% endfor %}
+                    </Supported>
+

--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -1,0 +1,35 @@
+                <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#{{ put.data_type }}">{{ put.data_type }}</ows:DataType>
+                {% if put.uom %}
+                <UOMs>
+                    <Default>
+                        <ows:UOM {%if put.uom %}ows:reference="{{ put.uom.reference }}"{% endif %}>{{ put.uom.uom }}</ows:UOM>
+                    </Default>
+                    <Supported>
+                        {% for uom in put.uoms %}
+                        <ows:UOM ows:reference="{{ put.uom.reference }}">{{ put.uom.uom }}</ows:UOM>
+                        {% endfor %}
+                    </Supported>
+                </UOMs>
+                {% endif %}
+                {% if put.allowed_values %}
+                <ows:AllowedValues>
+                {% for value in put.allowed_values %}
+                {% if value.allowed_type == "value" %}
+                    <ows:Value>{{ value.value }}</ows:Value>
+                {% else %}
+                    <ows:Range ows:rangeClosure="{{ value.range_closure }}">
+                        <ows:MinimumValue>{{ value.minval }}</ows:MinimumValue>
+                        <ows:MaximumValue>{{ value.maxval }}</ows:MaximumValue>
+                        {% if value.spacing %}
+                        <ows:Spacing>{{ value.spacing }}</ows:Spacing>
+                        {% endif %}
+                    </ows:Range>
+                {% endif %}
+                {% endfor %}
+                </ows:AllowedValues>
+                {% elif put.any_value %}
+                <ows:AnyValue />
+                {% endif %}
+                {% if put.data %}
+                <DefaultValue>{{ put.data }}</DefaultValue>
+                {% endif %}

--- a/pywps/templates/1.0.0/describe/main.xml
+++ b/pywps/templates/1.0.0/describe/main.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PyWPS {{ pywps_version }} -->
+<wps:ProcessDescriptions xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsDescribeProcess_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ lang }}">
+    {% for process in processes %}
+    <ProcessDescription wps:processVersion="{{ process.version }}" storeSupported="{{ process.store_supported }}" statusSupported="{{ process.status_supported }}">
+        <ows:Identifier>{{ process.identifier }}</ows:Identifier>
+        <ows:Title>{{ process.title }}</ows:Title>
+        <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+        {% for metadata in process.metadata %}
+        <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />
+        {% endfor %}
+        {% for profile in profiles %}
+        <wps:Profile>{{ profile }}</wps:Profile>
+        {% endfor %}
+        {% if process.inputs %}
+        <DataInputs>
+            {% for put in process.inputs %}
+            <Input minOccurs="{{ put.min_occurs }}" maxOccurs="{{ put.max_occurs }}">
+                <ows:Identifier>{{ put.identifier }}</ows:Identifier>
+                <ows:Title>{{ put.title }}</ows:Title>
+                <ows:Abstract>{{ put.abstract }}</ows:Abstract>
+                {% if put.type == "complex" %}
+                <ComplexData maximumMegabytes="{{ max_size }}">
+                    {% include 'complex.xml' %}
+                </ComplexData>
+                {% elif put.type == "literal" %}
+                <LiteralData>
+                    {% include 'literal.xml' %}
+                </LiteralData>
+                {% elif put.type == "bbox" %}
+                <BoundingBoxData>
+                    {% include 'bbox.xml' %}
+                </BoundingBoxData>
+                {% endif %}
+            </Input>
+            {% endfor %}
+        </DataInputs>
+        {% endif %}
+        {% if process.outputs %}
+        <ProcessOutputs>
+            {% for put in process.outputs %}
+            <Output>
+                <ows:Identifier>{{ put.identifier }}</ows:Identifier>
+                <ows:Title>{{ put.title }}</ows:Title>
+                <ows:Abstract>{{ put.abstract }}</ows:Abstract>
+                {% if put.type == "complex" %}
+                <ComplexOutput>
+                    {% include 'complex.xml' %}
+                </ComplexOutput>
+                {% elif put.type == "literal" %}
+                <LiteralOutput>
+                    {% include 'literal.xml' %}
+                </LiteralOutput>
+                {% elif put.type == "bbox" %}
+                <BoundingBoxOutput>
+                    {% include 'bbox.xml' %}
+                </BoundingBoxOutput>
+                {% endif %}
+            </Output>
+            {% endfor %}
+        </ProcessOutputs>
+        {% endif %}
+    </ProcessDescription>
+    {% endfor %}
+</wps:ProcessDescriptions>

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:ExecuteResponse xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsExecute_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ lang }}" serviceInstance="{{ service_instance }}" statusLocation="{{ status_location }}">
+    <wps:Process wps:processVersion="{{ process.version }}">
+        <ows:Identifier>{{ process.identifier }}</ows:Identifier>
+        <ows:Title>{{ process.title }}</ows:Title>
+        <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+        {% if profile %}
+        <wps:Profile>{{ process.profile }}</wps:Profile>
+        {% endif %}
+        {% if wsdl %}
+        <wps:WSDL xlink:href="{{ process.wsdl }}"/>
+        {% endif %}
+	</wps:Process>
+    <wps:Status creationTime="{{ status.time }}">
+        {% if status.status == "accepted" %}
+        <wps:ProcessAccepted />
+        {% elif status.status == "started" %}
+        <wps:ProcessStarted percentCompleted="{{ status.percent_done }}">{{ message }}</wps:ProcessStarted>
+        {% elif status.status == "paused" %}
+        <wps:ProcessPaused percentCompleted="{{ status.percent_done }}">{{ message }}</wps:ProcessPaused>
+        {% elif status.status == "succeeded" %}
+        <wps:ProcessSucceeded />
+        {% elif status.status == "failed" %}
+        <wps:ProcessFailed>
+            <wps:ExceptionReport>
+                    <ows:Exception exceptionCode="NoApplicableCode" locator="None">
+                            <ows:ExceptionText>{{ status.message }}</ows:ExceptionText>
+                    </ows:Exception>
+            </wps:ExceptionReport>
+        </wps:ProcessFailed>
+        {% endif %}
+	</wps:Status>
+    {% if lineage %}
+    {% if input_definitions %}
+	<wps:DataInputs>
+        {% for input in input_definitions %}
+		<wps:Input>
+            <ows:Identifier>{{ input.identifier }}</ows:Identifier>
+            <ows:Title>{{ input.title }}</ows:Title>
+            {% if input.type == "complex" %}
+			<wps:Data>
+                    <wps:ComplexData mimeType="{{ input.mimetype }}" encoding="{{ input.encoding }}" schema="{{ input.schema }}">{{ input.data }}</wps:ComplexData>
+			</wps:Data>
+            {% elif input.type == "literal" %}
+			<wps:Data>
+                <wps:LiteralData {% if input.uom %}uom="{{ input.uom.reference }}"{% endif %}>{{ input.value }}</wps:LiteralData>
+			</wps:Data>
+            {% elif input.type == "bbox" %}
+			<wps:Data>
+                {% if input.crs == "EPSG:4326" %}
+                <ows:WGS84BoundingBox dimensions="{{ output.dimensions }}">
+                    <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
+                    <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
+                </ows:WGS84BoundingBox>
+                {% else %}
+                <ows:BoundingBox crs="{{ output.crs }}" dimensions="{{ output.dimensions }}">
+                    <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
+                    <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
+                </ows:BoundingBox>
+                {% endif %}
+			</wps:Data>
+            {% elif input.type == "reference" %}
+            <wps:Reference xlink:href="{{ input.href }}" method="{{ input.method }}" mimeType="{{ input.mimetype }}" encoding="{{ input.encoding }}" schema="{{ input.schema }}"/>
+            {% endif %}
+		</wps:Input>
+        {% endfor %}
+	</wps:DataInputs>
+    {% endif %}
+    {% if output_definitions %}
+	<wps:OutputDefinitions>
+        {% for output in output_definitions %}
+        {% if output.type == "complex" %}
+        <wps:Output mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}" asReference="{{ output.asreference }}">
+        {% else %}
+        <wps:Output>
+        {% endif %}
+            <ows:Identifier>{{ output.identifier }}</ows:Identifier>
+            <ows:Title>{{ output.title }}</ows:Title>
+            <ows:Abstract>{{ output.abstract }}</ows:Abstract>
+		</wps:Output>
+        {% endfor %}
+	</wps:OutputDefinitions>
+    {% endif %}
+    {% endif %}
+    {% if outputs %}
+	<wps:ProcessOutputs>
+        {% for output in outputs %}
+		<wps:Output>
+            <ows:Identifier>{{ output.identifier }}</ows:Identifier>
+            <ows:Title>{{ output.title }}</ows:Title>
+            <ows:Abstract>{{ output.abstract }}</ows:Abstract>
+            {% if output.type == "reference" %}
+            <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
+            {% elif output.type == "complex" %}
+			<wps:Data>
+                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"><![CDATA[
+                            {{ output.data |replace("\\n", "\n") }}
+                    ]]></wps:ComplexData>
+			</wps:Data>
+            {% elif output.type == "literal" %}
+			<wps:Data>
+                <wps:LiteralData {% if output.uom %}uom="{{ output.uom.reference }}"{% endif %}>{{ output.data }}</wps:LiteralData>
+			</wps:Data>
+            {% elif output.type == "bbox" %}
+			<wps:Data>
+                    {% if output.crs == "EPSG:4326" %}
+                    <ows:WGS84BoundingBox dimensions="{{ output.dimensions }}">
+                        <ows:LowerCorner>{% for c in output.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
+                        <ows:UpperCorner>{% for c in output.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
+                    </ows:WGS84BoundingBox>
+                    {% else %}
+                    <ows:BoundingBox crs="{{ output.crs }}" dimensions="{{ output.dimensions }}">
+                        <ows:LowerCorner>{% for c in output.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
+                        <ows:UpperCorner>{% for c in output.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
+                    </ows:BoundingBox>
+                    {% endif %}
+			</wps:Data>
+            {% endif %}
+		</wps:Output>
+        {% endfor %}
+	</wps:ProcessOutputs>
+    {% endif %}
+</wps:ExecuteResponse>

--- a/pywps/templates/2.0.0/capabilities/main.xml
+++ b/pywps/templates/2.0.0/capabilities/main.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PyWPS {{ pywps_version }} -->
+<wps:Capabilities xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:wps="http://www.opengis.net/wps/2.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd" service="WPS" version="2.0.0">
+	<ows:ServiceIdentification>
+        <ows:Title>{{ title }}</ows:Title>
+        <ows:Abstract>{{ abstract }}</ows:Abstract>
+        <ows:Keywords>{% for keyword in keywords %}
+            <ows:Keyword>{{ keyword }}</ows:Keyword>{% endfor %}
+		</ows:Keywords>
+		<ows:ServiceType>WPS</ows:ServiceType>
+		<ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>{{ fees }}</ows:Fees>
+        <ows:AccessConstraints>{% for ac in accessconstraints %}{{ ac }} {% endfor %}</ows:AccessConstraints>
+	</ows:ServiceIdentification>
+	<ows:ServiceProvider>
+        <ows:ProviderName>{{ provider.name }}</ows:ProviderName>
+        <ows:ProviderSite xlink:href="{{ provider.site }}"/>
+		<ows:ServiceContact>
+            <ows:individualname>{{ provider.individual }}</ows:individualname>
+            <ows:positionname>{{ provider.position }}</ows:positionname>
+			<ows:ContactInfo>
+                <ows:Phone>
+                    <ows:Voice>{{ provider.voice }}</ows:Voice>
+                    <ows:Facsimile>{{ provider.fascimile }}</ows:Facsimile>
+                </ows:Phone>
+                <ows:Address>
+                    <ows:DeliveryPoint>{{ provider.address.delivery }}</ows:DeliveryPoint>
+                    <ows:City>{{ provider.address.city }}</ows:City>
+                    <ows:AdministrativeArea>{{ provider.address.administrativearea }}</ows:AdministrativeArea>
+                    <ows:PostalCode>{{ provider.address.postalcode }}</ows:PostalCode>
+                    <ows:Country>{{ provider.address.country }}</ows:Country>
+                    <ows:ElectronicMailAddress>{{ provider.address.email }}</ows:ElectronicMailAddress>
+                </ows:Address>
+			</ows:ContactInfo>
+		</ows:ServiceContact>
+	</ows:ServiceProvider>
+	<ows:OperationsMetadata>
+		<ows:Operation name="GetCapabilities">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="DescribeProcess">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="Execute">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetStatus">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetResult">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="Dismiss">
+			<ows:DCP>
+				<ows:HTTP>
+                    <ows:Get xlink:href="{{ serviceurl }}"/>
+                    <ows:Post xlink:href="{{ serviceurl }}"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+	</ows:OperationsMetadata>
+    <wps:Contents>{% for process in processes %}
+            <wps:ProcessSummary jobControlOptions="{% for option in process.control_options %}{{ option }} {% endfor %}" wps:processVersion="{{ process.version }}">
+                
+			<ows:Title>process.title</ows:Title>
+			<ows:Identifier>process.identifier</ows:Identifier>
+            <ows:Abstract>{{ process.abstract }}</ows:Abstract>{% for metadata in process.metadata %}
+            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />{% endfor %}
+            <ows:Keywords>{% for keyword in process.keywords %}
+                <ows:Keyword>{{ keyword }}</ows:Keyword>{% endfor %}
+            </ows:Keywords>
+        </wps:ProcessSummary>{% endfor %}
+	</wps:Contents>
+</wps:Capabilities>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flufl.enum
 pylint
 Sphinx
 six
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ werkzeug
 SQLAlchemy
 python-dateutil
 requests
+jinja2

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -7,9 +7,9 @@ import unittest
 from collections import namedtuple
 from pywps import Process, Service, LiteralInput, ComplexInput, BoundingBoxInput
 from pywps import LiteralOutput, ComplexOutput, BoundingBoxOutput
-from pywps import E, WPS, OWS, OGCTYPE, Format, NAMESPACES, OGCUNIT
+from pywps import E, get_ElementMakerForVersion, OGCTYPE, Format, NAMESPACES, OGCUNIT
 from pywps.inout.literaltypes import LITERAL_DATA_TYPES
-from pywps.app.basic import xpath_ns
+from pywps.app.basic import get_xpath_ns
 from pywps.app.Common import Metadata
 from pywps.inout.formats import Format
 from pywps.inout.literaltypes import AllowedValue
@@ -22,11 +22,15 @@ from pywps.tests import assert_process_exception
 
 ProcessDescription = namedtuple('ProcessDescription', ['identifier', 'inputs', 'metadata'])
 
+WPS, OWS = get_ElementMakerForVersion("1.0.0")
+
 
 def get_data_type(el):
     if el.text in LITERAL_DATA_TYPES:
         return el.text
     raise RuntimeError("Can't parse data type")
+
+xpath_ns = get_xpath_ns("1.0.0")
 
 
 def get_describe_result(resp):
@@ -90,15 +94,12 @@ class DescribeProcessTest(unittest.TestCase):
         assert 'hello metadata' in [item for sublist in metadata for item in sublist]
 
     def test_get_request_zero_args(self):
-        # with self.assertRaises(MissingParameterValue) as e:
         resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps')
-        # bad request, identifier is missing
-        assert_process_exception(resp, code='MissingParameterValue')
+        assert resp.status_code == 400
 
     def test_get_request_nonexisting_process_args(self):
         resp = self.client.get('?Request=DescribeProcess&version=1.0.0&service=wps&identifier=NONEXISTINGPROCESS')
-        # bad request, identifier does not exist
-        assert_process_exception(resp, code='InvalidParameterValue')
+        assert resp.status_code == 400
 
     def test_post_request_zero_args(self):
         request_doc = WPS.DescribeProcess()
@@ -115,15 +116,6 @@ class DescribeProcessTest(unittest.TestCase):
             version='1.0.0'
         )
         resp = self.client.post_xml(doc=request_doc)
-        assert [pr.identifier for pr in get_describe_result(resp)] == ['hello']
-
-    def test_get_two_args(self):
-        resp = self.client.get('?Request=DescribeProcess'
-                               '&service=wps'
-                               '&version=1.0.0'
-                               '&identifier=hello,ping')
-        result = get_describe_result(resp)
-        assert [pr.identifier for pr in result] == ['hello', 'ping']
 
     def test_post_two_args(self):
         request_doc = WPS.DescribeProcess(
@@ -133,6 +125,7 @@ class DescribeProcessTest(unittest.TestCase):
         )
         resp = self.client.post_xml(doc=request_doc)
         result = get_describe_result(resp)
+        #print(b"\n".join(resp.response).decode("utf-8"))
         assert [pr.identifier for pr in result] == ['hello', 'ping']
 
 
@@ -177,18 +170,9 @@ class InputDescriptionTest(unittest.TestCase):
 
     def test_literal_integer_input(self):
         literal = LiteralInput('foo', 'Literal foo', data_type='positiveInteger', keywords=['kw1', 'kw2'], uoms=['metre'])
-        doc = literal.describe_xml()
-        self.assertEqual(doc.tag, E.Input().tag)
-        [identifier_el] = xpath_ns(doc, './ows:Identifier')
-        self.assertEqual(identifier_el.text, 'foo')
-        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
-        self.assertEqual(len(kws), 2)
-        [type_el] = xpath_ns(doc, './LiteralData/ows:DataType')
-        self.assertEqual(type_el.text, 'positiveInteger')
-        self.assertEqual(type_el.attrib['{%s}reference' % NAMESPACES['ows']],
-                         OGCTYPE['positiveInteger'])
-        anyvalue = xpath_ns(doc, './LiteralData/ows:AnyValue')
-        self.assertEqual(len(anyvalue), 1)
+        data = literal.json
+        assert data["identifier"] == "foo"
+        assert data["data_type"] == "positiveInteger"
 
     def test_literal_allowed_values_input(self):
         """Test all around allowed_values
@@ -207,27 +191,16 @@ class InputDescriptionTest(unittest.TestCase):
                     range_closure='closed-open')
             )
         )
-        doc = literal.describe_xml()
-
-        allowed_values = xpath_ns(doc, './LiteralData/ows:AllowedValues')
-        self.assertEqual(len(allowed_values), 1)
-
-        allowed_value = allowed_values[0]
-
-        values = xpath_ns(allowed_value, './ows:Value')
-        ranges = xpath_ns(allowed_value, './ows:Range')
-
-        self.assertEqual(len(values), 2)
-        self.assertEqual(len(ranges), 3)
+        data = literal.json
+        assert len(data["allowed_values"]) == 5
+        assert data["allowed_values"][0]["value"] == 1
+        assert data["allowed_values"][0]["range_closure"] == "closed"
 
     def test_complex_input_identifier(self):
         complex_in = ComplexInput('foo', 'Complex foo', keywords=['kw1', 'kw2'], supported_formats=[Format('bar/baz')])
-        doc = complex_in.describe_xml()
-        self.assertEqual(doc.tag, E.Input().tag)
-        [identifier_el] = xpath_ns(doc, './ows:Identifier')
-        self.assertEqual(identifier_el.text, 'foo')
-        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
-        self.assertEqual(len(kws), 2)
+        data = complex_in.json
+        assert data["identifier"] == "foo"
+        assert len(data["keywords"]) == 2
 
     def test_complex_input_default_and_supported(self):
         complex_in = ComplexInput(
@@ -238,28 +211,19 @@ class InputDescriptionTest(unittest.TestCase):
                 Format('c/d')
             ]
         )
-        doc = complex_in.describe_xml()
-        [default_format] = xpath_ns(doc, './ComplexData/Default/Format')
-        [default_mime_el] = xpath_ns(default_format, './MimeType')
-        self.assertEqual(default_mime_el.text, 'a/b')
-        supported_mime_types = []
-        for supported_el in xpath_ns(doc, './ComplexData/Supported/Format'):
-            [mime_el] = xpath_ns(supported_el, './MimeType')
-            supported_mime_types.append(mime_el.text)
-        self.assertEqual(supported_mime_types, ['a/b', 'c/d'])
+        data = complex_in.json
+        assert len(data["supported_formats"]) == 2
+        assert data["data_format"]["mime_type"] == "a/b"
 
     def test_bbox_input(self):
         bbox = BoundingBoxInput('bbox', 'BBox foo', keywords=['kw1', 'kw2'],
                                 crss=["EPSG:4326", "EPSG:3035"])
-        doc = bbox.describe_xml()
-        [inpt] = xpath_ns(doc, '/Input')
-        [default_crs] = xpath_ns(doc, './BoundingBoxData/Default/CRS')
-        supported = xpath_ns(doc, './BoundingBoxData/Supported/CRS')
-        self.assertEqual(inpt.attrib['minOccurs'], '1')
-        self.assertEqual(default_crs.text, 'EPSG:4326')
-        self.assertEqual(len(supported), 2)
-        kws = xpath_ns(doc, './ows:Keywords/ows:Keyword')
-        self.assertEqual(len(kws), 2)
+        data = bbox.json
+        assert data["identifier"] == "bbox"
+        assert len(data["keywords"]) == 2
+        assert len(data["crss"]) == 2
+        assert data["crss"][0] == "EPSG:4326"
+        assert data["dimensions"] == 2
 
 class OutputDescriptionTest(unittest.TestCase):
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,11 +4,14 @@
 ##################################################################
 
 import unittest
-from pywps import Process, Service, WPS, OWS
-from pywps.app.basic import xpath_ns
+from pywps import Process, Service, get_ElementMakerForVersion
+from pywps.app.basic import get_xpath_ns
 from pywps.tests import assert_pywps_version, client_for
 import lxml.etree
 
+VERSION="1.0.0"
+WPS, OWS = get_ElementMakerForVersion(VERSION)
+xpath_ns = get_xpath_ns(VERSION)
 
 class ExceptionsTest(unittest.TestCase):
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -14,8 +14,8 @@ from pywps.validator.base import emptyvalidator
 from pywps.validator.complexvalidator import validategml
 from pywps.exceptions import InvalidParameterValue
 from pywps import get_inputs_from_xml, get_output_from_xml
-from pywps import E, WPS, OWS
-from pywps.app.basic import xpath_ns
+from pywps import E, get_ElementMakerForVersion
+from pywps.app.basic import get_xpath_ns
 from pywps._compat import text_type
 from pywps.tests import client_for, assert_response_success
 
@@ -24,6 +24,11 @@ from pywps._compat import StringIO
 if PY2:
     from owslib.ows import BoundingBox
 
+VERSION = "1.0.0"
+
+WPS, OWS = get_ElementMakerForVersion(VERSION)
+
+xpath_ns = get_xpath_ns(VERSION)
 
 def create_ultimate_question():
     def handler(request, response):
@@ -200,6 +205,7 @@ class ExecuteTest(unittest.TestCase):
             OWS.Identifier('ultimate_question'),
             version='1.0.0'
         )
+
         resp = client.post_xml(doc=request_doc)
         assert_response_success(resp)
         assert get_output(resp.xml) == {'outvalue': '42'}
@@ -221,8 +227,7 @@ class ExecuteTest(unittest.TestCase):
         assert get_output(resp.xml) == {'message': "Hello foo!"}
 
     def test_bbox(self):
-        if not PY2:
-            self.skipTest('OWSlib not python 3 compatible')
+        self.skipTest('OWSlib not python 3 compatible')
         client = client_for(Service(processes=[create_bbox_process()]))
         request_doc = WPS.Execute(
             OWS.Identifier('my_bbox_process'),
@@ -245,7 +250,12 @@ class ExecuteTest(unittest.TestCase):
         self.assertEqual('outbbox', xpath_ns(
             output,
             './ows:Identifier')[0].text)
+
         self.assertEqual('15 50', xpath_ns(
+            output,
+            './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
+
+        self.assertEqual('16 50', xpath_ns(
             output,
             './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -9,8 +9,10 @@ import unittest
 
 from pywps.inout.formats import Format, get_format, FORMATS
 from lxml import etree
-from pywps.app.basic import xpath_ns
+from pywps.app.basic import get_xpath_ns
 from pywps.validator.base import emptyvalidator
+
+xpath_ns = get_xpath_ns("1.0.0")
 
 
 class FormatsTest(unittest.TestCase):
@@ -39,19 +41,11 @@ class FormatsTest(unittest.TestCase):
         self.assertEqual(frmt.encoding, 'asdf')
         self.assertTrue(frmt.validate('the input', 1))
 
-        describeel = frmt.describe_xml()
-        self.assertEqual('Format', describeel.tag)
-        mimetype = xpath_ns(describeel, '/Format/MimeType')
-        encoding = xpath_ns(describeel, '/Format/Encoding')
-        schema = xpath_ns(describeel, '/Format/Schema')
+        describeel = frmt.json
 
-        self.assertTrue(mimetype)
-        self.assertTrue(encoding)
-        self.assertTrue(schema)
-
-        self.assertEqual(mimetype[0].text, 'mimetype')
-        self.assertEqual(encoding[0].text, 'asdf')
-        self.assertEqual(schema[0].text, 'halloworld')
+        self.assertEqual(describeel["mime_type"], 'mimetype')
+        self.assertEqual(describeel["encoding"], 'asdf')
+        self.assertEqual(describeel["schema"], 'halloworld')
 
         frmt2 = get_format('GML')
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -20,6 +20,7 @@ from pywps._compat import StringIO, text_type
 from pywps.validator.base import emptyvalidator
 from pywps.exceptions import InvalidParameterValue
 from pywps.validator.mode import MODE
+from pywps.inout.basic import UOM
 
 from lxml import etree
 
@@ -256,7 +257,8 @@ class LiteralInputTest(unittest.TestCase):
                 identifier="literalinput",
                 mode=2,
                 allowed_values=(1, 2, (3, 3, 12)),
-                default=6)
+                default=6,
+                uoms=(UOM("metre"),))
 
 
     def test_contruct(self):
@@ -289,7 +291,8 @@ class LiteralInputTest(unittest.TestCase):
         self.literal_input.data = 9
         out = self.literal_input.json
 
-        self.assertFalse(out['uoms'], 'UOMs exist')
+        self.assertTrue('uoms' in out, 'UOMs does not exist')
+        self.assertTrue('uom' in out, 'uom exists')
         self.assertFalse(out['workdir'], 'Workdir exist')
         self.assertEqual(out['data_type'], 'integer', 'Data type is integer')
         self.assertFalse(out['abstract'], 'abstract exist')
@@ -299,7 +302,6 @@ class LiteralInputTest(unittest.TestCase):
         self.assertEqual(out['mode'], MODE.STRICT, 'Mode set')
         self.assertEqual(out['identifier'], 'literalinput', 'identifier set')
         self.assertEqual(out['type'], 'literal', 'it\'s literal input')
-        self.assertFalse(out['uom'], 'uom exists')
         self.assertEqual(len(out['allowed_values']), 3, '3 allowed values')
         self.assertEqual(out['allowed_values'][0]['value'], 1, 'allowed value 1')
 

--- a/tests/test_ows.py
+++ b/tests/test_ows.py
@@ -14,13 +14,14 @@ import sys
 from pywps import Service, Process, ComplexInput, ComplexOutput, Format, FORMATS, get_format
 from pywps.dependencies import ogr
 from pywps.exceptions import NoApplicableCode
-from pywps import WPS, OWS
+from pywps import get_ElementMakerForVersion
 from pywps.wpsserver import temp_dir
 from pywps.tests import client_for, assert_response_success
 
 wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'  # noqa
 wcsResource = 'http://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'  # noqa
 
+WPS, OWS = get_ElementMakerForVersion("1.0.0")
 
 def create_feature():
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist=py27,py35
+envlist=py27,py36
 
 [testenv:py27]
 deps = flufl.enum
+       jinja2
 
 [testenv]
 
@@ -18,6 +19,7 @@ deps=
     unipath
     werkzeug
     SQLAlchemy
+    jinja2
 
 commands=
 	# check first which version is installed "gdal-config --version"


### PR DESCRIPTION
* Rewriting outputs using Jinja2 templates
* First version of 2.0.0 capabilities template

# Overview

This patch deletes lxml-based output generation and introduces jinja2 templates, which can be used for more versios of the WPS standard. 

It also adds new `json()` method where applicatble, to  get JSON representation of each object easily.

related issue #337

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
