### PR TITLE
Fix spacing support into float range input (#349)

### DIFF
--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -7,6 +7,7 @@
 """ Validator classes used for LiteralInputs
 """
 import logging
+from decimal import Decimal
 
 from pywps.validator.mode import MODE
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE, RANGECLOSURETYPE
@@ -74,7 +75,7 @@ def _validate_range(interval, data):
         if interval.spacing:
             spacing = abs(interval.spacing)
             diff = data - interval.minval
-            passed = diff % spacing == 0
+            passed = Decimal(str(diff)) % Decimal(str(spacing)) == 0
         else:
             passed = True
 


### PR DESCRIPTION
# Overview

Range input with spacing is supported with integer numbers but not float numbers. 
This is due to limitation into floating-point number arithmetic (see [wikipedia page](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems)).

# Related Issue / Discussion

```python
>>> # Validation works with integer
>>> 3 % 1 == 0
True
>>> # Validation fails with float
>>> 0.3 % 0.1 == 0
False
>>> 0.3 % 0.1
0.09999999999999998
>>> # Test assuming zero fails
>>>
>>> # Validation works now with float
>>> from decimal import Decimal
>>> Decimal(str(0.3)) % Decimal(str(0.1)) == 0
True
>>> # Still working with integer
>>> Decimal(str(3)) % Decimal(str(1)) == 0
True
```

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
