### PR TITLE
Fix urlparse usage

### DIFF
--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -285,7 +285,7 @@ def convert_anyURI(inpt):
     :rtype: url components
     """
     inpt = convert_string(inpt)
-    components = urlparse.urlparse(inpt)
+    components = urlparse(inpt)
 
     if components[0] and components[1]:
         return components

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -287,7 +287,7 @@ def convert_anyURI(inpt):
     inpt = convert_string(inpt)
     components = urlparse(inpt)
 
-    if components[0] and components[1]:
+    if (components[0] and components[1]) or components[0] == 'file':
         return components
     else:
         raise InvalidParameterValue(

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -77,7 +77,7 @@ class ConvertorTest(unittest.TestCase):
     def test_anyuri(self):
         """Test URI convertor"""
         self.assertEqual(convert_anyURI("http://username:password@hostname.dom:port/deep/path/;params?query#fragment"),
-                         ('http', 'username:password@hostname.dom:port', '/deep/path/', 'params', 'k=v', 'fragment')
+                         ('http', 'username:password@hostname.dom:port', '/deep/path/', 'params', 'query', 'fragment')
                         )
         self.assertEqual(convert_anyURI("file:///very/very/very/deep/path"),
                          ('file', '', '/very/very/very/deep/path', '', '', '')

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -15,7 +15,9 @@ from pywps.inout.literaltypes import (
     convert_time,
     convert_date,
     convert_datetime,
+    convert_anyURI,
     ValuesReference,
+    InvalidParameterValue,
 )
 
 

--- a/tests/test_literaltypes.py
+++ b/tests/test_literaltypes.py
@@ -74,6 +74,16 @@ class ConvertorTest(unittest.TestCase):
             convert_datetime(datetime.datetime(2016, 9, 22, 6)),
             datetime.datetime))
 
+    def test_anyuri(self):
+        """Test URI convertor"""
+        self.assertEqual(convert_anyURI("http://username:password@hostname.dom:port/deep/path/;params?query#fragment"),
+                         ('http', 'username:password@hostname.dom:port', '/deep/path/', 'params', 'k=v', 'fragment')
+                        )
+        self.assertEqual(convert_anyURI("file:///very/very/very/deep/path"),
+                         ('file', '', '/very/very/very/deep/path', '', '', '')
+                        )
+        with self.assertRaises(InvalidParameterValue):
+            convert_anyURI("ftp:///deep/path/;params?query#fragment")
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:


### PR DESCRIPTION
# Overview
Fix pywps._compat.urlparse usage.
`pywps._compat.urlparse` is a function, but `pywps.inout.literaltypes.convert_anyURI` used it as a module.

# Related Issue / Discussion
#486 

# Additional Information
When adding the test function, another issue emerged with `file:///` schema, thus we agreed to handle this case separately (see #486).

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
