### PR TITLE
Mention known issues with sqlite memory in docs for logging.database config

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -183,7 +183,7 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
 
 :database:
     Connection string to database where the login about requests/responses is to be stored. We are using `SQLAlchemy <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_
-    please use the configuration string. The default is SQLite3 `:memory:` object.
+    please use the configuration string. The default is SQLite3 `:memory:` object, however this has `known issues <https://github.com/geopython/pywps/issues?utf8=%E2%9C%93&q=is%3Aissue+async+sqlite>`_ with async processing and should be avoided.
 
 
 [grass]


### PR DESCRIPTION
# Overview
I've drafted a suggested change to docs to make it clear that the default `logging.database` setting has known issues and should be avoided.

# Related Issue / Discussion
- https://github.com/geopython/pywps/issues/245
- https://github.com/geopython/pywps/issues/495

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
