### PR TITLE
add type check before compare format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ docs/_build
 .DS_Store
 .*.un~
 
+# project
+.idea
+
 # git
 
 *.orig

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -129,6 +129,8 @@ class Format(object):
     def same_as(self, frmt):
         """Check input frmt, if it seems to be the same as self
         """
+        if not isinstance(frmt, Format):
+            return False
         return all([frmt.mime_type == self.mime_type,
                     frmt.encoding == self.encoding,
                     frmt.schema == self.schema])

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -63,6 +63,23 @@ class FormatsTest(unittest.TestCase):
 
         self.assertTrue(frmt.same_as(frmt2))
 
+    def test_format_equal_types(self):
+        """Test that equality check returns the expected bool and doesn't raise
+        when types mismatch.
+        """
+        frmt = get_format('GML')
+        self.assertTrue(isinstance(frmt, Format))
+        try:
+            res = frmt.same_as("GML")  # not a Format type
+        except AssertionError:
+            self.fail("Comparing a format to another type should not raise")
+        except Exception:
+            self.fail("Unexpected error, test failed for unknown reason")
+        self.assertFalse(res, "Equality check with other type should be False")
+
+        frmt_other = get_format('GML')
+        self.assertTrue(frmt == frmt_other, "Same formats should return True")
+
     def test_json_out(self):
         """Test json export
         """


### PR DESCRIPTION
Without the added type check, doing a comparison between `Format` and anything else will cause `AssertionError` instead of gracefully returning `False` because the "other" item to compare doesn't necessarily have the properties of `Format`.