### PR TITLE
fix setup.py and MANIFEST.in to include templates (PR #345)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include *.txt
-recursive-include pywps/schemas *
+include *.rst
+recursive-include pywps *
+global-exclude *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune tests/
 include *.txt
 include *.rst
 recursive-include pywps *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune docs/
 prune tests/
 include *.txt
 include *.rst

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ CONFIG = {
         'Topic :: Scientific/Engineering :: GIS'
     ],
     'install_requires': INSTALL_REQUIRES,
-    'packages': find_packages(exclude=["docs", "tests"]),
+    'packages': find_packages(exclude=["docs", "tests.*", "tests"]),
     'include_package_data': True,
     'scripts': [],
     'entry_points': {

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from setuptools import find_packages
+
 with open('VERSION.txt') as ff:
     VERSION = ff.read().strip()
 
@@ -46,16 +48,8 @@ CONFIG = {
         'Topic :: Scientific/Engineering :: GIS'
     ],
     'install_requires': INSTALL_REQUIRES,
-    'packages': [
-        'pywps',
-        'pywps/app',
-        'pywps/inout',
-        'pywps/resources',
-        'pywps/response',
-        'pywps/validator',
-        'pywps/inout/formats',
-        'pywps/processing',
-    ],
+    'packages': find_packages(exclude=["docs", "tests"]),
+    'include_package_data': True,
     'scripts': [],
     'entry_points': {
         'console_scripts': [


### PR DESCRIPTION
# Overview

I was updating the pywps conda package with the latest master including the PR #345 introducing templates. The `templates/` folder was missing in the installed python package. 

This PR updates `setup.py` and `MANIFEST.in` to include package data (`templates/`, `schema/`). 

# Related Issue / Discussion

PR #345

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
