### PR TITLE
Fix 2 logging issues

### DIFF
--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -21,7 +21,7 @@ import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, VARCHAR, Float, DateTime, LargeBinary
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
+from sqlalchemy.pool import NullPool, StaticPool
 
 LOGGER = logging.getLogger('PYWPS')
 _SESSION_MAKER = None
@@ -167,7 +167,10 @@ def get_session():
         echo = False
     try:
         if database.startswith("sqlite") or database.startswith("memory"):
-            engine = sqlalchemy.create_engine(database, connect_args={'check_same_thread': False}, echo=echo)
+            engine = sqlalchemy.create_engine(database,
+                                              connect_args={'check_same_thread': False},
+                                              poolclass=StaticPool,
+                                              echo=echo)
         else:
             engine = sqlalchemy.create_engine(database, echo=echo, poolclass=NullPool)
     except sqlalchemy.exc.SQLAlchemyError as e:

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -162,7 +162,8 @@ def get_session():
     database = configuration.get_config_value('logging', 'database')
     echo = True
     level = configuration.get_config_value('logging', 'level')
-    if level in ['INFO']:
+    level_name = logging.getLevelName(level)
+    if isinstance(level_name, int) and level_name >= logging.INFO:
         echo = False
     try:
         if database.startswith("sqlite") or database.startswith("memory"):


### PR DESCRIPTION
# Overview

1. sets sqlalchemy `echo` flag to False when the logging level >= logging.INFO (INFO, WARN, ERROR, etc.)
2. Fixes an issue I encountered when serving from waitress. The sqlite memory database was complaining that a table didn't exist when trying to write a second row.

# Additional Information

See sqlalchemy documentation section _Using a Memory Database in Multiple Threads_:
https://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#using-a-memory-database-in-multiple-threads

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

I'd like to contribute to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
