### PR TITLE
Do not call Session.close_all

### DIFF
--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -155,7 +155,6 @@ def get_session():
         _LAST_SESSION.close()
 
     if _SESSION_MAKER:
-        _SESSION_MAKER.close_all()
         _LAST_SESSION = _SESSION_MAKER()
         return _LAST_SESSION
 


### PR DESCRIPTION

# Overview


Do not call Session.close_all as this will close all the Sessions that exist in memory, including the sessions that are specific to the application and unrelated to PyPWS.

And here the closing of sessions is already handled by _LAST_SESSION.close(), so we can just remove the call to _SESSION_MAKER.close_all.

# Related Issue / Discussion

None

# Additional Information

None. The overview covers it all.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
