### PR TITLE
fix sphinx build

### DIFF
--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -76,7 +76,7 @@ class ProcessDocumenter(ClassDocumenter):
                 doc += ', units:[{}]'.format(', '.join([u.uom for u in obj.uoms]))
 
         except Exception as e:
-            raise type(e)(e.message + ' in {0} docstring'.format(self.object().identifier))
+            raise type(e)('{0} in {1} docstring'.format(e, self.object().identifier))
         return doc
 
     def make_numpy_doc(self):

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -37,7 +37,12 @@ LITERAL_DATA_TYPES = ('float', 'boolean', 'integer', 'string',
 
 class AnyValue(object):
     """Any value for literal input
+    NOTE: not really implemented
     """
+
+    @property
+    def value(self):
+        return None
 
     @property
     def json(self):


### PR DESCRIPTION
# Overview

Sphinx build was failing due to this errors:
* `AttributeError` exception having no `message` on Python 3.6.
* `AnyValue` missing `value`. 

Note, `AnyValue` is not really implemented yet.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
