### PR TITLE
Simplify ENV var config customisation for container use

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,7 +4,8 @@ Configuration
 =============
 
 PyWPS is configured using a configuration file. The file uses the
-`ConfigParser <https://wiki.python.org/moin/ConfigParserExamples>`_ format.
+`ConfigParser <https://wiki.python.org/moin/ConfigParserExamples>`_ format, with
+interpolation initialised using `os.environ`.
 
 .. versionadded:: 4.0.0
 .. warning:: Compatibility with PyWPS 3.x: major changes have been made

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -69,9 +69,9 @@ def load_configuration(cfgfiles=None):
 
     LOGGER.info('loading configuration')
     if PY2:
-        CONFIG = ConfigParser.SafeConfigParser()
+        CONFIG = ConfigParser.SafeConfigParser(os.environ)
     else:
-        CONFIG = configparser.ConfigParser()
+        CONFIG = configparser.ConfigParser(os.environ)
 
     LOGGER.debug('setting default values')
     CONFIG.add_section('server')


### PR DESCRIPTION
# Overview

When using Docker containers, ENV vars are often used to customise instance specific values.

by adding `os.environ` to the ConfigParser of the cfg file, we can use something like:

`docker run --name pywps -d -p 80:80 --hostname pywps.example.com pywps ....`

```
[default]
# baseurl can be overridden using env vars ala Docker
baseurl=http://%(HOSTNAME)s

[server]
url=%(baseurl)s/ncwps
# the output path and url need to correlate
outputurl=%(baseurl)s/ncwps/outputs
```

or, if you have an external https proxy like traefik:

`docker run --name pywps -d --env BASEURL=https://pywps.example.com:443 pywps ...` 

```
[default]
# baseurl can be overridden using env vars ala Docker
baseurl=http://%(HOSTNAME)s

[server]
url=%(baseurl)s/ncwps
# the output path and url need to correlate
outputurl=%(baseurl)s/ncwps/outputs
```

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
