### PR TITLE
Fix 406 user exceptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,10 @@ Process
 
 .. autoclass:: Process
 
+Exceptions you can raise in the process implementation to show a user-friendly error message.
+
+.. autoclass:: pywps.app.exceptions.ProcessError
+
 Inputs and outputs
 ==================
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -388,6 +388,42 @@ Example process
 .. literalinclude:: metalinkprocess.py
    :language: python
 
+Process Exceptions
+==================
+
+Any uncatched exception in the process execution will be handled by PyWPS and reported
+to the WPS client using an `ows:Exception`. PyWPS will only log the traceback and report
+a common error message like:
+
+    *Process failed, please check server error log.*
+
+This sparse error message is used to avoid security issues by providing internal
+service information in an uncontrolled way.
+
+But in some cases you want to provide a user-friendly error message to give the user a hint of
+what went wrong with the processing job. In this case you can use the :class:`ProcessError`
+exception. The error message will be send to the user encapsulated as `ows:Exception`.
+The class:`ProcessError` validates the error message to make sure it is not too long
+and it does not contain any suspicious characters.
+
+.. note::
+    By default a valid error message must have a length between 3 and 144 characters.
+    Only alpha-numeric characters and a few special ones are allowed.
+    The allowed special characters are: ".", ":", "!", "?", "=", ",", "-".
+
+.. note::
+    During the process development you might want to get traceback shown in `ows:Exception`.
+    This is possible by running PyWPS in debug mode. In `pywps.cfg` config file set::
+        [logging]
+        level=DEBUG
+
+
+Example process
+---------------
+
+.. literalinclude:: show_error.py
+   :language: python
+
 Process deployment
 ==================
 In order for clients to invoke processes, a PyWPS

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -401,9 +401,9 @@ This sparse error message is used to avoid security issues by providing internal
 service information in an uncontrolled way.
 
 But in some cases you want to provide a user-friendly error message to give the user a hint of
-what went wrong with the processing job. In this case you can use the :class:`ProcessError`
+what went wrong with the processing job. In this case you can use the :class:`pywps.app.exceptions.ProcessError`
 exception. The error message will be send to the user encapsulated as `ows:Exception`.
-The class:`ProcessError` validates the error message to make sure it is not too long
+The :class:`pywps.app.exceptions.ProcessError` validates the error message to make sure it is not too long
 and it does not contain any suspicious characters.
 
 .. note::
@@ -412,11 +412,11 @@ and it does not contain any suspicious characters.
     The allowed special characters are: ".", ":", "!", "?", "=", ",", "-".
 
 .. note::
-    During the process development you might want to get traceback shown in `ows:Exception`.
+    During the process development you might want to get a traceback shown in `ows:Exception`.
     This is possible by running PyWPS in debug mode. In `pywps.cfg` config file set::
+
         [logging]
         level=DEBUG
-
 
 Example process
 ---------------

--- a/docs/show_error.py
+++ b/docs/show_error.py
@@ -1,0 +1,36 @@
+from pywps import Process, LiteralInput
+from pywps.app.Common import Metadata
+from pywps.app.exceptions import ProcessError
+
+import logging
+LOGGER = logging.getLogger("PYWPS")
+
+
+class ShowError(Process):
+    def __init__(self):
+        inputs = [
+            LiteralInput('message', 'Error Message', data_type='string',
+                         abstract='Enter an error message that will be returned.',
+                         default="This process failed intentionally.",
+                         min_occurs=1,)]
+
+        super(ShowError, self).__init__(
+            self._handler,
+            identifier='show_error',
+            title='Show a WPS Error',
+            abstract='This process will fail intentionally with a WPS error message.',
+            metadata=[
+                Metadata('User Guide', 'https://pywps.org/')],
+            version='1.0',
+            inputs=inputs,
+            # outputs=outputs,
+            store_supported=True,
+            status_supported=True
+        )
+
+    @staticmethod
+    def _handler(request, response):
+        response.update_status('PyWPS Process started.', 0)
+
+        LOGGER.info("Raise intentionally an error ...")
+        raise ProcessError(request.inputs['message'][0].data)

--- a/docs/wps.rst
+++ b/docs/wps.rst
@@ -145,8 +145,8 @@ server:
     Although this is usually used for `ComplexData` input type, it can be used
     for literal and bounding box data too.
 
-Sychronous versus asynchronous process request
-----------------------------------------------
+Synchronous versus asynchronous process request
+-----------------------------------------------
 
 There are two modes of process instance execution: Synchronous and asynchronous.
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -235,9 +235,12 @@ class Process(object):
 
             msg = 'Process error: method={}.{}, line={}, msg={}'.format(fname, method_name, exc_tb.tb_lineno, e)
             LOGGER.error(msg)
+            # In case of a ProcessError use the validated exception message.
             if isinstance(e, ProcessError):
                 msg = "Process error: {}".format(e)
+            # Only in debug mode we use the log message including the traceback ...
             elif config.get_config_value("logging", "level") != "DEBUG":
+                # ... otherwise we use a sparse common error message.
                 msg = 'Process failed, please check server error log'
             wps_response._update_status(WPS_STATUS.FAILED, msg, 100)
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -21,6 +21,7 @@ import pywps.configuration as config
 from pywps._compat import PY2
 from pywps.exceptions import (StorageNotSupported, OperationNotSupported,
                               ServerBusy, NoApplicableCode)
+from pywps.app.exceptions import ProcessError
 
 
 LOGGER = logging.getLogger("PYWPS")
@@ -232,9 +233,11 @@ class Process(object):
 
             # update the process status to display process failed
 
-            msg = 'Process error: {}.{} Line {} {}'.format(fname, method_name, exc_tb.tb_lineno, e)
+            msg = 'Process error: method={}.{}, line={}, msg={}'.format(fname, method_name, exc_tb.tb_lineno, e)
             LOGGER.error(msg)
-            if config.get_config_value("logging", "level") != "DEBUG":
+            if isinstance(e, ProcessError):
+                msg = "Process error: {}".format(e)
+            elif config.get_config_value("logging", "level") != "DEBUG":
                 msg = 'Process failed, please check server error log'
             wps_response._update_status(WPS_STATUS.FAILED, msg, 100)
 

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -1,0 +1,68 @@
+##################################################################
+# Copyright 2018 Open Source Geospatial Foundation and others    #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+"""
+Process exceptions raised intentionally in processes to provide information for users.
+"""
+
+
+class ProcessError(Exception):
+    min_msg_length = 3
+    max_msg_length = 144
+    allowed_chars = ['.', ':', '!', '?', '=', ',', '-']
+    default_msg = 'Sorry, process failed.'
+
+    def __init__(self, msg=None):
+        self.msg = msg
+
+    def __str__(self):
+        return self.message
+
+    def _validate_message(self):
+        valid = False
+        if self.msg and len(self.msg) <= self.max_msg_length and \
+           len(self.msg) >= self.min_msg_length:
+            # remove spaces
+            test_str = self.msg.replace(' ', '')
+            # remove allowed non alpha-numeric chars
+            for char in self.allowed_chars:
+                test_str = test_str.replace(char, '')
+            # only alpha numeric string accepted
+            valid = test_str.isalnum()
+        return valid
+
+    @property
+    def message(self):
+        if self._validate_message():
+            new_msg = "{}".format(self.msg)
+        else:
+            new_msg = self.default_msg
+        return new_msg
+
+
+class StorageLimitExceeded(ProcessError):
+    default_msg = 'You have exceeded the storage limit'
+
+    def __init__(self, msg=None, used=None, available=None):
+        if used and available:
+            msg = msg or self.default_msg
+            self.msg = "{}: used={}, available={}".format(msg, used, available)
+        else:
+            self.msg = msg
+
+
+class TimeLimitExceeded(StorageLimitExceeded):
+    default_msg = 'You have exceeded the time limit'
+
+
+class DryRunWarning(ProcessError):
+    default_msg = 'You have submitted a job in dry-run mode'
+
+    def __init__(self, msg=None, storage_used=None, time_used=None):
+        if storage_used and time_used:
+            msg = msg or self.default_msg
+            self.msg = "{}. Used resources: storage={}, time={}".format(msg, storage_used, time_used)
+        else:
+            self.msg = msg

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -40,29 +40,3 @@ class ProcessError(Exception):
         else:
             new_msg = self.default_msg
         return new_msg
-
-
-class StorageLimitExceeded(ProcessError):
-    default_msg = 'You have exceeded the storage limit'
-
-    def __init__(self, msg=None, used=None, available=None):
-        if used and available:
-            msg = msg or self.default_msg
-            self.msg = "{}: used={}, available={}".format(msg, used, available)
-        else:
-            self.msg = msg
-
-
-class TimeLimitExceeded(StorageLimitExceeded):
-    default_msg = 'You have exceeded the time limit'
-
-
-class DryRunWarning(ProcessError):
-    default_msg = 'You have submitted a job in dry-run mode'
-
-    def __init__(self, msg=None, storage_used=None, time_used=None):
-        if storage_used and time_used:
-            msg = msg or self.default_msg
-            self.msg = "{}. Used resources: storage={}, time={}".format(msg, storage_used, time_used)
-        else:
-            self.msg = msg

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -9,6 +9,13 @@ Process exceptions raised intentionally in processes to provide information for 
 
 
 class ProcessError(Exception):
+    """:class:`pywps.app.exceptions.ProcessError` is an :class:`Exception`
+    you can intentionally raise in a process
+    to provide a user-friendly error message.
+    The error message gets validated (3<= message length <=144) and only
+    alpha numeric characters and a few special characters are allowed.
+    The special characters are: `.`, `:`, `!`, `?`, `=`, `,`, `-`.
+    """
     min_msg_length = 3
     max_msg_length = 144
     allowed_chars = ['.', ':', '!', '?', '=', ',', '-']

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -12,7 +12,7 @@ class ProcessError(Exception):
     min_msg_length = 3
     max_msg_length = 144
     allowed_chars = ['.', ':', '!', '?', '=', ',', '-']
-    default_msg = 'Sorry, process failed.'
+    default_msg = 'Sorry, process failed. Please check server error log.'
 
     def __init__(self, msg=None):
         self.msg = msg
@@ -22,8 +22,7 @@ class ProcessError(Exception):
 
     def _validate_message(self):
         valid = False
-        if self.msg and len(self.msg) <= self.max_msg_length and \
-           len(self.msg) >= self.min_msg_length:
+        if self.msg and self.min_msg_length <= len(self.msg) <= self.max_msg_length:
             # remove spaces
             test_str = self.msg.replace(' ', '')
             # remove allowed non alpha-numeric chars


### PR DESCRIPTION
# Overview

This PR introduces new exceptions which can be raised from the process code. 

Unlike to common exceptions, a message send using the new `ProcessError` exception will be returned to the user (wps client) via an OGC exception. The message text is validated before sending (not too long, no suspicious chars). If the message is not valid then a default message will be used.

This `ProcessError` exception is intentionally used to provide some "meaningful" information to the user of what went wrong. Otherwise we always get the message "sorry, something went wrong, please check the logs", which is of not much help to end-users. 

This PR fixes #406.

# Related Issue / Discussion

#406.

# Additional Information

See an example in Emu:
https://github.com/bird-house/emu/blob/758563fdee2f468c0e94392192475e3d3ca5037e/emu/processes/wps_error.py#L38

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
