### PR TITLE
use service_ok in tests

### DIFF
--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -4,6 +4,7 @@
 ##################################################################
 
 import lxml.etree
+import requests
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 from pywps import __version__
@@ -17,6 +18,22 @@ import re
 import logging
 
 logging.disable(logging.CRITICAL)
+
+
+def service_ok(url, timeout=5):
+    try:
+        resp = requests.get(url, timeout=timeout)
+        if 'html' in resp.headers['content-type']:
+            ok = False
+        else:
+            ok = resp.ok
+    except requests.exceptions.ReadTimeout:
+        ok = False
+    except requests.exceptions.ConnectTimeout:
+        ok = False
+    except Exception:
+        ok = False
+    return ok
 
 
 class DocExampleProcess(Process):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -31,6 +31,7 @@ from pywps.validator.mode import MODE
 from pywps.inout.basic import UOM
 from pywps.inout.storage import FileStorage
 from pywps._compat import PY2
+from pywps.tests import service_ok
 
 
 from lxml import etree
@@ -134,7 +135,8 @@ class IOHandlerTest(unittest.TestCase):
             self.iohandler[0].data = '5'
 
     def test_url(self):
-
+        if not service_ok('https://demo.mapserver.org'):
+            self.skipTest("mapserver is unreachable")
         wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \
                       'service=WFS&version=1.1.0&' \
                       'request=GetFeature&' \

--- a/tests/test_ows.py
+++ b/tests/test_ows.py
@@ -17,12 +17,13 @@ from pywps.exceptions import NoApplicableCode
 from pywps import get_ElementMakerForVersion
 from pywps.wpsserver import temp_dir
 import pywps.configuration as config
-from pywps.tests import client_for, assert_response_success
+from pywps.tests import client_for, assert_response_success, service_ok
 
-wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'  # noqa
-wcsResource = 'http://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'  # noqa
+wfsResource = 'https://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'  # noqa
+wcsResource = 'https://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'  # noqa
 
 WPS, OWS = get_ElementMakerForVersion("1.0.0")
+
 
 def create_feature():
 
@@ -129,6 +130,8 @@ def create_sum_one():
 class ExecuteTests(unittest.TestCase):
 
     def test_wfs(self):
+        if not service_ok('https://demo.mapserver.org'):
+            self.skipTest("mapserver is unreachable")
         client = client_for(Service(processes=[create_feature()]))
         request_doc = WPS.Execute(
             OWS.Identifier('feature'),
@@ -155,6 +158,8 @@ class ExecuteTests(unittest.TestCase):
     def test_wcs(self):
         if not config.CONFIG.get('grass', 'gisbase'):
             self.skipTest('GRASS lib not found')
+        if not service_ok('https://demo.mapserver.org'):
+            self.skipTest("mapserver is unreachable")
 
         client = client_for(Service(processes=[create_sum_one()]))
         request_doc = WPS.Execute(


### PR DESCRIPTION
# Overview

Adds and uses `pywps.test.service_ok` to check if test service is available.

# Related Issue / Discussion

#478 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
