### PR TITLE
fixed AllowedValue range

### DIFF
--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -84,20 +84,23 @@ class AllowedValue(object):
     :param pywps.input.literaltypes.RANGECLOSURETYPE range_closure:
     """
 
-    def __init__(self, value=None,
+    def __init__(self, allowed_type=None, value=None,
                  minval=None, maxval=None, spacing=None,
                  range_closure=RANGECLOSURETYPE.CLOSED):
 
+        self.allowed_type = allowed_type
         self.value = value
         self.minval = minval
         self.maxval = maxval
         self.spacing = spacing
         self.range_closure = range_closure
 
-        if self.minval or self.maxval or self.spacing:
-            self.allowed_type = ALLOWEDVALUETYPE.RANGE
-        else:
-            self.allowed_type = ALLOWEDVALUETYPE.VALUE
+        if not self.allowed_type:
+            # automatically set allowed_type: RANGE or VALUE
+            if self.minval or self.maxval or self.spacing:
+                self.allowed_type = ALLOWEDVALUETYPE.RANGE
+            else:
+                self.allowed_type = ALLOWEDVALUETYPE.VALUE
 
     def __eq__(self, other):
         return isinstance(other, AllowedValue) and self.json == other.json

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -84,16 +84,20 @@ class AllowedValue(object):
     :param pywps.input.literaltypes.RANGECLOSURETYPE range_closure:
     """
 
-    def __init__(self, allowed_type=ALLOWEDVALUETYPE.VALUE, value=None,
+    def __init__(self, value=None,
                  minval=None, maxval=None, spacing=None,
                  range_closure=RANGECLOSURETYPE.CLOSED):
 
-        self.allowed_type = allowed_type
         self.value = value
         self.minval = minval
         self.maxval = maxval
         self.spacing = spacing
         self.range_closure = range_closure
+
+        if self.minval or self.maxval or self.spacing:
+            self.allowed_type = ALLOWEDVALUETYPE.RANGE
+        else:
+            self.allowed_type = ALLOWEDVALUETYPE.VALUE
 
     def __eq__(self, other):
         return isinstance(other, AllowedValue) and self.json == other.json
@@ -357,8 +361,7 @@ def make_allowedvalues(allowed_values):
                 spacing = value[1]
                 maxval = value[2]
             new_allowedvalues.append(
-                AllowedValue(allowed_type=ALLOWEDVALUETYPE.RANGE,
-                             minval=minval, maxval=maxval,
+                AllowedValue(minval=minval, maxval=maxval,
                              spacing=spacing)
             )
 

--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -86,13 +86,13 @@ def _validate_range(interval, data):
 
         if passed:
             if interval.range_closure == RANGECLOSURETYPE.OPEN:
-                passed = (interval.minval <= data <= interval.maxval)
-            elif interval.range_closure == RANGECLOSURETYPE.CLOSED:
                 passed = (interval.minval < data < interval.maxval)
+            elif interval.range_closure == RANGECLOSURETYPE.CLOSED:
+                passed = (interval.minval <= data <= interval.maxval)
             elif interval.range_closure == RANGECLOSURETYPE.OPENCLOSED:
-                passed = (interval.minval <= data < interval.maxval)
-            elif interval.range_closure == RANGECLOSURETYPE.CLOSEDOPEN:
                 passed = (interval.minval < data <= interval.maxval)
+            elif interval.range_closure == RANGECLOSURETYPE.CLOSEDOPEN:
+                passed = (interval.minval <= data < interval.maxval)
     else:
         passed = False
 

--- a/tests/validator/test_literalvalidators.py
+++ b/tests/validator/test_literalvalidators.py
@@ -10,12 +10,12 @@ import unittest
 from pywps.validator.literalvalidator import *
 from pywps.inout.literaltypes import AllowedValue
 
-def get_input(allowed_values, data = 1):
+
+def get_input(allowed_values, data=1):
 
     class FakeInput(object):
         data = 1
         data_type = 'data'
-
 
     fake_input = FakeInput()
     fake_input.data = data
@@ -35,7 +35,7 @@ class ValidateTest(unittest.TestCase):
 
     def test_anyvalue_validator(self):
         """Test anyvalue validator"""
-        inpt = get_input(allowed_values = None)
+        inpt = get_input(allowed_values=None)
         self.assertTrue(validate_anyvalue(inpt, MODE.NONE))
 
     def test_allowedvalues_values_validator(self):
@@ -44,7 +44,7 @@ class ValidateTest(unittest.TestCase):
         allowed_value.allowed_type = ALLOWEDVALUETYPE.VALUE
         allowed_value.value = 1
 
-        inpt = get_input(allowed_values = [allowed_value])
+        inpt = get_input(allowed_values=[allowed_value])
         self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Allowed value 1 allowed')
 
         inpt.data = 2
@@ -58,12 +58,12 @@ class ValidateTest(unittest.TestCase):
         allowed_value.minval = 1
         allowed_value.maxval = 11
         allowed_value.spacing = 2
-        allowed_value.range_closure = RANGECLOSURETYPE.OPEN
+        allowed_value.range_closure = RANGECLOSURETYPE.CLOSED
 
-        inpt = get_input(allowed_values = [allowed_value])
+        inpt = get_input(allowed_values=[allowed_value])
 
         inpt.data = 1
-        self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range OPEN closure')
+        self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range CLOSED closure')
 
         inpt.data = 12
         self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'Value too big')
@@ -76,12 +76,13 @@ class ValidateTest(unittest.TestCase):
 
         inpt.data = 11
         allowed_value.range_closure = RANGECLOSURETYPE.OPEN
-        self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Open Range')
+        self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'Open Range')
 
+        inpt.data = 1
         allowed_value.range_closure = RANGECLOSURETYPE.OPENCLOSED
         self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'OPENCLOSED Range')
 
-        inpt.data = 1
+        inpt.data = 11
         allowed_value.range_closure = RANGECLOSURETYPE.CLOSEDOPEN
         self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'CLOSEDOPEN Range')
 
@@ -93,16 +94,16 @@ class ValidateTest(unittest.TestCase):
         allowed_value1.minval = 1
         allowed_value1.maxval = 11
         allowed_value1.spacing = 2
-        allowed_value1.range_closure = RANGECLOSURETYPE.OPEN
+        allowed_value1.range_closure = RANGECLOSURETYPE.CLOSED
 
         allowed_value2 = AllowedValue()
         allowed_value2.allowed_type = ALLOWEDVALUETYPE.VALUE
         allowed_value2.value = 15
 
-        inpt = get_input(allowed_values = [allowed_value1, allowed_value2])
+        inpt = get_input(allowed_values=[allowed_value1, allowed_value2])
 
         inpt.data = 1
-        self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range OPEN closure')
+        self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'Range CLOSED closure')
 
         inpt.data = 15
         self.assertTrue(validate_allowed_values(inpt, MODE.SIMPLE), 'AllowedValue')


### PR DESCRIPTION
# Overview

This PR fixes the `AllowedValue` for range values:

* Implicitly sets allowed_type to `RANGE` or `VALUE`,
* fixes the closure, see description in ows:schema below.

# Related Issue / Discussion

# Additional Information

OWS Schema:
https://www.mediamaps.ch/ogc/schemas-xsdoc/sld/1.2/owsDomainType_xsd.html#rangeClosure

closed: The specified minimum and maximum values are included in this range.

open: The specified minimum and maximum values are NOT included in this range.


# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
