### PR TITLE
fix update status doc (#377)

### DIFF
--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -13,13 +13,13 @@
 	</wps:Process>
     <wps:Status creationTime="{{ status.time }}">
         {% if status.status == "accepted" %}
-        <wps:ProcessAccepted />
+        <wps:ProcessAccepted percentCompleted="{{ status.percent_done }}">{{ status.message }}</wps:ProcessAccepted>
         {% elif status.status == "started" %}
-        <wps:ProcessStarted percentCompleted="{{ status.percent_done }}">{{ message }}</wps:ProcessStarted>
+        <wps:ProcessStarted percentCompleted="{{ status.percent_done }}">{{ status.message }}</wps:ProcessStarted>
         {% elif status.status == "paused" %}
-        <wps:ProcessPaused percentCompleted="{{ status.percent_done }}">{{ message }}</wps:ProcessPaused>
+        <wps:ProcessPaused percentCompleted="{{ status.percent_done }}">{{ status.message }}</wps:ProcessPaused>
         {% elif status.status == "succeeded" %}
-        <wps:ProcessSucceeded />
+        <wps:ProcessSucceeded>{{ status.message }}</wps:ProcessSucceeded>
         {% elif status.status == "failed" %}
         <wps:ProcessFailed>
             <wps:ExceptionReport>


### PR DESCRIPTION
# Overview

This PR fixes #377.

Changes:
* Fixed `update_status()` to use the current status instead of `WPS_STATUS.ACCEPTED`.
* Fixed execute response template: `status.message`.
* Reduced code duplication when generating json document for current status.

# Related Issue / Discussion

This PR probably also fixes #332.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
