### PR TITLE
Added unicode output in tests

### DIFF
--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Unit tests for IOs
 """
 ##################################################################
@@ -273,7 +275,7 @@ class ComplexOutputTest(unittest.TestCase):
                                          data_format=data_format,
                                          supported_formats=[data_format],
                                          mode=MODE.NONE)
-        self.data = json.dumps({'a': 1})
+        self.data = json.dumps({'a': 1, 'unicodé': u'éîïç', })
 
         self.test_fn = os.path.join(self.complex_out.workdir, 'test.json')
         with open(self.test_fn, 'w') as f:


### PR DESCRIPTION
# Overview

Just added unicode strings in ComplexOutputTest to verify it is handled properly. 

# Related Issue / Discussion
#233 

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
