### PR TITLE
Check data is defined in literal template

### DIFF
--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -32,6 +32,6 @@
                     {% endfor %}
                 </ows:AllowedValues>
                 {% endif %}
-                {% if put.data is not none %}
+                {% if put.data is defined and put.data is not none %}
                 <DefaultValue>{{ put.data }}</DefaultValue>
                 {% endif %}


### PR DESCRIPTION
# Overview
I think this started causing issues with owslib 0.18. 

# Related Issue / Discussion
Fixes #498 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
