### PR TITLE
remove a sleep timer that is only useful for async requests

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -250,13 +250,8 @@ class Process(object):
         try:
             LOGGER.debug("Checking for stored requests")
 
-            for _ in range(2):
-                stored_request = dblog.pop_first_stored()
-                if stored_request:
-                    break
-                LOGGER.debug("No stored request found, retrying in 1 second")
-                time.sleep(1)
-            else:
+            stored_request = dblog.pop_first_stored()
+            if not stored_request:
                 LOGGER.debug("No stored request found")
                 return
 


### PR DESCRIPTION
But annoying for sync requests and tests. The purpose of this timer is to
cover a case when a request finishes more or less at the same
time another is stored. The stored request is not started until another
request ends.

Introduced in #455 that was recently merged.

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
