### PR TITLE
Fixed a bug in the execute xml jinja template

### DIFF
--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -48,12 +48,12 @@
             {% elif input.type == "bbox" %}
 			<wps:Data>
                 {% if input.crs == "EPSG:4326" %}
-                <ows:WGS84BoundingBox dimensions="{{ output.dimensions }}">
+                <ows:WGS84BoundingBox dimensions="{{ input.dimensions }}">
                     <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
                     <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
                 </ows:WGS84BoundingBox>
                 {% else %}
-                <ows:BoundingBox crs="{{ output.crs }}" dimensions="{{ output.dimensions }}">
+                <ows:BoundingBox crs="{{ input.crs }}" dimensions="{{ input.dimensions }}">
                     <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
                     <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
                 </ows:BoundingBox>


### PR DESCRIPTION
# Overview
Small issue that was causing the rendering of a result XML to crash when using a bbox input. 

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute this bugfix to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
