### PR TITLE
Fixing WPSRequest parsing when no inputs is provided

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -143,6 +143,9 @@ class WPSRequest(object):
                 http_request, 'lineage', 'false')
             wpsrequest.inputs = get_data_from_kvp(
                 _get_get_param(http_request, 'DataInputs'), 'DataInputs')
+            if self.inputs is None:
+                self.inputs = {}
+
             wpsrequest.outputs = {}
 
             # take responseDocument preferably


### PR DESCRIPTION
# Overview

Hello,

When an execute request with GET method has not input an incorrect exception is raised. A WPS process may have no inputs.

This patch fix this issue.

Best regards

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
