### PR TITLE
fix for `allowed_values == AnyValue` in templates

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -288,6 +288,7 @@ class LiteralInput(basic.LiteralInput):
             'data_type': self.data_type,
             'workdir': self.workdir,
             'allowed_values': [value.json for value in self.allowed_values],
+            'any_value': self.any_value,
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
             'max_occurs': self.max_occurs,
@@ -329,6 +330,7 @@ class LiteralInput(basic.LiteralInput):
         uom = json_input.pop('uom', None)
         metadata = json_input.pop('metadata', [])
         json_input.pop('type')
+        json_input.pop('any_value', None)
 
         instance = cls(**json_input)
 

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -83,8 +83,6 @@ class AllowedValue(object):
                  minval=None, maxval=None, spacing=None,
                  range_closure=RANGECLOSURETYPE.CLOSED):
 
-        AnyValue.__init__(self)
-
         self.allowed_type = allowed_type
         self.value = value
         self.minval = minval
@@ -93,14 +91,15 @@ class AllowedValue(object):
         self.range_closure = range_closure
 
     def __eq__(self, other):
-        return all([
-            self.allowed_type == other.allowed_type,
-            self.value == other.value,
-            self.minval == other.minval,
-            self.maxval == other.maxval,
-            self.spacing == other.spacing,
-            self.range_closure == other.range_closure,
-        ])
+        return (
+            isinstance(other, AllowedValue)
+            and self.allowed_type == other.allowed_type
+            and self.value == other.value
+            and self.minval == other.minval
+            and self.maxval == other.maxval
+            and self.spacing == other.spacing
+            and self.range_closure == other.range_closure
+        )
 
     @property
     def json(self):
@@ -116,6 +115,9 @@ class AllowedValue(object):
             'spacing': self.spacing,
             'range_closure': self.range_closure
         }
+
+
+ALLOWED_VALUES_TYPES = (AllowedValue, AnyValue, NoValue, ValuesReference)
 
 
 def get_converter(convertor):
@@ -341,7 +343,9 @@ def make_allowedvalues(allowed_values):
 
     for value in allowed_values:
 
-        if isinstance(value, (AllowedValue, AnyValue, NoValue, ValuesReference)):
+        if value in ALLOWED_VALUES_TYPES:
+            new_allowedvalues.append(value())
+        elif isinstance(value, ALLOWED_VALUES_TYPES):
             new_allowedvalues.append(value)
 
         elif type(value) == tuple or type(value) == list:

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -336,8 +336,10 @@ def make_allowedvalues(allowed_values):
     for value in allowed_values:
 
         if value in ALLOWED_VALUES_TYPES:
+            # value is equal to one of the allowed classes objects
             new_allowedvalues.append(value())
         elif isinstance(value, ALLOWED_VALUES_TYPES):
+            # value is an instance of one of the allowed classes
             new_allowedvalues.append(value)
 
         elif type(value) == tuple or type(value) == list:

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -91,15 +91,7 @@ class AllowedValue(object):
         self.range_closure = range_closure
 
     def __eq__(self, other):
-        return (
-            isinstance(other, AllowedValue)
-            and self.allowed_type == other.allowed_type
-            and self.value == other.value
-            and self.minval == other.minval
-            and self.maxval == other.maxval
-            and self.spacing == other.spacing
-            and self.range_closure == other.range_closure
-        )
+        return isinstance(other, AllowedValue) and self.json == other.json
 
     @property
     def json(self):

--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -11,12 +11,14 @@
                     </Supported>
                 </UOMs>
                 {% endif %}
-                {% if put.allowed_values %}
+                {% if put.any_value %}
+                <ows:AnyValue />
+                {% elif put.allowed_values %}
                 <ows:AllowedValues>
-                {% for value in put.allowed_values %}
-                {% if value.allowed_type == "value" %}
+                    {% for value in put.allowed_values %}
+                    {% if value.allowed_type == "value" %}
                     <ows:Value>{{ value.value }}</ows:Value>
-                {% else %}
+                    {% else %}
                     <ows:Range ows:rangeClosure="{{ value.range_closure }}">
                         <ows:MinimumValue>{{ value.minval }}</ows:MinimumValue>
                         <ows:MaximumValue>{{ value.maxval }}</ows:MaximumValue>
@@ -24,11 +26,9 @@
                         <ows:Spacing>{{ value.spacing }}</ows:Spacing>
                         {% endif %}
                     </ows:Range>
-                {% endif %}
-                {% endfor %}
+                    {% endif %}
+                    {% endfor %}
                 </ows:AllowedValues>
-                {% elif put.any_value %}
-                <ows:AnyValue />
                 {% endif %}
                 {% if put.data %}
                 <DefaultValue>{{ put.data }}</DefaultValue>

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -21,7 +21,7 @@ from pywps.app.Common import Metadata
 from pywps.validator import get_validator
 from pywps.inout.basic import IOHandler, SOURCE_TYPE, SimpleHandler, BBoxInput, BBoxOutput, \
     ComplexInput, ComplexOutput, LiteralOutput, LiteralInput, _is_textfile
-from pywps.inout.literaltypes import convert, AllowedValue
+from pywps.inout.literaltypes import convert, AllowedValue, AnyValue
 from pywps._compat import StringIO, text_type, urlparse
 from pywps.validator.base import emptyvalidator
 from pywps.exceptions import InvalidParameterValue
@@ -327,7 +327,7 @@ class SerializationLiteralInputTest(unittest.TestCase):
             min_occurs=2,
             max_occurs=5,
             mode=MODE.STRICT,
-            allowed_values=[AllowedValue(value='something'), AllowedValue(value='something else')],
+            allowed_values=[AllowedValue(value='something'), AllowedValue(value='something else'), AnyValue()],
             default="something else",
             default_type=SOURCE_TYPE.DATA,
         )
@@ -349,6 +349,8 @@ class SerializationLiteralInputTest(unittest.TestCase):
         self.assertEqual(literal_1.max_occurs, literal_2.max_occurs)
         self.assertEqual(literal_1.valid_mode, literal_2.valid_mode)
         self.assertEqual(literal_1.allowed_values, literal_2.allowed_values)
+        self.assertEqual(literal_1.any_value, literal_2.any_value)
+        self.assertTrue(literal_1.any_value)
         self.assertEqual(literal_1.as_reference, literal_2.as_reference)
 
         self.assertEqual(literal_1.data, literal_2.data)


### PR DESCRIPTION
# Overview

The `any_value` parameter was left out of the `LiteralInput` serialization, but the xml template response depends on it.

# Related Issue / Discussion

#456 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
