### PR TITLE
Fixed Python 3 issue with scheduler extension

### DIFF
--- a/pywps/processing/job.py
+++ b/pywps/processing/job.py
@@ -37,7 +37,7 @@ class Job(object):
         LOGGER.debug('dump job ...')
         import dill
         filename = tempfile.mkstemp(prefix='job_', suffix='.dump', dir=self.workdir)[1]
-        with open(filename, 'w') as fp:
+        with open(filename, 'wb') as fp:
             dill.dump(self, fp)
             LOGGER.debug("dumped job status to {}".format(filename))
             return filename
@@ -47,7 +47,7 @@ class Job(object):
     def load(cls, filename):
         LOGGER.debug('load job ...')
         import dill
-        with open(filename) as fp:
+        with open(filename, 'rb') as fp:
             job = dill.load(fp)
             return job
         return None


### PR DESCRIPTION
# Overview
The scheduler extension is not working with Python 3.
This is one small fix that puts it closer, but there are still other issues.

# Related Issue / Discussion
#480 

# Additional Information
The issue with the extension I was having was to do with how the jobs are pickled.
With this small Python 3 issue resolved, I still have this error:

```
2019-08-05 10:31:20,506] [ERROR] line=45 module=exceptions Exception: code: 400, description: Could not submit job: seek, locator:
Traceback (most recent call last):
  File "/etc/emu/src/pywps/pywps/processing/scheduler.py", line 40, in run_job
    dump_filename = self.job.dump()
  File "/etc/emu/src/pywps/pywps/processing/job.py", line 41, in dump
    dill.dump(self, fp)
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 287, in dump
    pik.dump(obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 437, in dump
    self.save(obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 549, in save
    self.save_reduce(obj=obj, *rv)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 662, in save_reduce
    save(state)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 910, in save_module_dict
    StockPickler.save_dict(pickler, obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 856, in save_dict
    self._batch_setitems(obj.items())
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 882, in _batch_setitems
    save(v)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 549, in save
    self.save_reduce(obj=obj, *rv)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 662, in save_reduce
    save(state)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 910, in save_module_dict
    StockPickler.save_dict(pickler, obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 856, in save_dict
    self._batch_setitems(obj.items())
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 882, in _batch_setitems
    save(v)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 549, in save
    self.save_reduce(obj=obj, *rv)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 662, in save_reduce
    save(state)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 910, in save_module_dict
    StockPickler.save_dict(pickler, obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 856, in save_dict
    self._batch_setitems(obj.items())
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 882, in _batch_setitems
    save(v)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 910, in save_module_dict
    StockPickler.save_dict(pickler, obj)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 856, in save_dict
    self._batch_setitems(obj.items())
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 882, in _batch_setitems
    save(v)
  File "/etc/miniconda3/envs/emu/lib/python3.7/pickle.py", line 504, in save
    f(self, obj) # Call unbound method with explicit self
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 999, in save_file
    f = _save_file(pickler, obj, open)
  File "/etc/miniconda3/envs/emu/lib/python3.7/site-packages/dill/_dill.py", line 973, in _save_file
    position = obj.tell()
io.UnsupportedOperation: seek
```

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute this bugfix to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
