### PR TITLE
fix duplicate storage outputs (#392)

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -974,7 +974,9 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
 
     @storage.setter
     def storage(self, storage):
-        self._storage = storage
+        # don't set storage twice
+        if self._storage is None:
+            self._storage = storage
 
     # TODO: refactor ?
     def get_url(self):

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -62,7 +62,7 @@ class DummyStorage(StorageAbstract):
         """
         """
 
-    def store(self, ouput):
+    def store(self, output):
         pass
 
 

--- a/pywps/inout/storage.py
+++ b/pywps/inout/storage.py
@@ -33,7 +33,20 @@ class StorageAbstract(object):
             store - string describing storage - file name, database connection
             url - url, where the data can be downloaded
         """
-        pass
+        raise NotImplementedError
+
+
+class CachedStorage(StorageAbstract):
+    def __init__(self):
+        self._cache = {}
+
+    def store(self, output):
+        if output.identifier not in self._cache:
+            self._cache[output.identifier] = self._do_store(output)
+        return self._cache[output.identifier]
+
+    def _do_store(self, output):
+        raise NotImplementedError
 
 
 class DummyStorage(StorageAbstract):
@@ -53,7 +66,7 @@ class DummyStorage(StorageAbstract):
         pass
 
 
-class FileStorage(StorageAbstract):
+class FileStorage(CachedStorage):
     """File storage implementation, stores data to file system
 
     >>> import ConfigParser
@@ -81,10 +94,11 @@ class FileStorage(StorageAbstract):
     def __init__(self):
         """
         """
+        CachedStorage.__init__(self)
         self.target = config.get_config_value('server', 'outputpath')
         self.output_url = config.get_config_value('server', 'outputurl')
 
-    def store(self, output):
+    def _do_store(self, output):
         import math
         import shutil
         import tempfile


### PR DESCRIPTION
# Overview

This PR fixes issue #392.

Changes:
* make sure we only use one storage instance.
* added a cache to avoid storing outputs more than once.

# Related Issue / Discussion

#392.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
