### PR TITLE
added metadata href+role (#362)

### DIFF
--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -37,7 +37,8 @@ class WPSResponse(object):
         self.version = version
         self.template_env = RelEnvironment(
             loader=PackageLoader('pywps', 'templates'),
-            trim_blocks=True, lstrip_blocks=True
+            trim_blocks=True, lstrip_blocks=True,
+            autoescape=True,
         )
 
         self.update_status(message="Request accepted", status_percentage=0, status=self.status)

--- a/pywps/templates/1.0.0/capabilities/main.xml
+++ b/pywps/templates/1.0.0/capabilities/main.xml
@@ -83,7 +83,14 @@
             </ows:Keywords>
             {% endif %}
             {% for metadata in process.metadata %}
-            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />
+            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}"
+            {% if metadata.href != None %}
+              xlink:href="{{ metadata.href }}"
+            {% endif %}
+            {% if metadata.role != None %}
+              xlink:role="{{ metadata.role }}"
+            {% endif %}
+            />
             {% endfor %}
         </wps:Process>
     {% endfor %}
@@ -97,6 +104,6 @@
             <ows:Language>lang</ows:Language>
             {% endfor %}
         </wps:Supported>
-    </wps:Languages> 
+    </wps:Languages>
     {# <wps:WSDL xlink:href="{{ wsdl }}"/> #}
 </wps:Capabilities>

--- a/pywps/templates/1.0.0/describe/main.xml
+++ b/pywps/templates/1.0.0/describe/main.xml
@@ -7,7 +7,14 @@
         <ows:Title>{{ process.title }}</ows:Title>
         <ows:Abstract>{{ process.abstract }}</ows:Abstract>
         {% for metadata in process.metadata %}
-        <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />
+        <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}"
+          {% if metadata.href != None %}
+            xlink:href="{{ metadata.href }}"
+          {% endif %}
+          {% if metadata.role != None %}
+            xlink:role="{{ metadata.role }}"
+          {% endif %}
+        />
         {% endfor %}
         {% for profile in profiles %}
         <wps:Profile>{{ profile }}</wps:Profile>

--- a/pywps/templates/2.0.0/capabilities/main.xml
+++ b/pywps/templates/2.0.0/capabilities/main.xml
@@ -85,11 +85,19 @@
 	</ows:OperationsMetadata>
     <wps:Contents>{% for process in processes %}
             <wps:ProcessSummary jobControlOptions="{% for option in process.control_options %}{{ option }} {% endfor %}" wps:processVersion="{{ process.version }}">
-                
+
 			<ows:Title>process.title</ows:Title>
 			<ows:Identifier>process.identifier</ows:Identifier>
             <ows:Abstract>{{ process.abstract }}</ows:Abstract>{% for metadata in process.metadata %}
-            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}" />{% endfor %}
+            <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}"
+						{% if metadata.href != None %}
+							xlink:href="{{ metadata.href }}"
+						{% endif %}
+						{% if metadata.role != None %}
+							xlink:role="{{ metadata.role }}"
+						{% endif %}
+						/>
+						{% endfor %}
             <ows:Keywords>{% for keyword in process.keywords %}
                 <ows:Keyword>{{ keyword }}</ows:Keyword>{% endfor %}
             </ows:Keywords>


### PR DESCRIPTION
# Overview

This PR is a fix for #362 and adds the optional metadata attributes `href` and `role` to the jinja templates. These attributes are only added when they are set.

Also `autoescape` is enabled for the jinja environment which is needed to encode URLs. 

# Related Issue / Discussion

#362.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
