### PR TITLE
Bug fix 412

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -416,7 +416,6 @@ class UrlHandler(FileHandler):
         self._reset_cache()
         self._url = value
         self._check_valid()
-        self.as_reference = True
 
     @property
     def file(self):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -24,7 +24,7 @@ from pywps._compat import PY2, urlparse
 import base64
 from collections import namedtuple
 from io import BytesIO
-
+import six
 
 _SOURCE_TYPE = namedtuple('SOURCE_TYPE', 'MEMORY, FILE, STREAM, DATA, URL')
 SOURCE_TYPE = _SOURCE_TYPE(0, 1, 2, 3, 4)
@@ -292,7 +292,8 @@ class FileHandler(IOHandler):
     @property
     def base64(self):
         """Return base64 encoding of data."""
-        return base64.b64encode(self.data)
+        data = self.data.encode() if not isinstance(self.data, bytes) else self.data
+        return base64.b64encode(data)
 
     @property
     def stream(self):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -279,7 +279,6 @@ class FileHandler(IOHandler):
         """Set file name"""
         self._reset_cache()
         self._file = os.path.abspath(value)
-        self.as_reference = True
         self._check_valid()
 
     @property

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -180,7 +180,7 @@ FORMATS = _FORMATS(
     Format('application/x-ogc-wms; version=1.0.0', extension='.xml'),
     Format('text/plain', extension='.txt'),
     Format('application/x-ogc-dods', extension='.nc'),
-    Format('application/x-netcdf', extension='.nc'),
+    Format('application/x-netcdf', extension='.nc', encoding='base64'),
     Format('application/octet-stream', extension='.laz'),
     Format('application/octet-stream', extension='.las'),
 )

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -127,14 +127,19 @@ class ComplexOutput(basic.ComplexOutput):
         except Exception:
 
             if self.data:
-                if isinstance(self.data, six.string_types):
+
+                if self.data_format.encoding == 'base64':
+                    data["data"] = etree.CDATA(self.base64)
+
+                elif isinstance(self.data, six.string_types):
                     if isinstance(self.data, bytes):
                         data["data"] = self.data.decode("utf-8")
                     else:
                         data["data"] = self.data
 
                 else:
-                    data["data"] = etree.tostring(etree.CDATA(self.base64))
+                    raise NotImplementedError
+
 
         return data
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -127,15 +127,20 @@ class ComplexOutput(basic.ComplexOutput):
         except Exception:
 
             if self.data:
+                # XML compatible formats don't have to be wrapped in a CDATA tag.
+                if self.data_format.mime_type in ["application/xml", "application/gml+xml", "text/xml"]:
+                    fmt = "{}"
+                else:
+                    fmt = "<![CDATA[{}]]>"
 
                 if self.data_format.encoding == 'base64':
-                    data["data"] = etree.CDATA(self.base64)
+                    data["data"] = fmt.format(etree.CDATA(self.base64))
 
                 elif isinstance(self.data, six.string_types):
                     if isinstance(self.data, bytes):
-                        data["data"] = self.data.decode("utf-8")
+                        data["data"] = fmt.format(self.data.decode("utf-8"))
                     else:
-                        data["data"] = self.data
+                        data["data"] = fmt.format(self.data)
 
                 else:
                     raise NotImplementedError

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -140,7 +140,6 @@ class ComplexOutput(basic.ComplexOutput):
                 else:
                     raise NotImplementedError
 
-
         return data
 
 

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -93,9 +93,7 @@
             <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
             {% elif output.type == "complex" %}
 			<wps:Data>
-                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}">
-                            {{ output.data |safe }}
-                    </wps:ComplexData>
+                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"><![CDATA[{{ output.data | safe }}]]></wps:ComplexData>
 			</wps:Data>
             {% elif output.type == "literal" %}
 			<wps:Data>

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -93,13 +93,7 @@
             <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
             {% elif output.type == "complex" %}
 			<wps:Data>
-                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}">
-                        {% if output.data_format.mime_type in ["application/xml", "application/gml+xml", "text/xml"] %}
-                            {{ output.data | safe }}
-                        {% else %}
-                            <![CDATA[{{ output.data | safe }}]]>
-                        {% endif %}
-                    </wps:ComplexData>
+                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}">{{ output.data | safe }}</wps:ComplexData>
 			</wps:Data>
             {% elif output.type == "literal" %}
 			<wps:Data>

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -93,9 +93,9 @@
             <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
             {% elif output.type == "complex" %}
 			<wps:Data>
-                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"><![CDATA[
-                            {{ output.data |replace("\\n", "\n") }}
-                    ]]></wps:ComplexData>
+                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}">
+                            {{ output.data |safe }}
+                    </wps:ComplexData>
 			</wps:Data>
             {% elif output.type == "literal" %}
 			<wps:Data>

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -93,7 +93,13 @@
             <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
             {% elif output.type == "complex" %}
 			<wps:Data>
-                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"><![CDATA[{{ output.data | safe }}]]></wps:ComplexData>
+                    <wps:ComplexData mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}">
+                        {% if output.data_format.mime_type in ["application/xml", "application/gml+xml", "text/xml"] %}
+                            {{ output.data | safe }}
+                        {% else %}
+                            <![CDATA[{{ output.data | safe }}]]>
+                        {% endif %}
+                    </wps:ComplexData>
 			</wps:Data>
             {% elif output.type == "literal" %}
 			<wps:Data>

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -40,6 +40,7 @@ WPS, OWS = get_ElementMakerForVersion(VERSION)
 
 xpath_ns = get_xpath_ns(VERSION)
 
+
 def create_ultimate_question():
     def handler(request, response):
         response.outputs['outvalue'].data = '42'
@@ -86,7 +87,7 @@ def create_complex_proces():
         response.outputs['complex'].data = request.inputs['complex'][0].data
         return response
 
-    frmt = Format(mime_type='application/gml', extension=".gml") #  this is unknown mimetype
+    frmt = Format(mime_type='application/gml', extension=".gml")  # this is unknown mimetype
 
     return Process(handler=complex_proces,
                    identifier='my_complex_process',
@@ -115,7 +116,7 @@ def create_complex_nc_process():
 
         response.outputs['outdods'].url = url
         response.outputs['ncraw'].file = os.path.join(DATA_DIR, 'netcdf', 'time.nc')
-        response.outputs['ncraw'].data_format=FORMATS.NETCDF
+        response.outputs['ncraw'].data_format = FORMATS.NETCDF
         return response
 
     return Process(handler=complex_proces,
@@ -125,7 +126,7 @@ def create_complex_nc_process():
                        ComplexInput(
                            'dods',
                            'Opendap input',
-                           supported_formats=[Format('DODS'), Format('NETCDF'),],
+                           supported_formats=[Format('DODS'), Format('NETCDF')],
                            #   mode=MODE.STRICT
                        )
                    ],
@@ -152,15 +153,15 @@ def create_mimetype_process():
     frmt_txt2 = Format(mime_type='text/plain+test')
 
     return Process(handler=_handler,
-            identifier='get_mimetype_process',
-            title='Get mimeType process',
-            inputs=[],
-            outputs=[
-                ComplexOutput(
-                    'mimetype',
-                    'mimetype of requested output',
-                    supported_formats=[frmt_txt,frmt_txt2])
-             ])
+                   identifier='get_mimetype_process',
+                   title='Get mimeType process',
+                   inputs=[],
+                   outputs=[
+                       ComplexOutput(
+                           'mimetype',
+                           'mimetype of requested output',
+                           supported_formats=[frmt_txt, frmt_txt2])
+                   ])
 
 
 def get_output(doc):
@@ -179,7 +180,6 @@ class ExecuteTest(unittest.TestCase):
     def test_dods(self):
         my_process = create_complex_nc_process()
         service = Service(processes=[my_process])
-        client = client_for(service)
 
         href = "http://test.opendap.org:80/opendap/netcdf/examples/sresa1b_ncar_ccsm3_0_run1_200001.nc"
 
@@ -194,7 +194,8 @@ class ExecuteTest(unittest.TestCase):
                         {'{http://www.w3.org/1999/xlink}href': href},
                         method='POST'
                     )
-                    #WPS.Data(WPS.ComplexData(href=href, mime_type='application/x-ogc-dods')) this form is not supported yet. Should it be ?
+                    #WPS.Data(WPS.ComplexData(href=href, mime_type='application/x-ogc-dods'))
+                    # This form is not supported yet. Should it be ?
                 )
             ),
             version='1.0.0'
@@ -210,9 +211,9 @@ class ExecuteTest(unittest.TestCase):
             version = '1.0.0'
             raw = True,
             inputs = {'dods': [{
-                    'identifier': 'dods',
-                    'href': href,
-                }]}
+                'identifier': 'dods',
+                'href': href,
+            }]}
             store_execute = False
             lineage = False
             outputs = ['conventions']
@@ -228,7 +229,6 @@ class ExecuteTest(unittest.TestCase):
             data = f.read()
         self.assertEqual(resp.outputs['ncraw'].data, data)
 
-
     def test_input_parser(self):
         """Test input parsing
         """
@@ -239,15 +239,15 @@ class ExecuteTest(unittest.TestCase):
 
         class FakeRequest():
             identifier = 'complex_process'
-            service='wps'
-            operation='execute'
-            version='1.0.0'
+            service = 'wps'
+            operation = 'execute'
+            version = '1.0.0'
             inputs = {'complex': [{
-                    'identifier': 'complex',
-                    'mimeType': 'text/gml',
-                    'data': 'the data'
-                }]}
-        request = FakeRequest();
+                'identifier': 'complex',
+                'mimeType': 'text/gml',
+                'data': 'the data'
+            }]}
+        request = FakeRequest()
 
         try:
             service.execute('my_complex_process', request, 'fakeuuid')
@@ -265,7 +265,7 @@ class ExecuteTest(unittest.TestCase):
         request.inputs['complex'][0]['mimeType'] = 'application/xml+gml'
         try:
             parsed_inputs = service.create_complex_inputs(my_process.inputs[0],
-                                                      request.inputs['complex'])
+                                                          request.inputs['complex'])
         except InvalidParameterValue as e:
             self.assertEqual(e.locator, 'mimeType')
 
@@ -280,7 +280,7 @@ class ExecuteTest(unittest.TestCase):
         my_process.inputs[0].supported_formats = [frmt]
         my_process.inputs[0].data_format = Format(mime_type='application/xml+gml')
         parsed_inputs = service.create_complex_inputs(my_process.inputs[0],
-                                              request.inputs['complex'])
+                                                      request.inputs['complex'])
 
         self.assertEqual(parsed_inputs[0].data_format.validate, validategml)
 
@@ -295,7 +295,7 @@ class ExecuteTest(unittest.TestCase):
         class FakeRequest():
             identifier = 'complex_process'
             service = 'wps'
-            operation='execute'
+            operation = 'execute'
             version = '1.0.0'
             inputs = {}
             raw = False
@@ -318,14 +318,14 @@ class ExecuteTest(unittest.TestCase):
         class FakeRequest():
             def __init__(self, mimetype):
                 self.outputs = {'mimetype': {
-                        'identifier': 'mimetype',
-                        'mimetype': mimetype,
-                        'data': 'the data'
+                    'identifier': 'mimetype',
+                    'mimetype': mimetype,
+                    'data': 'the data'
                 }}
 
             identifier = 'get_mimetype_process'
             service = 'wps'
-            operation='execute'
+            operation = 'execute'
             version = '1.0.0'
             inputs = {}
             raw = False
@@ -353,7 +353,6 @@ class ExecuteTest(unittest.TestCase):
         assert_response_success(resp)
 
         assert get_output(resp.xml) == {'outvalue': '42'}
-
 
     def test_post_with_no_inputs(self):
         client = client_for(Service(processes=[create_ultimate_question()]))
@@ -415,7 +414,6 @@ class ExecuteTest(unittest.TestCase):
             output,
             './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
 
-
     def test_output_response_dataType(self):
         client = client_for(Service(processes=[create_greeter()]))
         request_doc = WPS.Execute(
@@ -451,7 +449,7 @@ class ExecuteXmlParserTest(unittest.TestCase):
                 WPS.Input(
                     OWS.Identifier('name'),
                     WPS.Data(WPS.LiteralData('bar')))
-                ))
+            ))
         rv = get_inputs_from_xml(request_doc)
         self.assertTrue('name' in rv)
         self.assertEqual(len(rv['name']), 2)
@@ -512,13 +510,12 @@ class ExecuteXmlParserTest(unittest.TestCase):
                     OWS.Identifier('json'),
                     WPS.Data(
                         WPS.ComplexData(the_data,
-                            encoding='base64',
-                            mimeType='application/json')))))
+                                        encoding='base64',
+                                        mimeType='application/json')))))
         rv = get_inputs_from_xml(request_doc)
         self.assertEqual(rv['json'][0]['mimeType'], 'application/json')
         json_data = json.loads(rv['json'][0]['data'].decode())
         self.assertEqual(json_data['plot']['Version'], '0.1')
-
 
     def test_bbox_input(self):
         if not PY2:
@@ -567,7 +564,7 @@ class ExecuteXmlParserTest(unittest.TestCase):
                     OWS.Identifier('name'),
                     WPS.Reference(
                         WPS.BodyReference(
-                        {'{http://www.w3.org/1999/xlink}href': 'http://foo/bar/reference'}),
+                            {'{http://www.w3.org/1999/xlink}href': 'http://foo/bar/reference'}),
                         {'{http://www.w3.org/1999/xlink}href': 'http://foo/bar/service'},
                         method='POST'
                     )
@@ -597,7 +594,7 @@ class ExecuteXmlParserTest(unittest.TestCase):
             h._build_file_name('https://path/to/test.txt?token=abc&expires_at=1234567'),
             os.path.join(workdir, 'test.txt'))
 
-        h.supported_formats = [FORMATS.TEXT,]
+        h.supported_formats = [FORMATS.TEXT, ]
         h.data_format = FORMATS.TEXT
         self.assertEqual(
             h._build_file_name('http://path/to/test'),

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -86,24 +86,24 @@ def create_complex_proces():
         response.outputs['complex'].data = request.inputs['complex'][0].data
         return response
 
-    frmt = Format(mime_type='application/gml', extension=".gml") # this is unknown mimetype
+    frmt = Format(mime_type='application/gml', extension=".gml") #  this is unknown mimetype
 
     return Process(handler=complex_proces,
-            identifier='my_complex_process',
-            title='Complex process',
-            inputs=[
-                ComplexInput(
-                    'complex',
-                    'Complex input',
-                    default="DEFAULT COMPLEX DATA",
-                    supported_formats=[frmt])
-            ],
-            outputs=[
-                ComplexOutput(
-                    'complex',
-                    'Complex output',
-                    supported_formats=[frmt])
-             ])
+                   identifier='my_complex_process',
+                   title='Complex process',
+                   inputs=[
+                       ComplexInput(
+                           'complex',
+                           'Complex input',
+                           default="DEFAULT COMPLEX DATA",
+                           supported_formats=[frmt])
+                   ],
+                   outputs=[
+                       ComplexOutput(
+                           'complex',
+                           'Complex output',
+                           supported_formats=[frmt])
+                   ])
 
 
 def create_complex_nc_process():
@@ -119,28 +119,29 @@ def create_complex_nc_process():
         return response
 
     return Process(handler=complex_proces,
-            identifier='my_opendap_process',
-            title='Opendap process',
-            inputs=[
-                ComplexInput(
-                    'dods',
-                    'Opendap input',
-                    supported_formats=[Format('DODS'), Format('NETCDF'),],
-                 #   mode=MODE.STRICT
-                )
-            ],
-            outputs=[
-                LiteralOutput(
-                    'conventions',
-                    'NetCDF convention',
-                    ),
-                ComplexOutput('outdods', 'Opendap output',
-                              supported_formats=[FORMATS.DODS, ],
-                              as_reference=True),
-                ComplexOutput('ncraw', 'NetCDF raw data output',
-                              supported_formats=[FORMATS.NETCDF, ],
-                              as_reference=False)
-             ])
+                   identifier='my_opendap_process',
+                   title='Opendap process',
+                   inputs=[
+                       ComplexInput(
+                           'dods',
+                           'Opendap input',
+                           supported_formats=[Format('DODS'), Format('NETCDF'),],
+                           #   mode=MODE.STRICT
+                       )
+                   ],
+                   outputs=[
+                       LiteralOutput(
+                           'conventions',
+                           'NetCDF convention',
+                       ),
+                       ComplexOutput('outdods', 'Opendap output',
+                                     supported_formats=[FORMATS.DODS, ],
+                                     as_reference=True),
+                       ComplexOutput('ncraw', 'NetCDF raw data output',
+                                     supported_formats=[FORMATS.NETCDF, ],
+                                     as_reference=False)
+                   ])
+
 
 def create_mimetype_process():
     def _handler(request, response):

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -178,6 +178,8 @@ class ExecuteTest(unittest.TestCase):
     """Test for Exeucte request KVP request"""
 
     def test_dods(self):
+        if not WITH_NC4:
+            self.skipTest('netCDF4 not installed')
         my_process = create_complex_nc_process()
         service = Service(processes=[my_process])
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -285,7 +285,6 @@ class ComplexOutputTest(unittest.TestCase):
 
         self.data = json.dumps({'a': 1, 'unicodé': u'éîïç', })
         self.ncfile = os.path.join(DATA_DIR, 'netcdf', 'time.nc')
-        self.test_nc_fn = open(os.path.join(self.complex_out.workdir, 'test.nc'), 'wb')
 
         self.test_fn = os.path.join(self.complex_out.workdir, 'test.json')
         with open(self.test_fn, 'w') as f:
@@ -335,7 +334,10 @@ class ComplexOutputTest(unittest.TestCase):
     def test_base64(self):
         self.complex_out.data = self.data
         b = self.complex_out.base64
-        self.assertEqual(base64.b64decode(b), self.data)
+        if PY2:
+            self.assertEqual(base64.b64decode(b), self.data)
+        else:
+            self.assertEqual(base64.b64decode(b).decode(), self.data)
 
     def test_url_handler(self):
         wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -14,6 +14,7 @@ import tempfile
 import datetime
 import unittest
 import json
+import base64
 from pywps import Format
 from pywps.validator import get_validator
 from pywps import NAMESPACES
@@ -28,6 +29,7 @@ from pywps.validator.mode import MODE
 from pywps.inout.basic import UOM
 from pywps.inout.storage import FileStorage
 from pywps._compat import PY2
+
 
 from lxml import etree
 
@@ -275,7 +277,15 @@ class ComplexOutputTest(unittest.TestCase):
                                          data_format=data_format,
                                          supported_formats=[data_format],
                                          mode=MODE.NONE)
+
+        self.complex_out_nc = ComplexOutput(identifier="netcdf", workdir=tmp_dir,
+                                            data_format=get_data_format('application/x-netcdf'),
+                                            supported_formats=[get_data_format('application/x-netcdf')],
+                                            mode=MODE.NONE)
+
         self.data = json.dumps({'a': 1, 'unicodé': u'éîïç', })
+        self.ncfile = os.path.join(DATA_DIR, 'netcdf', 'time.nc')
+        self.test_nc_fn = open(os.path.join(self.complex_out.workdir, 'test.nc'), 'wb')
 
         self.test_fn = os.path.join(self.complex_out.workdir, 'test.json')
         with open(self.test_fn, 'w') as f:
@@ -298,6 +308,9 @@ class ComplexOutputTest(unittest.TestCase):
         self.assertEqual(self.complex_out.validator,
                          get_validator('application/json'))
 
+        self.assertEqual(self.complex_out_nc.validator,
+                         get_validator('application/x-netcdf'))
+
     def test_file_handler(self):
         self.complex_out.file = self.test_fn
         self.assertEqual(self.complex_out.data, self.data)
@@ -310,10 +323,19 @@ class ComplexOutputTest(unittest.TestCase):
         with open(urlparse(self.complex_out.url).path) as f:
             self.assertEqual(f.read(), self.data)
 
+    def test_file_handler_netcdf(self):
+        self.complex_out_nc.file = self.ncfile
+        data = self.complex_out_nc.base64
+
     def test_data_handler(self):
         self.complex_out.data = self.data
         with open(self.complex_out.file) as f:
             self.assertEqual(f.read(), self.data)
+
+    def test_base64(self):
+        self.complex_out.data = self.data
+        b = self.complex_out.base64
+        self.assertEqual(base64.b64decode(b), self.data)
 
     def test_url_handler(self):
         wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \


### PR DESCRIPTION
# Overview

Fixes issue with ComplexOutput and as_reference. 

When ComplexOutput was set by a file, it forced as_reference to True. 
Binary data was output as string instead of base64. 
Also, the raw CDATA content had extra white space. 

# Related Issue / Discussion
https://github.com/geopython/pywps/issues/412

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
