### PR TITLE
Fix error messages

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -114,7 +114,7 @@ class Service(object):
             if not request_inputs:
                 if inpt._default is not None:
                     if not inpt.data_set and isinstance(inpt, ComplexInput):
-                            inpt._set_default_value()
+                        inpt._set_default_value()
 
                     data_inputs[inpt.identifier] = [inpt.clone()]
             else:

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -41,7 +41,7 @@ class NoApplicableCode(HTTPException):
         self.code = code
         self.description = description
         self.locator = locator
-        msg = 'Exception: code: {}, locator: {}, description: {}'.format(self.code, self.description, self.locator)
+        msg = 'Exception: code: {}, description: {}, locator: {}'.format(self.code, self.description, self.locator)
         LOGGER.exception(msg)
 
         HTTPException.__init__(self)

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -434,12 +434,11 @@ class UrlHandler(FileHandler):
         except Exception as e:
             raise NoApplicableCode('File reference error: {}'.format(e))
 
-        FSEE = FileSizeExceeded(
-            'File size for input {} exceeded. Maximum allowed: {} megabytes'.
-            format(getattr(self.inpt, 'identifier', '?'), max_byte_size))
+        error_message = 'File size for input "{}" exceeded. Maximum allowed: {} megabytes'.format(
+            self.inpt.get('identifier', '?'), max_byte_size)
 
         if int(data_size) > int(max_byte_size):
-            raise FSEE
+            raise FileSizeExceeded(error_message)
 
         try:
             with open(self._file, 'wb') as f:
@@ -447,7 +446,7 @@ class UrlHandler(FileHandler):
                 for chunk in reference_file.iter_content(chunk_size=1024):
                     data_size += len(chunk)
                     if int(data_size) > int(max_byte_size):
-                        raise FSEE
+                        raise FileSizeExceeded(error_message)
                     f.write(chunk)
 
         except Exception as e:


### PR DESCRIPTION
# Overview

- remove unnecessary error message in logs about file size exceeded

(When an exception is instantiated, it is logged. Even if it's not
raised. So don't instantiate it unless there is an actual error)

- switch description and locator properties for error messages 

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
