### PR TITLE
Improve queue race conditions

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -270,6 +270,7 @@ class Process(object):
             process._set_uuid(uuid)
             process.async = True
             new_wps_response = ExecuteResponse(new_wps_request, process=process, uuid=uuid)
+            new_wps_response.store_status_file = True
             process._run_async(new_wps_request, new_wps_response)
         except Exception as e:
             LOGGER.exception("Could not run stored process. {}".format(e))

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -147,8 +147,8 @@ class Process(object):
         """
 
         maxparallel = int(config.get_config_value('server', 'parallelprocesses'))
-        running = dblog.get_running().count()
-        stored = dblog.get_stored().count()
+
+        running, stored = dblog.get_process_counts()
 
         # async
         if async:

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -243,8 +243,13 @@ class Process(object):
         try:
             LOGGER.debug("Checking for stored requests")
 
-            stored_request = dblog.get_first_stored()
-            if not stored_request:
+            for _ in range(2):
+                stored_request = dblog.pop_first_stored()
+                if stored_request:
+                    break
+                LOGGER.debug("No stored request found, retrying in 1 second")
+                time.sleep(1)
+            else:
                 LOGGER.debug("No stored request found")
                 return
 
@@ -260,7 +265,6 @@ class Process(object):
             process.async = True
             new_wps_response = ExecuteResponse(new_wps_request, process=process, uuid=uuid)
             process._run_async(new_wps_request, new_wps_response)
-            dblog.remove_stored(uuid)
         except Exception as e:
             LOGGER.error("Could not run stored process. {}".format(e))
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -9,6 +9,7 @@ import sys
 import traceback
 import json
 import shutil
+import time
 import tempfile
 
 from pywps import get_ElementMakerForVersion, E, dblog

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -78,28 +78,23 @@ def log_request(uuid, request):
     # NoApplicableCode("Could commit to database: {}".format(e.message))
 
 
-def get_running():
-    """Returns running processes ids
+def get_process_counts():
+    """Returns running and stored process counts and
     """
 
     session = get_session()
-    running = session.query(ProcessInstance).filter(
-        ProcessInstance.percent_done < 100).filter(
-            ProcessInstance.percent_done > -1)
-
+    stored_query = session.query(RequestInstance.uuid)
+    running_count = (
+        session.query(ProcessInstance)
+        .filter(ProcessInstance.percent_done < 100)
+        .filter(ProcessInstance.percent_done > -1)
+        .filter(~ProcessInstance.uuid.in_(stored_query))
+        .count()
+    )
+    stored_count = stored_query.count()
     session.close()
-    return running
+    return running_count, stored_count
 
-
-def get_stored():
-    """Returns running processes ids
-    """
-
-    session = get_session()
-    stored = session.query(RequestInstance)
-
-    session.close()
-    return stored
 
 
 def get_first_stored():

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -96,14 +96,19 @@ def get_process_counts():
     return running_count, stored_count
 
 
-
-def get_first_stored():
-    """Returns running processes ids
+def pop_first_stored():
+    """Gets the first stored process and delete it from the stored_requests table
     """
-
     session = get_session()
     request = session.query(RequestInstance).first()
 
+    if request:
+        delete_count = session.query(RequestInstance).filter_by(uuid=request.uuid).delete()
+        if delete_count == 0:
+            LOGGER.debug("Another thread or process took the same stored request")
+            request = None
+
+        session.commit()
     return request
 
 

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -198,14 +198,3 @@ def store_process(uuid, request):
     session.add(request)
     session.commit()
     session.close()
-
-
-def remove_stored(uuid):
-    """Remove given request from stored requests
-    """
-
-    session = get_session()
-    request = session.query(RequestInstance).filter_by(uuid=str(uuid)).first()
-    session.delete(request)
-    session.commit()
-    session.close()


### PR DESCRIPTION
# Overview

When I tested sending lots of small requests to pywps:

- Multiple threads couldn't write to the database at the same time (a global session was shared between threads)
- Workers would take the same request twice from the stored_requests table
- Unfinished requests would pile up and being considered as running, even though an error happened

I found that making Pywps completely threadsafe and multi-process safe is challenging. When I started using locks, the forked Pywps workers would copy the opened lock to the forked process, leading to a deadlock.

Another solution would be to [spawn](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) processes instead of forking them. But this is Python 3.4+ only.

So I fixed a few things so that race conditions are less likely to happen.

# Related Issue / Discussion

Also, I think 24f48dd fixes #450

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
