### PR TITLE
fixed ValuesReference implementation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,6 +37,8 @@ LiteralData
 
 .. autoclass:: pywps.inout.literaltypes.AllowedValue
 
+.. autoclass:: pywps.inout.literaltypes.ValuesReference
+
 .. autodata:: pywps.inout.literaltypes.LITERAL_DATA_TYPES
 
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -255,15 +255,15 @@ class LiteralInput(basic.LiteralInput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     """
 
-    def __init__(self, identifier, title=None, data_type='integer', workdir=None, abstract='', keywords=[],
+    def __init__(self, identifier, title=None, data_type=None, workdir=None, abstract='', keywords=[],
                  metadata=[], uoms=None,
                  min_occurs=1, max_occurs=1,
-                 mode=MODE.SIMPLE, allowed_values=AnyValue,
+                 mode=MODE.SIMPLE, allowed_values=None,
                  default=None, default_type=basic.SOURCE_TYPE.DATA):
 
         """Constructor
         """
-
+        data_type = data_type or 'string'
         basic.LiteralInput.__init__(self, identifier, title=title,
                                     data_type=data_type, workdir=workdir, abstract=abstract,
                                     keywords=keywords, metadata=metadata,
@@ -289,6 +289,7 @@ class LiteralInput(basic.LiteralInput):
             'workdir': self.workdir,
             'allowed_values': [value.json for value in self.allowed_values],
             'any_value': self.any_value,
+            'values_reference': self.values_reference,
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
             'max_occurs': self.max_occurs,
@@ -331,6 +332,7 @@ class LiteralInput(basic.LiteralInput):
         metadata = json_input.pop('metadata', [])
         json_input.pop('type')
         json_input.pop('any_value', None)
+        json_input.pop('values_reference', None)
 
         instance = cls(**json_input)
 

--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -12,7 +12,9 @@
                 </UOMs>
                 {% endif %}
                 {% if put.any_value %}
-                <ows:AnyValue />
+                <ows:AnyValue/>
+                {% elif put.values_reference %}
+                <ows:ValuesReference ows:reference="{{ put.values_reference.reference }}"/>
                 {% elif put.allowed_values %}
                 <ows:AllowedValues>
                     {% for value in put.allowed_values %}

--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -16,11 +16,45 @@ from pywps.validator.allowed_value import ALLOWEDVALUETYPE, RANGECLOSURETYPE
 LOGGER = logging.getLogger('PYWPS')
 
 
+def validate_value(data_input, mode):
+    """Validate a literal value of type string, integer etc.
+
+    TODO: not fully implemented
+    """
+    if mode == MODE.NONE:
+        passed = True
+    else:
+        LOGGER.debug('validating literal value.')
+        data_input.data
+        # TODO: we currently rely only on the data conversion in `pywps.inout.literaltypes.convert`
+        passed = True
+
+    LOGGER.debug('validation result: {}'.format(passed))
+    return passed
+
+
 def validate_anyvalue(data_input, mode):
     """Just placeholder, anyvalue is always valid
     """
 
     return True
+
+
+def validate_values_reference(data_input, mode):
+    """Validate values reference
+
+    TODO: not fully implemented
+    """
+    if mode == MODE.NONE:
+        passed = True
+    else:
+        LOGGER.debug('validating values reference.')
+        data_input.data
+        # TODO: we don't validate if the data is within the reference values
+        passed = True
+
+    LOGGER.debug('validation result: {}'.format(passed))
+    return passed
 
 
 def validate_allowed_values(data_input, mode):

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -149,7 +149,7 @@ class DescribeProcessInputTest(unittest.TestCase):
                 Metadata('process metadata 2', 'http://example.org/2')]
         )
         result = self.describe_process(hello_process)
-        assert result.inputs == [('the_name', 'literal', 'integer')]
+        assert result.inputs == [('the_name', 'literal', 'string')]
         assert result.metadata == ['process metadata 1', 'process metadata 2']
 
     def test_one_literal_integer_input(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -554,6 +554,7 @@ class LiteralInputTest(unittest.TestCase):
         self.literal_input = inout.inputs.LiteralInput(
             identifier="literalinput",
             title="Literal Input",
+            data_type='integer',
             mode=2,
             allowed_values=(1, 2, (3, 3, 12)),
             default=6,

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -9,6 +9,7 @@ import unittest
 import datetime
 from pywps.inout.literaltypes import *
 
+
 class ConvertorTest(unittest.TestCase):
     """IOHandler test cases"""
 

--- a/tests/validator/test_literalvalidators.py
+++ b/tests/validator/test_literalvalidators.py
@@ -8,7 +8,7 @@
 
 import unittest
 from pywps.validator.literalvalidator import *
-from pywps.inout.literaltypes import AllowedValue
+from pywps.inout.literaltypes import AllowedValue, AnyValue, ValuesReference
 
 
 def get_input(allowed_values, data=1):
@@ -33,10 +33,20 @@ class ValidateTest(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_value_validator(self):
+        """Test simple validator for string, integer, etc"""
+        inpt = get_input(allowed_values=None, data='test')
+        self.assertTrue(validate_value(inpt, MODE.SIMPLE))
+
     def test_anyvalue_validator(self):
         """Test anyvalue validator"""
-        inpt = get_input(allowed_values=None)
-        self.assertTrue(validate_anyvalue(inpt, MODE.NONE))
+        inpt = get_input(allowed_values=AnyValue())
+        self.assertTrue(validate_anyvalue(inpt, MODE.SIMPLE))
+
+    def test_values_reference_validator(self):
+        """Test ValuesReference validator"""
+        inpt = get_input(allowed_values=ValuesReference(reference='http://some.org?search=test&format=json'))
+        self.assertTrue(validate_values_reference(inpt, MODE.SIMPLE))
 
     def test_allowedvalues_values_validator(self):
         """Test allowed values - values"""
@@ -110,7 +120,6 @@ class ValidateTest(unittest.TestCase):
 
         inpt.data = 13
         self.assertFalse(validate_allowed_values(inpt, MODE.SIMPLE), 'Out of range')
-
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

This PR implements the literal value type `ValuesReference` as defined in the WPS 1.0.0 standard.

Changes:
* Fixed `AnyValue` flag ... it was always set for literal values.
* Implemented `ValuesReference`.
* Prepared validators for `ValuesReference` and `AllowedValue`.
* Updated tests.
* Updated docs.

The validator for `ValuesReference` is currently only a dummy implementation.

# Related Issue / Discussion

# Additional Information

* `ValuesReference` defined in WPS 1.0.0 standard, Table 29 and 30:

> References an externally defined finite set of values and ranges for this input

* See also `AllowedValue` range PR #467.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
