### PR TITLE
Fixed bbox handling for POST request

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -434,15 +434,15 @@ def get_inputs_from_xml(doc):
             the_inputs[identifier].append(inpt)
             continue
 
-        # OWSlib is not python 3 compatible yet
-        if PY2:
-            from owslib.ows import BoundingBox
-            bbox_datas = xpath_ns(input_el, './wps:Data/wps:BoundingBoxData')
-            if bbox_datas:
-                for bbox_data in bbox_datas:
-                    bbox_data_el = bbox_data
-                    bbox = BoundingBox(bbox_data_el)
-                    the_inputs[identifier].append(bbox)
+        # Using OWSlib BoundingBox
+        from owslib.ows import BoundingBox
+        bbox_datas = xpath_ns(input_el, './wps:Data/wps:BoundingBoxData')
+        if bbox_datas:
+            for bbox_data in bbox_datas:
+                bbox_data_el = bbox_data
+                bbox = BoundingBox(bbox_data_el)
+                the_inputs[identifier].append(bbox)
+                LOGGER.debug("parse bbox: {},{},{},{}".format(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy))
     return the_inputs
 
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -672,8 +672,20 @@ class BasicBoundingBox(object):
         self.crss = crss or ['epsg:4326']
         self.crs = self.crss[0]
         self.dimensions = dimensions
-        self.ll = []
-        self.ur = []
+
+    @property
+    def ll(self):
+        data = getattr(self, 'data', None)
+        if data:
+            return data[:2]
+        return []
+
+    @property
+    def ur(self):
+        data = getattr(self, 'data', None)
+        if data:
+            return data[2:]
+        return []
 
 
 class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -61,7 +61,9 @@ class BoundingBoxInput(basic.BBoxInput):
             'crs': self.crs,
             'crss': self.crss,
             'metadata': [m.json for m in self.metadata],
-            'bbox': (self.ll, self.ur),
+            'bbox': self.data,
+            'll': self.ll,
+            'ur': self.ur,
             'dimensions': self.dimensions,
             'workdir': self.workdir,
             'mode': self.valid_mode,
@@ -84,8 +86,7 @@ class BoundingBoxInput(basic.BBoxInput):
             min_occurs=json_input['min_occurs'],
             max_occurs=json_input['max_occurs'],
         )
-        instance.ll = json_input['bbox'][0]
-        instance.ur = json_input['bbox'][1]
+        instance.data = json_input['bbox']
 
         return instance
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -57,7 +57,9 @@ class BoundingBoxOutput(basic.BBoxOutput):
             'crs': self.crs,
             'crss': self.crss,
             'dimensions': self.dimensions,
-            'bbox': (self.ll, self.ur),
+            'bbox': self.data,
+            'll': self.ll,
+            'ur': self.ur,
             'workdir': self.workdir,
             'mode': self.valid_mode,
         }

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -411,7 +411,6 @@ class ExecuteTest(unittest.TestCase):
         assert get_output(resp.xml) == {'message': "Hello foo!"}
 
     def test_bbox(self):
-        self.skipTest('OWSlib not python 3 compatible')
         client = client_for(Service(processes=[create_bbox_process()]))
         request_doc = WPS.Execute(
             OWS.Identifier('my_bbox_process'),

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -434,13 +434,13 @@ class ExecuteTest(unittest.TestCase):
             output,
             './ows:Identifier')[0].text)
 
-        self.assertEqual('15 50', xpath_ns(
+        self.assertEqual(' 15  50 ', xpath_ns(
             output,
-            './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
+            './wps:Data/ows:WGS84BoundingBox/ows:LowerCorner')[0].text)
 
-        self.assertEqual('16 50', xpath_ns(
+        self.assertEqual(' 16  51 ', xpath_ns(
             output,
-            './wps:Data/ows:BoundingBox/ows:LowerCorner')[0].text)
+            './wps:Data/ows:WGS84BoundingBox/ows:UpperCorner')[0].text)
 
     def test_output_response_dataType(self):
         client = client_for(Service(processes=[create_greeter()]))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -659,8 +659,7 @@ class BoxInputTest(unittest.TestCase):
     def setUp(self):
 
         self.bbox_input = inout.inputs.BoundingBoxInput("bboxinput", title="BBox input", dimensions=2)
-        self.bbox_input.ll = [0, 1]
-        self.bbox_input.ur = [2, 4]
+        self.bbox_input.data = [0, 1, 2, 4]
 
     def test_contruct(self):
         self.assertIsInstance(self.bbox_input, BBoxInput)
@@ -672,7 +671,8 @@ class BoxInputTest(unittest.TestCase):
         self.assertTrue(out['title'], 'title does not exist')
         self.assertFalse(out['abstract'], 'abstract set')
         self.assertEqual(out['type'], 'bbox', 'type set')
-        self.assertTupleEqual(out['bbox'], ([0, 1], [2, 4]), 'data are tehre')
+        # self.assertTupleEqual(out['bbox'], ([0, 1], [2, 4]), 'data are there')
+        self.assertEqual(out['bbox'], [0, 1, 2, 4], 'data are there')
         self.assertEqual(out['dimensions'], 2, 'Dimensions set')
 
 


### PR DESCRIPTION
# Overview

This PR fixes the bbox handling for POST requests.

Changes:
* bbox support needs OWSLib which is now also available on Python 3.x.
* adds property `ll` and `ur` to `BasicBoundingBox` which relies on `data`.
* `data` is the only storage for coordinates.
* fixed json conversion and execute response template.
* fixed bbox tests.

# Related Issue / Discussion

#405

# Additional Information

bbox handling for GET is still broken #404.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
