### PR TITLE
Implements explicit URL handling

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,7 +63,7 @@ BoundingBoxData
 Request and response objects
 ----------------------------
 
-.. autodata:: pywps.response.status.STATUS
+.. autodata:: pywps.response.status.WPS_STATUS
     :annotation:
 
     Process status information

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -54,7 +54,7 @@ you shall use first index of an input list::
 
 Inputs and outputs data manipulation
 ------------------------------------
-Btw, PyWPS Inputs do now have `file`, `data` and `stream` attributes. They are
+Btw, PyWPS Inputs do now have `file`, `data`, `url` and `stream` attributes. They are
 transparently converting one data-representation-type to another. You can read
 input data from file-like object using `stream` or get directly the data into
 variable with `input.data`. You can also save output data directly using

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -320,7 +320,6 @@ class Service(object):
                 raise RuntimeError("Unknown operation %r"
                                    % wps_request.operation)
 
-
         except NoApplicableCode as e:
             return e
         except HTTPException as e:

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -158,89 +158,6 @@ class Service(object):
         wps_response = process.execute(wps_request, uuid)
         return wps_response
 
-    def _get_complex_input_handler(self, href):
-        """Return function for parsing and storing complexdata
-        :param href: href object yes or not
-        """
-
-        def href_handler(complexinput, datain):
-            """<wps:Reference /> handler"""
-            # save the reference input in workdir
-            tmp_file = _build_input_file_name(
-                href=datain.get('href'),
-                workdir=complexinput.workdir,
-                extension=_extension(complexinput))
-
-            try:
-                reference_file = _openurl(datain)
-                data_size = reference_file.headers.get('Content-Length', 0)
-            except Exception as e:
-                raise NoApplicableCode('File reference error: %s' % e)
-
-            # if the response did not return a 'Content-Length' header then
-            # calculate the size
-            if data_size == 0:
-                LOGGER.debug('no Content-Length, calculating size')
-
-            # check if input file size was not exceeded
-            complexinput.calculate_max_input_size()
-            max_byte_size = complexinput.max_size * 1024 * 1024
-            if int(data_size) > int(max_byte_size):
-                raise FileSizeExceeded('File size for input exceeded.'
-                                       ' Maximum allowed: %i megabytes' %
-                                       complexinput.max_size, complexinput.identifier)
-
-            try:
-                with open(tmp_file, 'wb') as f:
-                    data_size = 0
-                    for chunk in reference_file.iter_content(chunk_size=1024):
-                        data_size += len(chunk)
-                        if int(data_size) > int(max_byte_size):
-                            raise FileSizeExceeded('File size for input exceeded.'
-                                                   ' Maximum allowed: %i megabytes' %
-                                                   complexinput.max_size, complexinput.identifier)
-                        f.write(chunk)
-            except Exception as e:
-                raise NoApplicableCode(e)
-
-            complexinput.file = tmp_file
-
-        def file_handler(complexinput, datain):
-            """<wps:Reference /> handler.
-            Used when href is a file url."""
-            # check if file url is allowed
-            _validate_file_input(href=datain.get('href'))
-            # save the file reference input in workdir
-            tmp_file = _build_input_file_name(
-                href=datain.get('href'),
-                workdir=complexinput.workdir,
-                extension=_extension(complexinput))
-            try:
-                inpt_file = urlparse(datain.get('href')).path
-                inpt_file = os.path.abspath(inpt_file)
-                os.symlink(inpt_file, tmp_file)
-                LOGGER.debug("Linked input file %s to %s.", inpt_file, tmp_file)
-            except Exception:
-                # TODO: handle os.symlink on windows
-                # raise NoApplicableCode("Could not link file reference: %s" % e)
-                LOGGER.warn("Could not link file reference")
-                shutil.copy2(inpt_file, tmp_file)
-
-            complexinput.file = tmp_file
-
-        def data_handler(complexinput, datain):
-            """<wps:Data> ... </wps:Data> handler"""
-
-            complexinput.data = datain.get('data')
-
-        if href:
-            if urlparse(href).scheme == 'file':
-                return file_handler
-            else:
-                return href_handler
-        else:
-            return data_handler
-
     def create_complex_inputs(self, source, inputs):
         """Create new ComplexInput as clone of original ComplexInput
         because of inputs can be more then one, take it just as Prototype
@@ -267,14 +184,9 @@ class Service(object):
                     'mimeType')
 
             data_input.method = inpt.get('method', 'GET')
-
-            # get the referenced input otherwise get the value of the field
-            href = inpt.get('href', None)
-
-            complex_data_handler = self._get_complex_input_handler(href)
-            complex_data_handler(data_input, inpt)
-
+            data_input.process(inpt)
             outinputs.append(data_input)
+
         if len(outinputs) < source.min_occurs:
             raise MissingParameterValue(description="Given data input is missing", locator=source.identifier)
         return outinputs
@@ -357,6 +269,7 @@ class Service(object):
 
     # May not raise exceptions, this function must return a valid werkzeug.wrappers.Response.
     def call(self, http_request):
+
         try:
             # This try block handle Exception generated before the request is accepted. Once the request is accepted
             # a valid wps_reponse must exist. To report error use the wps_response using
@@ -406,6 +319,7 @@ class Service(object):
             else:
                 raise RuntimeError("Unknown operation %r"
                                    % wps_request.operation)
+
 
         except NoApplicableCode as e:
             return e

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -18,8 +18,8 @@ from pywps.validator.base import emptyvalidator
 from pywps.validator import get_validator
 from pywps.validator.literalvalidator import (validate_anyvalue,
                                               validate_allowed_values)
-from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
-    StorageNotSupported, FileURLNotSupported
+from pywps.exceptions import NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
+    FileURLNotSupported
 from pywps._compat import PY2, urlparse
 import base64
 from collections import namedtuple

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -31,6 +31,7 @@ SOURCE_TYPE = _SOURCE_TYPE(0, 1, 2, 3, 4)
 
 LOGGER = logging.getLogger("PYWPS")
 
+
 def _is_textfile(filename):
     try:
         # use python-magic if available
@@ -483,7 +484,6 @@ class UrlHandler(FileHandler):
         """
         ms = config.get_config_value('server', 'maxsingleinputsize')
         return config.get_size_mb(ms) * 1024**2
-
 
 
 class SimpleHandler(DataHandler):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -78,8 +78,7 @@ class IOHandler(object):
     :param workdir: working directory, to save temporal file objects in.
     :param mode: ``MODE`` validation mode.
 
-    Properties
-    ----------
+
     `file` : str
       Filename on the local disk.
     `url` : str
@@ -91,9 +90,6 @@ class IOHandler(object):
     `base64` : str
       A base 64 encoding of the data.
 
-
-    Example
-    -------
     >>> # setting up
     >>> import os
     >>> from io import RawIOBase

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -86,12 +86,10 @@ class ComplexOutput(basic.ComplexOutput):
             'max_occurs': self.max_occurs
         }
 
-        if self.file:
-
-            if self.as_reference:
-                data = self._json_reference(data)
-            else:
-                data = self._json_data(data)
+        if self.as_reference:
+            data = self._json_reference(data)
+        else:
+            data = self._json_data(data)
 
         if self.data_format:
             if self.data_format.mime_type:
@@ -109,8 +107,11 @@ class ComplexOutput(basic.ComplexOutput):
         data["type"] = "reference"
 
         # get_url will create the file and return the url for it
-        self.storage = FileStorage()
-        data["href"] = self.get_url()
+        if self.prop == 'url':
+            data["href"] = self.url
+        elif self.prop is not None:
+            self.storage = FileStorage()
+            data["href"] = self.get_url()
 
         return data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy
 python-dateutil
 requests
 jinja2
+pathlib

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -31,8 +31,8 @@ DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
 
 
 def get_data_format(mime_type):
-    return Format(mime_type=mime_type,
-    validate=get_validator(mime_type))
+    return Format(mime_type=mime_type, validate=get_validator(mime_type))
+
 
 class IOHandlerTest(unittest.TestCase):
     """IOHandler test cases"""
@@ -58,7 +58,7 @@ class IOHandlerTest(unittest.TestCase):
         """Test all outputs"""
 
         self.assertEqual(source_type, self.iohandler.source_type,
-                          'Source type properly set')
+                         'Source type properly set')
 
         self.assertEqual(self._value, self.iohandler.data, 'Data obtained')
 
@@ -93,7 +93,7 @@ class IOHandlerTest(unittest.TestCase):
             source = StringIO(text_type(self._value))
             self.iohandler.stream = source
 
-        #self.assertEqual(stream_val, self.iohandler.memory_object,
+        # self.assertEqual(stream_val, self.iohandler.memory_object,
         #                 'Memory object obtained')
 
     def test_data(self):
@@ -120,7 +120,10 @@ class IOHandlerTest(unittest.TestCase):
 
     def test_url(self):
 
-        wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=2'
+        wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \
+                      'service=WFS&version=1.1.0&' \
+                      'request=GetFeature&' \
+                      'typename=continents&maxfeatures=2'
         self._value = requests.get(wfsResource).text
         self.iohandler.url = wfsResource
         self._test_outout(SOURCE_TYPE.URL)
@@ -186,12 +189,14 @@ class ComplexInputTest(unittest.TestCase):
 
     def test_validator(self):
         self.assertEqual(self.complex_in.data_format.validate,
-                       get_validator('application/json'))
+                         get_validator('application/json'))
         self.assertEqual(self.complex_in.validator,
                          get_validator('application/json'))
         frmt = get_data_format('application/json')
+
         def my_validate():
             return True
+
         frmt.validate = my_validate
         self.assertNotEqual(self.complex_in.validator, frmt.validate)
 
@@ -216,6 +221,7 @@ class ComplexInputTest(unittest.TestCase):
         self.assertEqual(out['type'], 'complex', 'it is complex input')
         self.assertTrue(out['data_format'], 'data_format set')
         self.assertEqual(out['data_format']['mime_type'], 'application/json', 'data_format set')
+
 
 class ComplexOutputTest(unittest.TestCase):
     """ComplexOutput test cases"""
@@ -245,7 +251,6 @@ class ComplexOutputTest(unittest.TestCase):
                          get_validator('application/json'))
 
 
-
 class SimpleHandlerTest(unittest.TestCase):
     """SimpleHandler test cases"""
 
@@ -261,18 +266,18 @@ class SimpleHandlerTest(unittest.TestCase):
     def test_data_type(self):
         self.assertEqual(convert(self.simple_handler.data_type, '1'), 1)
 
+
 class LiteralInputTest(unittest.TestCase):
     """LiteralInput test cases"""
 
     def setUp(self):
 
         self.literal_input = LiteralInput(
-                identifier="literalinput",
-                mode=2,
-                allowed_values=(1, 2, (3, 3, 12)),
-                default=6,
-                uoms=(UOM("metre"),))
-
+            identifier="literalinput",
+            mode=2,
+            allowed_values=(1, 2, (3, 3, 12)),
+            default=6,
+            uoms=(UOM("metre"),))
 
     def test_contruct(self):
         self.assertIsInstance(self.literal_input, LiteralInput)
@@ -346,7 +351,6 @@ class LiteralInputTest(unittest.TestCase):
         self.assertEqual(out['data'], datetime.date(2017, 4, 20), 'date set')
 
 
-
 class LiteralOutputTest(unittest.TestCase):
     """LiteralOutput test cases"""
 
@@ -363,6 +367,7 @@ class LiteralOutputTest(unittest.TestCase):
         storage = Storage()
         self.literal_output.store = storage
         self.assertEqual(self.literal_output.store, storage)
+
 
 class BoxInputTest(unittest.TestCase):
     """BBoxInput test cases"""
@@ -404,6 +409,7 @@ class BoxOutputTest(unittest.TestCase):
         self.bbox_out.store = storage
         self.assertEqual(self.bbox_out.store, storage)
 
+
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:
         loader = unittest.TestLoader()
@@ -418,4 +424,3 @@ def load_tests(loader=None, tests=None, pattern=None):
         loader.loadTestsFromTestCase(BoxOutputTest)
     ]
     return unittest.TestSuite(suite_list)
-

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -268,7 +268,10 @@ class ComplexOutputTest(unittest.TestCase):
     def test_file_handler(self):
         self.complex_out.file = self.test_fn
         self.assertEqual(self.complex_out.data, self.data)
-        self.assertEqual(self.complex_out.stream.read(), self.data)
+        if PY2:
+            self.assertEqual(self.complex_out.stream.read(), self.data)
+        else:
+            self.assertEqual(self.complex_out.stream.read(), bytes(self.data, encoding='utf8'))
         self.assertEqual(open(urlparse(self.complex_out.url).path).read(), self.data)
 
     def test_data_handler(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -12,7 +12,6 @@ import tempfile
 import datetime
 import unittest
 import json
-from urlparse import urlparse
 from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
@@ -20,7 +19,7 @@ from pywps.inout.basic import IOHandler, SOURCE_TYPE, SimpleHandler, BBoxInput, 
     ComplexInput, ComplexOutput, LiteralOutput, LiteralInput, _is_textfile
 from pywps.inout import BoundingBoxInput as BoundingBoxInputXML
 from pywps.inout.literaltypes import convert, AllowedValue
-from pywps._compat import StringIO, text_type
+from pywps._compat import StringIO, text_type, urlparse
 from pywps.validator.base import emptyvalidator
 from pywps.exceptions import InvalidParameterValue
 from pywps.validator.mode import MODE

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -11,6 +11,8 @@ import os
 import tempfile
 import datetime
 import unittest
+import json
+from urlparse import urlparse
 from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
@@ -23,6 +25,7 @@ from pywps.validator.base import emptyvalidator
 from pywps.exceptions import InvalidParameterValue
 from pywps.validator.mode import MODE
 from pywps.inout.basic import UOM
+from pywps.inout.storage import FileStorage
 from pywps._compat import PY2
 
 from lxml import etree
@@ -62,6 +65,11 @@ class IOHandlerTest(unittest.TestCase):
 
         self.assertEqual(self._value, self.iohandler.data, 'Data obtained')
 
+        if self.iohandler.source_type == SOURCE_TYPE.URL:
+            self.assertEqual('http', urlparse(self.iohandler.url).scheme)
+        else:
+            self.assertEqual('file', urlparse(self.iohandler.url).scheme)
+
         if self.iohandler.source_type == SOURCE_TYPE.STREAM:
             source = StringIO(text_type(self._value))
             self.iohandler.stream = source
@@ -92,6 +100,8 @@ class IOHandlerTest(unittest.TestCase):
         if self.iohandler.source_type == SOURCE_TYPE.STREAM:
             source = StringIO(text_type(self._value))
             self.iohandler.stream = source
+
+
 
         # self.assertEqual(stream_val, self.iohandler.memory_object,
         #                 'Memory object obtained')
@@ -231,7 +241,13 @@ class ComplexOutputTest(unittest.TestCase):
         data_format = get_data_format('application/json')
         self.complex_out = ComplexOutput(identifier="complexinput", workdir=tmp_dir,
                                          data_format=data_format,
-                                         supported_formats=[data_format])
+                                         supported_formats=[data_format],
+                                         mode=MODE.NONE)
+        self.data = json.dumps({'a': 1})
+
+        self.test_fn = os.path.join(self.complex_out.workdir, 'test.json')
+        with open(self.test_fn, 'w') as f:
+            f.write(self.data)
 
     def test_contruct(self):
         self.assertIsInstance(self.complex_out, ComplexOutput)
@@ -249,6 +265,28 @@ class ComplexOutputTest(unittest.TestCase):
     def test_validator(self):
         self.assertEqual(self.complex_out.validator,
                          get_validator('application/json'))
+
+    def test_file_handler(self):
+        self.complex_out.file = self.test_fn
+        self.assertEqual(self.complex_out.data, self.data)
+        self.assertEqual(self.complex_out.stream.read(), self.data)
+        self.assertEqual(open(urlparse(self.complex_out.url).path).read(), self.data)
+
+    def test_data_handler(self):
+        self.complex_out.data = self.data
+        self.assertEqual(open(self.complex_out.file).read(), self.data)
+
+    def test_url_handler(self):
+        wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \
+                      'service=WFS&version=1.1.0&' \
+                      'request=GetFeature&' \
+                      'typename=continents&maxfeatures=2'
+        self.complex_out.url = wfsResource
+        storage = FileStorage()
+        self.complex_out.storage = storage
+        url = self.complex_out.get_url()
+        self.assertEqual('file', urlparse(url).scheme)
+
 
 
 class SimpleHandlerTest(unittest.TestCase):


### PR DESCRIPTION
# Overview

Adds a UrlHandler class. Previously, when users provided a URL to a ComplexInput, the file was automatically downloaded locally. With this PR, the link is instead stored in the url property and the file is only downloaded when the object's file, data or stream attributes are accessed. This allows processes using protocols such as opendap to use the url without downloading the file. 

Existing processes should not be affected because they would typically be accessing the file attribute in the _handler function. 

Note that the test coverage for ComplexOutput is somewhat thin. I suspect this PR could introduce bugs related to output properties. 

Tested with emu. 

# Related Issue / Discussion
Issue #352 

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
