### PR TITLE
disabled process clean (#370)

### DIFF
--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -206,7 +206,9 @@ class ExecuteResponse(WPSResponse):
             try:
                 doc = self._construct_doc()
                 if self.store_status_file:
-                    self.process.clean()
+                    # TODO: disabled this clean as workaround for #370
+                    # self.process.clean()
+                    pass
             # TODO: If an exception occur here we must generate a valid status file
             except HTTPException as httpexp:
                 return httpexp


### PR DESCRIPTION
# Overview

This PR is a workaround for issue #370. 

It disables the `process.clean()` call to avoid removing the workdir before the process job has started.

It is probably not a solution to #370 and there is more work do be done for process cleaning.

# Related Issue / Discussion

See #370 and #358.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
