### PR TITLE
Fixing unit test to accept text/xml; charset=*

### DIFF
--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -12,6 +12,7 @@ from pywps.inout import LiteralInput, LiteralOutput, ComplexInput, ComplexOutput
 from pywps.inout import Format
 from pywps.app.Common import Metadata
 
+import re
 
 import logging
 
@@ -72,7 +73,7 @@ class WpsTestResponse(BaseResponse):
 
     def __init__(self, *args):
         super(WpsTestResponse, self).__init__(*args)
-        if self.headers.get('Content-Type') == 'text/xml':
+        if re.match('text/xml(;\s*charset=.*)?', self.headers.get('Content-Type')):
             self.xml = lxml.etree.fromstring(self.get_data())
 
     def xpath(self, path):
@@ -95,7 +96,7 @@ def client_for(service):
 
 def assert_response_accepted(resp):
     assert resp.status_code == 200
-    assert resp.headers['Content-Type'] == 'text/xml'
+    assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
     success = resp.xpath_text('/wps:ExecuteResponse'
                               '/wps:Status'
                               '/wps:ProcessAccepted')
@@ -105,7 +106,7 @@ def assert_response_accepted(resp):
 
 def assert_process_started(resp):
     assert resp.status_code == 200
-    assert resp.headers['Content-Type'] == 'text/xml'
+    assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
     success = resp.xpath_text('/wps:ExecuteResponse'
                               '/wps:Status'
                               'ProcessStarted')
@@ -115,14 +116,14 @@ def assert_process_started(resp):
 
 def assert_response_success(resp):
     assert resp.status_code == 200
-    assert resp.headers['Content-Type'] == 'text/xml'
+    assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
     success = resp.xpath('/wps:ExecuteResponse/wps:Status/wps:ProcessSucceeded')
     assert len(success) == 1
 
 
 def assert_process_exception(resp, code=None):
     assert resp.status_code == 400
-    assert resp.headers['Content-Type'] == 'text/xml'
+    assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
     elem = resp.xpath('/ows:ExceptionReport'
                       '/ows:Exception')
     assert elem[0].attrib['exceptionCode'] == code

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,6 +9,8 @@ from pywps.app.basic import get_xpath_ns
 from pywps.tests import assert_pywps_version, client_for
 import lxml.etree
 
+import re
+
 VERSION="1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)
 xpath_ns = get_xpath_ns(VERSION)
@@ -23,7 +25,7 @@ class ExceptionsTest(unittest.TestCase):
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'InvalidParameterValue'
         assert resp.status_code == 400
-        assert resp.headers['Content-Type'] == 'text/xml'
+        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
         assert_pywps_version(resp)
 
     def test_missing_parameter_value(self):
@@ -31,20 +33,20 @@ class ExceptionsTest(unittest.TestCase):
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'MissingParameterValue'
         assert resp.status_code == 400
-        assert resp.headers['Content-Type'] == 'text/xml'
+        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
 
     def test_missing_request(self):
         resp = self.client.get("?service=wps")
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception/ows:ExceptionText')[0]
         # should mention something about a request
         assert 'request' in exception_el.text
-        assert resp.headers['Content-Type'] == 'text/xml'
+        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
 
     def test_bad_request(self):
         resp = self.client.get("?service=wps&request=xyz")
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'OperationNotSupported'
-        assert resp.headers['Content-Type'] == 'text/xml'
+        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:


### PR DESCRIPTION
The unit test is to restrictive and do not accept the valid content type
text/xml; charset=utf-8. This patch correct it

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
