### PR TITLE
fix file storage

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -966,7 +966,7 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
         """Return URL pointing to data
         """
         # TODO: it is not obvious that storing happens here
-        (outtype, storage, url) = self.storage.store(self)
+        (_, _, url) = self.storage.store(self)
         # url = self.storage.url(self)
         return url
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -965,7 +965,9 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     def get_url(self):
         """Return URL pointing to data
         """
-        url = self.storage.url(self)
+        # TODO: it is not obvious that storing happens here
+        (outtype, storage, url) = self.storage.store(self)
+        # url = self.storage.url(self)
         return url
 
 

--- a/pywps/inout/storage/file.py
+++ b/pywps/inout/storage/file.py
@@ -108,7 +108,7 @@ class FileStorage(CachedStorage):
 
         just_file_name = os.path.basename(output_name)
 
-        url = self.url(urljoin(str(request_uuid), just_file_name))
+        url = self.url("{}/{}".format(request_uuid, just_file_name))
         LOGGER.info('File output URI: {}'.format(url))
 
         return (STORE_TYPE.PATH, output_name, url)
@@ -131,7 +131,7 @@ class FileStorage(CachedStorage):
         if isinstance(destination, IOHandler):
             output_name, _ = _build_output_name(destination)
             just_file_name = os.path.basename(output_name)
-            dst = urljoin(str(destination.uuid), just_file_name)
+            dst = "{}/{}".format(destination.uuid, just_file_name)
         else:
             dst = destination
 

--- a/tests/test_filestorage.py
+++ b/tests/test_filestorage.py
@@ -15,6 +15,7 @@ import os
 
 import unittest
 
+
 class FileStorageTests(unittest.TestCase):
 
     def setUp(self):
@@ -42,7 +43,6 @@ class FileStorageTests(unittest.TestCase):
         with open(self.tmp_dir + '/' + store_str) as f:
             self.assertEqual(f.read(), "Hello World!")
 
-
     def test_write(self):
         configuration.CONFIG.set('server', 'outputpath', self.tmp_dir)
         configuration.CONFIG.set('server', 'outputurl', 'file://' + self.tmp_dir)
@@ -61,15 +61,15 @@ class FileStorageTests(unittest.TestCase):
         storage = FileStorageBuilder().build()
         output = ComplexOutput('testme', 'Test', supported_formats=[FORMATS.TEXT], workdir=self.tmp_dir)
         output.data = "Hello World!"
+        output.uuid = '595129f0-1a6c-11ea-a30c-acde48001122'
         url = storage.url(output)
 
-        self.assertEqual('file://' + self.tmp_dir + '/input.txt', url)
+        self.assertEqual('file://' + self.tmp_dir + '/595129f0-1a6c-11ea-a30c-acde48001122' + '/input.txt', url)
 
         file_name = 'test.txt'
         url = storage.url(file_name)
 
         self.assertEqual('file://' + self.tmp_dir + '/test.txt', url)
-
 
     def test_location(self):
         configuration.CONFIG.set('server', 'outputpath', self.tmp_dir)


### PR DESCRIPTION
# Overview

This PR fixes the file storage. Output files were not saved to storage after introducing PR #451.

# Related Issue / Discussion

#451

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
