### PR TITLE
removed self.skipTest in _test_outout method.

### DIFF
--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -87,9 +87,8 @@ class IOHandlerTest(unittest.TestCase):
             source = StringIO(text_type(self._value))
             self.iohandler.stream = source
 
-        self.skipTest('Memory object not implemented')
-        self.assertEqual(stream_val, self.iohandler.memory_object,
-                         'Memory object obtained')
+        #self.assertEqual(stream_val, self.iohandler.memory_object,
+        #                 'Memory object obtained')
 
     def test_data(self):
         """Test data input IOHandler"""


### PR DESCRIPTION
# Overview
Removes self.skipTest call in _test_outout. 

# Related Issue / Discussion
#381 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
