### PR TITLE
fix for a LiteralInput with a default value of 0

### DIFF
--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -32,6 +32,6 @@
                     {% endfor %}
                 </ows:AllowedValues>
                 {% endif %}
-                {% if put.data %}
+                {% if put.data is not none %}
                 <DefaultValue>{{ put.data }}</DefaultValue>
                 {% endif %}


### PR DESCRIPTION
# Overview

When a LiteralInput is configured to have a default value of 0, or anything that is not None but 'falsy', The default is absent in the DescribeProcess template.

# Related Issue / Discussion

https://github.com/bird-house/birdy/issues/120

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
