### PR TITLE
Add support for multiple languages

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -86,6 +86,8 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
     ``pointOfContact``, ``distributor``, ``user``, ``resourceProvider``,
     ``originator``, ``owner``, ``principalInvestigator``
 
+.. _server-configuration:
+
 [server]
 --------
 
@@ -93,7 +95,8 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
     the URL of the WPS service endpoint
 
 :language:
-    the ISO 639-1 language and ISO 3166-1 alpha2 country code of the service
+    a comma-separated list of ISO 639-1 language and ISO 3166-1 alpha2 country 
+    code of the service
     (e.g. ``en-CA``, ``fr-CA``, ``en-US``)
 
 :encoding:
@@ -197,6 +200,8 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
 
 
 [s3]
+----
+
 :bucket:
   Name of the bucket to store files in. e.g. ``my-wps-results``
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -474,6 +474,64 @@ Use the `run` method to start the server::
 
 To make the server visible from another computer, replace ``localhost`` with ``0.0.0.0``.
 
+Supporting multiple languages
+=============================
+
+Supporting multiple languages requires:
+
+- Setting the `language` property in the server configuration (see :ref:`server-configuration`)
+- Adding translations to :class:`Process`, inputs and outputs objects
+
+The expected translations format is always the same. The first key is the RFC 4646 language code, 
+and the nested mapping contains translated strings accessible by a string property::
+
+    from pywps import Process, LiteralInput, LiteralOutput
+
+
+    class SayHello(Process):
+        def __init__(self):
+            inputs = [
+                LiteralInput(
+                    'name',
+                    title='Input name',
+                    abstract='The name to say hello to.',
+                    translations={"fr-CA": {"abstract": "Le nom à saluer."}}
+                )
+            ],
+            outputs=[
+                LiteralOutput(
+                    'response',
+                    title='Output response',
+                    abstract='The complete output message.',
+                    translations={"fr-CA": {
+                        "title": "La réponse", 
+                        "abstract": "Le message complet."
+                    }}
+                )
+            ],
+
+            super().__init__(
+                self._handler,
+                identifier='say_hello',
+                title='Process Say Hello',
+                abstract='Returns a literal string output with Hello plus the inputed name',
+                version='1.0',
+                inputs=inputs,
+                outputs=outputs,
+                store_supported=True,
+                status_supported=True,
+                translations={"fr-CA": {
+                    "title": "Processus Dire Bonjour", 
+                    "abstract": "Retourne une chaine de caractères qui dit bonjour au nom fournit en entrée."
+                }},
+            )
+
+        def _handler(self, request, response):
+            ...
+
+The translation will default to the untranslated attribute of the base object if 
+the key is not provided in the `translations` dictionnary.
+
 Automated process documentation
 ===============================
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -52,7 +52,7 @@ class Process(object):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, handler, identifier, title, abstract='', keywords=[], profile=[],

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -50,7 +50,7 @@ class Process(object):
                    objects.
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -50,7 +50,7 @@ class Process(object):
                    objects.
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from pywps.translations import lower_case_dict
 import sys
 import traceback
 import json
@@ -49,10 +50,14 @@ class Process(object):
                    objects.
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
-    def __init__(self, handler, identifier, title, abstract='', keywords=[], profile=[], metadata=[], inputs=[],
-                 outputs=[], version='None', store_supported=False, status_supported=False, grass_location=None):
+    def __init__(self, handler, identifier, title, abstract='', keywords=[], profile=[],
+                 metadata=[], inputs=[], outputs=[], version='None', store_supported=False,
+                 status_supported=False, grass_location=None, translations=None):
         self.identifier = identifier
         self.handler = handler
         self.title = title
@@ -71,6 +76,7 @@ class Process(object):
         self._grass_mapset = None
         self.grass_location = grass_location
         self.service = None
+        self.translations = lower_case_dict(translations)
 
         if store_supported:
             self.store_supported = 'true'
@@ -100,6 +106,7 @@ class Process(object):
             'store_supported': self.store_supported,
             'status_supported': self.status_supported,
             'profile': [p for p in self.profile],
+            'translations': self.translations,
         }
 
     @classmethod

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -306,6 +306,7 @@ class WPSRequest(object):
         """set this.language
         """
         supported_languages = configuration.get_config_value('server', 'language').split(',')
+        supported_languages = [lang.strip() for lang in supported_languages]
 
         if not language:
             # default to the first supported language

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -111,6 +111,9 @@ class WPSRequest(object):
             acceptedversions = _get_get_param(http_request, 'acceptversions')
             wpsrequest.check_accepted_versions(acceptedversions)
 
+            language = _get_get_param(http_request, 'language')
+            wpsrequest.check_and_set_language(language)
+
         def parse_get_describeprocess(http_request):
             """Parse GET DescribeProcess request
             """
@@ -191,6 +194,9 @@ class WPSRequest(object):
                 map(lambda v: v.text, acceptedversions))
             wpsrequest.check_accepted_versions(acceptedversions)
 
+            language = doc.attrib.get('language')
+            wpsrequest.check_and_set_language(language)
+
         def parse_post_describeprocess(doc):
             """Parse POST DescribeProcess request
             """
@@ -208,7 +214,6 @@ class WPSRequest(object):
         def parse_post_execute(doc):
             """Parse POST Execute request
             """
-
             version = doc.attrib.get('version')
             wpsrequest.check_and_set_version(version)
 
@@ -300,14 +305,19 @@ class WPSRequest(object):
     def check_and_set_language(self, language):
         """set this.language
         """
+        supported_languages = configuration.get_config_value('server', 'language').split(',')
 
         if not language:
-            language = 'None'
-        elif language != 'en-US':
+            # default to the first supported language
+            language = supported_languages[0]
+
+        if language not in supported_languages:
             raise InvalidParameterValue(
-                'The requested language "{}" is not supported by this server'.format(language), 'language')
-        else:
-            self.language = language
+                'The requested language "{}" is not supported by this server'.format(language),
+                'language',
+            )
+
+        self.language = language
 
     @property
     def json(self):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -3,6 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+from pywps.translations import lower_case_dict
 from pywps._compat import text_type, StringIO
 import os
 from io import open
@@ -544,7 +545,7 @@ class BasicIO:
     """Basic Input/Output class
     """
     def __init__(self, identifier, title=None, abstract=None, keywords=None,
-                 min_occurs=1, max_occurs=1, metadata=[]):
+                 min_occurs=1, max_occurs=1, metadata=[], translations=None):
         self.identifier = identifier
         self.title = title
         self.abstract = abstract
@@ -552,6 +553,7 @@ class BasicIO:
         self.min_occurs = int(min_occurs)
         self.max_occurs = int(max_occurs)
         self.metadata = metadata
+        self.translations = lower_case_dict(translations)
 
 
 class BasicLiteral:
@@ -701,9 +703,17 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
                  data_type="integer", workdir=None, allowed_values=None,
                  uoms=None, mode=MODE.NONE,
                  min_occurs=1, max_occurs=1, metadata=[],
-                 default=None, default_type=SOURCE_TYPE.DATA):
-        BasicIO.__init__(self, identifier, title, abstract, keywords,
-                         min_occurs, max_occurs, metadata)
+                 default=None, default_type=SOURCE_TYPE.DATA, translations=None):
+        BasicIO.__init__(self, 
+            identifier=identifier,
+            title=title,
+            abstract=abstract,
+            keywords=keywords,
+            min_occurs=min_occurs,
+            max_occurs=max_occurs,
+            metadata=metadata,
+            translations=translations,
+        )
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir, data_type, mode=mode)
 
@@ -752,8 +762,8 @@ class LiteralOutput(BasicIO, BasicLiteral, SimpleHandler):
 
     def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  data_type=None, workdir=None, uoms=None, validate=None,
-                 mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract, keywords)
+                 mode=MODE.NONE, translations=None):
+        BasicIO.__init__(self, identifier, title, abstract, keywords, translations=translations)
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir=None, data_type=data_type,
                                mode=mode)
@@ -784,9 +794,17 @@ class BBoxInput(BasicIO, BasicBoundingBox, DataHandler):
                  dimensions=None, workdir=None,
                  mode=MODE.SIMPLE,
                  min_occurs=1, max_occurs=1, metadata=[],
-                 default=None, default_type=SOURCE_TYPE.DATA):
-        BasicIO.__init__(self, identifier, title, abstract, keywords,
-                         min_occurs, max_occurs, metadata)
+                 default=None, default_type=SOURCE_TYPE.DATA, translations=None):
+        BasicIO.__init__(self, 
+            identifier=identifier,
+            title=title,
+            abstract=abstract,
+            keywords=keywords,
+            min_occurs=min_occurs,
+            max_occurs=max_occurs,
+            metadata=metadata,
+            translations=translations,
+        )
         BasicBoundingBox.__init__(self, crss, dimensions)
         DataHandler.__init__(self, workdir=workdir, mode=mode)
 
@@ -804,8 +822,8 @@ class BBoxOutput(BasicIO, BasicBoundingBox, DataHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None, keywords=None, crss=None,
-                 dimensions=None, workdir=None, mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract, keywords)
+                 dimensions=None, workdir=None, mode=MODE.NONE, translations=None):
+        BasicIO.__init__(self, identifier, title, abstract, keywords, translations=translations)
         BasicBoundingBox.__init__(self, crss, dimensions)
         DataHandler.__init__(self, workdir=workdir, mode=mode)
         self._storage = None
@@ -832,10 +850,17 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
                  workdir=None, data_format=None, supported_formats=None,
                  mode=MODE.NONE,
                  min_occurs=1, max_occurs=1, metadata=[],
-                 default=None, default_type=SOURCE_TYPE.DATA):
-
-        BasicIO.__init__(self, identifier, title, abstract, keywords,
-                         min_occurs, max_occurs, metadata)
+                 default=None, default_type=SOURCE_TYPE.DATA, translations=None):
+        BasicIO.__init__(self, 
+            identifier=identifier,
+            title=title,
+            abstract=abstract,
+            keywords=keywords,
+            min_occurs=min_occurs,
+            max_occurs=max_occurs,
+            metadata=metadata,
+            translations=translations,
+        )
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
 
@@ -944,8 +969,8 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
 
     def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  workdir=None, data_format=None, supported_formats=None,
-                 mode=MODE.NONE):
-        BasicIO.__init__(self, identifier, title, abstract, keywords)
+                 mode=MODE.NONE, translations=None):
+        BasicIO.__init__(self, identifier, title, abstract, keywords, translations=translations)
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -544,6 +544,7 @@ class SimpleHandler(DataHandler):
 class BasicIO:
     """Basic Input/Output class
     """
+
     def __init__(self, identifier, title=None, abstract=None, keywords=None,
                  min_occurs=1, max_occurs=1, metadata=[], translations=None):
         self.identifier = identifier
@@ -704,16 +705,16 @@ class LiteralInput(BasicIO, BasicLiteral, SimpleHandler):
                  uoms=None, mode=MODE.NONE,
                  min_occurs=1, max_occurs=1, metadata=[],
                  default=None, default_type=SOURCE_TYPE.DATA, translations=None):
-        BasicIO.__init__(self, 
-            identifier=identifier,
-            title=title,
-            abstract=abstract,
-            keywords=keywords,
-            min_occurs=min_occurs,
-            max_occurs=max_occurs,
-            metadata=metadata,
-            translations=translations,
-        )
+        BasicIO.__init__(self,
+                         identifier=identifier,
+                         title=title,
+                         abstract=abstract,
+                         keywords=keywords,
+                         min_occurs=min_occurs,
+                         max_occurs=max_occurs,
+                         metadata=metadata,
+                         translations=translations,
+                         )
         BasicLiteral.__init__(self, data_type, uoms)
         SimpleHandler.__init__(self, workdir, data_type, mode=mode)
 
@@ -795,16 +796,16 @@ class BBoxInput(BasicIO, BasicBoundingBox, DataHandler):
                  mode=MODE.SIMPLE,
                  min_occurs=1, max_occurs=1, metadata=[],
                  default=None, default_type=SOURCE_TYPE.DATA, translations=None):
-        BasicIO.__init__(self, 
-            identifier=identifier,
-            title=title,
-            abstract=abstract,
-            keywords=keywords,
-            min_occurs=min_occurs,
-            max_occurs=max_occurs,
-            metadata=metadata,
-            translations=translations,
-        )
+        BasicIO.__init__(self,
+                         identifier=identifier,
+                         title=title,
+                         abstract=abstract,
+                         keywords=keywords,
+                         min_occurs=min_occurs,
+                         max_occurs=max_occurs,
+                         metadata=metadata,
+                         translations=translations,
+                         )
         BasicBoundingBox.__init__(self, crss, dimensions)
         DataHandler.__init__(self, workdir=workdir, mode=mode)
 
@@ -851,16 +852,16 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
                  mode=MODE.NONE,
                  min_occurs=1, max_occurs=1, metadata=[],
                  default=None, default_type=SOURCE_TYPE.DATA, translations=None):
-        BasicIO.__init__(self, 
-            identifier=identifier,
-            title=title,
-            abstract=abstract,
-            keywords=keywords,
-            min_occurs=min_occurs,
-            max_occurs=max_occurs,
-            metadata=metadata,
-            translations=translations,
-        )
+        BasicIO.__init__(self,
+                         identifier=identifier,
+                         title=title,
+                         abstract=abstract,
+                         keywords=keywords,
+                         min_occurs=min_occurs,
+                         max_occurs=max_occurs,
+                         metadata=metadata,
+                         translations=translations,
+                         )
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -33,7 +33,7 @@ class BoundingBoxInput(basic.BBoxInput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, crss=None, abstract='', keywords=[],
@@ -121,7 +121,7 @@ class ComplexInput(basic.ComplexInput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, supported_formats,
@@ -268,7 +268,7 @@ class LiteralInput(basic.LiteralInput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title=None, data_type=None, workdir=None, abstract='', keywords=[],

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -31,7 +31,7 @@ class BoundingBoxInput(basic.BBoxInput):
     :param int max_occurs: how many times this input occurs
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -119,7 +119,7 @@ class ComplexInput(basic.ComplexInput):
     :param int min_occurs: minimum occurrence
     :param int max_occurs: maximum occurrence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -266,7 +266,7 @@ class LiteralInput(basic.LiteralInput):
     :param pywps.inout.literaltypes.AnyValue allowed_values: or :py:class:`pywps.inout.literaltypes.AllowedValue` object
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -31,20 +31,25 @@ class BoundingBoxInput(basic.BBoxInput):
     :param int max_occurs: how many times this input occurs
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, crss=None, abstract='', keywords=[],
                  dimensions=2, workdir=None, metadata=[], min_occurs=1,
                  max_occurs=1,
                  mode=MODE.NONE,
-                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+                 default=None, default_type=basic.SOURCE_TYPE.DATA,
+                 translations=None):
 
         basic.BBoxInput.__init__(self, identifier, title=title, crss=crss,
                                  abstract=abstract, keywords=keywords,
                                  dimensions=dimensions, workdir=workdir, metadata=metadata,
                                  min_occurs=min_occurs, max_occurs=max_occurs,
                                  mode=mode, default=default,
-                                 default_type=default_type)
+                                 default_type=default_type,
+                                 translations=translations)
 
         self.as_reference = False
 
@@ -68,7 +73,8 @@ class BoundingBoxInput(basic.BBoxInput):
             'workdir': self.workdir,
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
-            'max_occurs': self.max_occurs
+            'max_occurs': self.max_occurs,
+            'translations': self.translations,
         }
 
     @classmethod
@@ -85,6 +91,7 @@ class BoundingBoxInput(basic.BBoxInput):
             mode=json_input['mode'],
             min_occurs=json_input['min_occurs'],
             max_occurs=json_input['max_occurs'],
+            translations=json_input.get('translations'),
         )
         instance.data = json_input['bbox']
 
@@ -112,12 +119,15 @@ class ComplexInput(basic.ComplexInput):
     :param int min_occurs: minimum occurrence
     :param int max_occurs: maximum occurrence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, supported_formats,
                  data_format=None, abstract='', keywords=[], workdir=None, metadata=[], min_occurs=1,
                  max_occurs=1, mode=MODE.NONE,
-                 default=None, default_type=basic.SOURCE_TYPE.DATA):
+                 default=None, default_type=basic.SOURCE_TYPE.DATA, translations=None):
         """constructor"""
 
         basic.ComplexInput.__init__(self, identifier, title=title,
@@ -126,7 +136,7 @@ class ComplexInput(basic.ComplexInput):
                                     keywords=keywords, workdir=workdir, metadata=metadata,
                                     min_occurs=min_occurs,
                                     max_occurs=max_occurs, mode=mode,
-                                    default=default, default_type=default_type)
+                                    default=default, default_type=default_type, translations=translations)
 
         self.as_reference = False
         self.method = ''
@@ -148,7 +158,8 @@ class ComplexInput(basic.ComplexInput):
             'workdir': self.workdir,
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
-            'max_occurs': self.max_occurs
+            'max_occurs': self.max_occurs,
+            'translations': self.translations,
         }
 
         if self.prop == 'file':
@@ -194,7 +205,8 @@ class ComplexInput(basic.ComplexInput):
                     encoding=infrmt.get('encoding')
                 ) for infrmt in json_input['supported_formats']
             ],
-            mode=json_input.get('mode', MODE.NONE)
+            mode=json_input.get('mode', MODE.NONE),
+            translations=json_input.get('translations'),
         )
         instance.as_reference = json_input.get('asreference', False)
         if json_input.get('file'):
@@ -254,14 +266,16 @@ class LiteralInput(basic.LiteralInput):
     :param pywps.inout.literaltypes.AnyValue allowed_values: or :py:class:`pywps.inout.literaltypes.AllowedValue` object
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title=None, data_type=None, workdir=None, abstract='', keywords=[],
                  metadata=[], uoms=None,
                  min_occurs=1, max_occurs=1,
                  mode=MODE.SIMPLE, allowed_values=None,
-                 default=None, default_type=basic.SOURCE_TYPE.DATA):
-
+                 default=None, default_type=basic.SOURCE_TYPE.DATA, translations=None):
         """Constructor
         """
         data_type = data_type or 'string'
@@ -271,7 +285,8 @@ class LiteralInput(basic.LiteralInput):
                                     uoms=uoms, min_occurs=min_occurs,
                                     max_occurs=max_occurs, mode=mode,
                                     allowed_values=allowed_values,
-                                    default=default, default_type=default_type)
+                                    default=default, default_type=default_type,
+                                    translations=translations)
 
         self.as_reference = False
 
@@ -293,6 +308,7 @@ class LiteralInput(basic.LiteralInput):
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
             'max_occurs': self.max_occurs,
+            'translations': self.translations,
             # other values not set in the constructor
         }
         if self.values_reference:

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -31,7 +31,7 @@ class BoundingBoxInput(basic.BBoxInput):
     :param int max_occurs: how many times this input occurs
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -119,7 +119,7 @@ class ComplexInput(basic.ComplexInput):
     :param int min_occurs: minimum occurrence
     :param int max_occurs: maximum occurrence
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -266,7 +266,7 @@ class LiteralInput(basic.LiteralInput):
     :param pywps.inout.literaltypes.AnyValue allowed_values: or :py:class:`pywps.inout.literaltypes.AllowedValue` object
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -29,7 +29,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -103,7 +103,7 @@ class ComplexOutput(basic.ComplexOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -245,7 +245,7 @@ class LiteralOutput(basic.LiteralOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
+    :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -31,7 +31,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, crss, abstract='', keywords=[],
@@ -105,7 +105,7 @@ class ComplexOutput(basic.ComplexOutput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, supported_formats=None,
@@ -247,7 +247,7 @@ class LiteralOutput(basic.LiteralOutput):
                      should be :class:`pywps.app.Common.Metadata` objects.
     :param dict[str,dict[str,str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
-        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
+        e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, data_type='string', abstract='', keywords=[],

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -29,7 +29,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -103,7 +103,7 @@ class ComplexOutput(basic.ComplexOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -245,7 +245,7 @@ class LiteralOutput(basic.LiteralOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
-    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code,
         and the nested mapping contains translated strings accessible by a string property.
         ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
@@ -303,6 +303,7 @@ class LiteralOutput(basic.LiteralOutput):
 
 class MetaFile:
     """MetaFile object."""
+
     def __init__(self, identity=None, description=None, fmt=None):
         """Create a `MetaFile` object.
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -29,15 +29,18 @@ class BoundingBoxOutput(basic.BBoxOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, crss, abstract='', keywords=[],
                  dimensions=2, metadata=[], min_occurs='1',
                  max_occurs='1', as_reference=False,
-                 mode=MODE.NONE):
+                 mode=MODE.NONE, translations=None):
         basic.BBoxOutput.__init__(self, identifier, title=title,
                                   abstract=abstract, keywords=keywords, crss=crss,
-                                  dimensions=dimensions, mode=mode)
+                                  dimensions=dimensions, mode=mode, translations=translations)
 
         self.metadata = metadata
         self.min_occurs = min_occurs
@@ -65,6 +68,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
             'ur': self.ur,
             'workdir': self.workdir,
             'mode': self.valid_mode,
+            'translations': self.translations,
         }
 
     @classmethod
@@ -80,6 +84,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
             crss=json_output['crss'],
             dimensions=json_output['dimensions'],
             mode=json_output['mode'],
+            translations=json_output.get('translations'),
         )
         instance.data = json_output['bbox']
         instance.workdir = json_output['workdir']
@@ -98,11 +103,14 @@ class ComplexOutput(basic.ComplexOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, supported_formats=None,
                  data_format=None, abstract='', keywords=[], workdir=None, metadata=None,
-                 as_reference=False, mode=MODE.NONE):
+                 as_reference=False, mode=MODE.NONE, translations=None):
         if metadata is None:
             metadata = []
 
@@ -110,7 +118,7 @@ class ComplexOutput(basic.ComplexOutput):
                                      data_format=data_format, abstract=abstract, keywords=keywords,
                                      workdir=workdir,
                                      supported_formats=supported_formats,
-                                     mode=mode)
+                                     mode=mode, translations=translations)
         self.metadata = metadata
         self.as_reference = as_reference
 
@@ -133,7 +141,8 @@ class ComplexOutput(basic.ComplexOutput):
             'workdir': self.workdir,
             'mode': self.valid_mode,
             'min_occurs': self.min_occurs,
-            'max_occurs': self.max_occurs
+            'max_occurs': self.max_occurs,
+            'translations': self.translations,
         }
 
         if self.as_reference:
@@ -174,7 +183,8 @@ class ComplexOutput(basic.ComplexOutput):
                     encoding=infrmt.get('encoding')
                 ) for infrmt in json_output['supported_formats']
             ],
-            mode=json_output.get('mode', MODE.NONE)
+            mode=json_output.get('mode', MODE.NONE),
+            translations=json_output.get('translations'),
         )
         instance.as_reference = json_output.get('asreference', False)
         if json_output.get('file'):
@@ -235,14 +245,17 @@ class LiteralOutput(basic.LiteralOutput):
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
+    :param dict[str, dict[str, str]] translations: The first key is the RFC 4646 language code, 
+        and the nested mapping contains translated strings accessible by a string property.
+        ex: {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
     def __init__(self, identifier, title, data_type='string', abstract='', keywords=[],
-                 metadata=[], uoms=None, mode=MODE.SIMPLE):
+                 metadata=[], uoms=None, mode=MODE.SIMPLE, translations=None):
         if uoms is None:
             uoms = []
         basic.LiteralOutput.__init__(self, identifier, title=title, abstract=abstract, keywords=keywords,
-                                     data_type=data_type, uoms=uoms, mode=mode)
+                                     data_type=data_type, uoms=uoms, mode=mode, translations=translations)
         self.metadata = metadata
 
     @property
@@ -257,7 +270,8 @@ class LiteralOutput(basic.LiteralOutput):
             "data": self.data,
             "data_type": self.data_type,
             "type": "literal",
-            "uoms": [u.json for u in self.uoms]
+            "uoms": [u.json for u in self.uoms],
+            "translations": self.translations,
         }
 
         if self.uom:
@@ -277,6 +291,7 @@ class LiteralOutput(basic.LiteralOutput):
             abstract=json_output['abstract'],
             keywords=json_output['keywords'],
             uoms=uoms,
+            translations=json_output.get('translations'),
         )
 
         instance.data = json_output.get('data')

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -1,5 +1,6 @@
 from pywps.dblog import store_status
 from pywps.response.status import WPS_STATUS
+from pywps.translations import get_translation
 from jinja2 import Environment, PackageLoader
 import os
 
@@ -40,6 +41,7 @@ class WPSResponse(object):
             trim_blocks=True, lstrip_blocks=True,
             autoescape=True,
         )
+        self.template_env.globals.update(get_translation=get_translation)
 
     def _update_status(self, status, message, status_percentage):
         """

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -56,6 +56,7 @@ class CapabilitiesResponse(WPSResponse):
             },
             'serviceurl': config.get_config_value('server', 'url'),
             'languages': config.get_config_value('server', 'language').split(','),
+            'language': self.wps_request.language,
             'processes': processes
         }
 

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -38,7 +38,7 @@ class DescribeResponse(WPSResponse):
         return {
             'pywps_version': __version__,
             'processes': processes,
-            'lang': 'en-US'
+            'language': self.wps_request.language,
         }
 
     def _construct_doc(self):

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -155,7 +155,7 @@ class ExecuteResponse(WPSResponse):
     @property
     def json(self):
         data = {}
-        data["lang"] = "en-US"
+        data["language"] = self.wps_request.language
         data["service_instance"] = self._get_serviceinstance()
         data["process"] = self.process.json
 

--- a/pywps/templates/1.0.0/capabilities/main.xml
+++ b/pywps/templates/1.0.0/capabilities/main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- PyWPS {{ pywps_version }} -->
-<wps:Capabilities service="WPS" version="1.0.0" xml:lang="en-CA" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsGetCapabilities_response.xsd" updateSequence="1">
+<wps:Capabilities service="WPS" version="1.0.0" xml:lang="{{ language }}" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsGetCapabilities_response.xsd" updateSequence="1">
     <ows:ServiceIdentification>
         <ows:Title>{{ title }}</ows:Title>
         <ows:Abstract>{{ abstract }}</ows:Abstract>
@@ -73,8 +73,8 @@
         {% for process in processes %}
         <wps:Process wps:processVersion="{{ process.version }}">
             <ows:Identifier>{{ process.identifier }}</ows:Identifier>
-            <ows:Title>{{ process.title }}</ows:Title>
-            <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+            <ows:Title>{{ get_translation(process, "title", language) }}</ows:Title>
+            <ows:Abstract>{{ get_translation(process, "abstract", language) }}</ows:Abstract>
             {% if process.keywords %}
             <ows:Keywords>
             {% for keyword in process.keywords %}
@@ -93,7 +93,7 @@
             />
             {% endfor %}
         </wps:Process>
-    {% endfor %}
+        {% endfor %}
     </wps:ProcessOfferings>
     <wps:Languages>
         <wps:Default>
@@ -101,7 +101,7 @@
         </wps:Default>
         <wps:Supported>
             {% for lang in languages %}
-            <ows:Language>lang</ows:Language>
+            <ows:Language>{{ lang }}</ows:Language>
             {% endfor %}
         </wps:Supported>
     </wps:Languages>

--- a/pywps/templates/1.0.0/describe/main.xml
+++ b/pywps/templates/1.0.0/describe/main.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- PyWPS {{ pywps_version }} -->
-<wps:ProcessDescriptions xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsDescribeProcess_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ lang }}">
+<wps:ProcessDescriptions xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsDescribeProcess_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ language }}">
     {% for process in processes %}
     <ProcessDescription wps:processVersion="{{ process.version }}" storeSupported="{{ process.store_supported }}" statusSupported="{{ process.status_supported }}">
         <ows:Identifier>{{ process.identifier }}</ows:Identifier>
-        <ows:Title>{{ process.title }}</ows:Title>
-        <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+        <ows:Title>{{ get_translation(process, "title", language) }}</ows:Title>
+        <ows:Abstract>{{ get_translation(process, "abstract", language) }}</ows:Abstract>
         {% for metadata in process.metadata %}
         <ows:Metadata xlink:title="{{ metadata.title }}" xlink:type="{{ metadata.type }}"
           {% if metadata.href != None %}
@@ -24,8 +24,8 @@
             {% for put in process.inputs %}
             <Input minOccurs="{{ put.min_occurs }}" maxOccurs="{{ put.max_occurs }}">
                 <ows:Identifier>{{ put.identifier }}</ows:Identifier>
-                <ows:Title>{{ put.title }}</ows:Title>
-                <ows:Abstract>{{ put.abstract }}</ows:Abstract>
+                <ows:Title>{{ get_translation(put, "title", language) }}</ows:Title>
+                <ows:Abstract>{{ get_translation(put, "abstract", language) }}</ows:Abstract>
                 {% if put.type == "complex" %}
                 <ComplexData maximumMegabytes="{{ max_size }}">
                     {% include 'complex.xml' %}
@@ -48,8 +48,8 @@
             {% for put in process.outputs %}
             <Output>
                 <ows:Identifier>{{ put.identifier }}</ows:Identifier>
-                <ows:Title>{{ put.title }}</ows:Title>
-                <ows:Abstract>{{ put.abstract }}</ows:Abstract>
+                <ows:Title>{{ get_translation(put, "title", language) }}</ows:Title>
+                <ows:Abstract>{{ get_translation(put, "abstract", language) }}</ows:Abstract>
                 {% if put.type in ["complex", "reference"] %}
                 <ComplexOutput>
                     {% include 'complex.xml' %}

--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wps:ExecuteResponse xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsExecute_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ lang }}" serviceInstance="{{ service_instance }}" statusLocation="{{ status_location }}">
+<wps:ExecuteResponse xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsExecute_response.xsd" service="WPS" version="1.0.0" xml:lang="{{ language }}" serviceInstance="{{ service_instance }}" statusLocation="{{ status_location }}">
     <wps:Process wps:processVersion="{{ process.version }}">
         <ows:Identifier>{{ process.identifier }}</ows:Identifier>
-        <ows:Title>{{ process.title }}</ows:Title>
-        <ows:Abstract>{{ process.abstract }}</ows:Abstract>
+        <ows:Title>{{ get_translation(process, "title", language) }}</ows:Title>
+        <ows:Abstract>{{ get_translation(process, "abstract", language) }}</ows:Abstract>
         {% if profile %}
         <wps:Profile>{{ process.profile }}</wps:Profile>
         {% endif %}
@@ -36,7 +36,8 @@
         {% for input in input_definitions %}
 		<wps:Input>
             <ows:Identifier>{{ input.identifier }}</ows:Identifier>
-            <ows:Title>{{ input.title }}</ows:Title>
+            <ows:Title>{{ get_translation(input, "title", language) }}</ows:Title>
+            <ows:Abstract>{{ get_translation(input, "abstract", language) }}</ows:Abstract>
             {% if input.type == "complex" %}
 			<wps:Data>
                     <wps:ComplexData mimeType="{{ input.mimetype }}" encoding="{{ input.encoding }}" schema="{{ input.schema }}">{{ input.data | safe }}</wps:ComplexData>
@@ -75,8 +76,8 @@
         <wps:Output>
         {% endif %}
             <ows:Identifier>{{ output.identifier }}</ows:Identifier>
-            <ows:Title>{{ output.title }}</ows:Title>
-            <ows:Abstract>{{ output.abstract }}</ows:Abstract>
+            <ows:Title>{{ get_translation(output, "title", language) }}</ows:Title>
+            <ows:Abstract>{{ get_translation(output, "abstract", language) }}</ows:Abstract>
 		</wps:Output>
         {% endfor %}
 	</wps:OutputDefinitions>
@@ -87,8 +88,8 @@
         {% for output in outputs %}
 		<wps:Output>
             <ows:Identifier>{{ output.identifier }}</ows:Identifier>
-            <ows:Title>{{ output.title }}</ows:Title>
-            <ows:Abstract>{{ output.abstract }}</ows:Abstract>
+            <ows:Title>{{ get_translation(output, "title", language) }}</ows:Title>
+            <ows:Abstract>{{ get_translation(output, "abstract", language) }}</ows:Abstract>
             {% if output.type == "reference" %}
             <wps:Reference href="{{ output.href }}" mimeType="{{ output.mimetype }}" encoding="{{ output.encoding }}" schema="{{ output.schema }}"/>
             {% elif output.type == "complex" %}

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -46,7 +46,7 @@ class DocExampleProcess(Process):
     """
 
     def __init__(self):
-        inputs = [LiteralInput('literal_input', "Literal input title", 'integer', "Literal input value abstract.",
+        inputs = [LiteralInput('literal_input', "Literal input title", 'integer', abstract="Literal input value abstract.",
                                min_occurs=0, max_occurs=1, uoms=['meters', 'feet'], default=1),
                   LiteralInput('date_input', 'The title is shown when no abstract is provided.', 'date',
                                allowed_values=['2000-01-01', '2018-01-01']),
@@ -56,7 +56,7 @@ class DocExampleProcess(Process):
                   BoundingBoxInput('bb_input', 'BoundingBox input title', ['EPSG:4326', ],
                                    metadata=[Metadata('EPSG.io', 'http://epsg.io/'), ]),
                   ]
-        outputs = [LiteralOutput('literal_output', 'Literal output title', 'boolean', 'Boolean output abstract.',),
+        outputs = [LiteralOutput('literal_output', 'Literal output title', 'boolean', abstract='Boolean output abstract.',),
                    ComplexOutput('complex_output', 'Complex output', [Format('text/plain'), ], ),
                    BoundingBoxOutput('bb_output', 'BoundingBox output title', ['EPSG:4326', ])]
 

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -46,19 +46,26 @@ class DocExampleProcess(Process):
     """
 
     def __init__(self):
-        inputs = [LiteralInput('literal_input', "Literal input title", 'integer', abstract="Literal input value abstract.",
-                               min_occurs=0, max_occurs=1, uoms=['meters', 'feet'], default=1),
-                  LiteralInput('date_input', 'The title is shown when no abstract is provided.', 'date',
-                               allowed_values=['2000-01-01', '2018-01-01']),
-                  ComplexInput('complex_input', 'Complex input title',
-                               [Format('application/json'), Format('application/x-netcdf')],
-                               abstract="Complex input abstract.", ),
-                  BoundingBoxInput('bb_input', 'BoundingBox input title', ['EPSG:4326', ],
-                                   metadata=[Metadata('EPSG.io', 'http://epsg.io/'), ]),
-                  ]
-        outputs = [LiteralOutput('literal_output', 'Literal output title', 'boolean', abstract='Boolean output abstract.',),
-                   ComplexOutput('complex_output', 'Complex output', [Format('text/plain'), ], ),
-                   BoundingBoxOutput('bb_output', 'BoundingBox output title', ['EPSG:4326', ])]
+        inputs = [
+            LiteralInput(
+                'literal_input', "Literal input title", 'integer', abstract="Literal input value abstract.",
+                min_occurs=0, max_occurs=1, uoms=['meters', 'feet'], default=1
+            ),
+            LiteralInput('date_input', 'The title is shown when no abstract is provided.', 'date',
+                         allowed_values=['2000-01-01', '2018-01-01']),
+            ComplexInput('complex_input', 'Complex input title',
+                         [Format('application/json'), Format('application/x-netcdf')],
+                         abstract="Complex input abstract.", ),
+            BoundingBoxInput('bb_input', 'BoundingBox input title', ['EPSG:4326', ],
+                             metadata=[Metadata('EPSG.io', 'http://epsg.io/'), ]),
+        ]
+        outputs = [
+            LiteralOutput(
+                'literal_output', 'Literal output title', 'boolean', abstract='Boolean output abstract.'
+            ),
+            ComplexOutput('complex_output', 'Complex output', [Format('text/plain'), ], ),
+            BoundingBoxOutput('bb_output', 'BoundingBox output title', ['EPSG:4326', ])
+        ]
 
         super(DocExampleProcess, self).__init__(
             self._handler,

--- a/pywps/translations.py
+++ b/pywps/translations.py
@@ -1,0 +1,47 @@
+def get_translation(obj, attribute, language):
+    """Get the translation from an object, for an attribute.
+
+    The `obj` object is expected to have an attribute or key named `translations`
+    and its value should be of type `dict[str, dict[str, str]]`.
+
+    If the translation can't be found in the translations mapping, 
+    get the attribute on the object itself and raise 
+    :py:exc:`AttributeError` if it can't be found.
+
+    The language property is converted to lowercase (see :py:func:`lower_case_dict`
+    which must have been called on the translations first.
+
+    :param str attribute: The attribute to get
+    :param str language: The RFC 4646 language code
+    """
+    language = language.lower()
+    try:
+        return obj.translations[language][attribute]
+    except (AttributeError, KeyError, TypeError):
+        pass
+    try:
+        return obj["translations"][language][attribute]
+    except (AttributeError, KeyError, TypeError):
+        pass
+
+    if hasattr(obj, attribute):
+        return getattr(obj, attribute)
+
+    try:
+        return obj[attribute]
+    except (TypeError, AttributeError):
+        pass
+
+    raise AttributeError(
+        "Can't find translation '{}' for object type '{}'".format(attribute, type(obj).__name__)
+    )
+
+
+def lower_case_dict(translations=None):
+    """Returns a new dict, with its keys converted to lowercase.
+
+    :param dict[str, Any] translations: A dictionnary to be converted.
+    """
+    if translations is None:
+        return
+    return {k.lower(): v for k, v in translations.items()}

--- a/pywps/translations.py
+++ b/pywps/translations.py
@@ -4,8 +4,8 @@ def get_translation(obj, attribute, language):
     The `obj` object is expected to have an attribute or key named `translations`
     and its value should be of type `dict[str, dict[str, str]]`.
 
-    If the translation can't be found in the translations mapping, 
-    get the attribute on the object itself and raise 
+    If the translation can't be found in the translations mapping,
+    get the attribute on the object itself and raise
     :py:exc:`AttributeError` if it can't be found.
 
     The language property is converted to lowercase (see :py:func:`lower_case_dict`

--- a/pywps/translations.py
+++ b/pywps/translations.py
@@ -2,7 +2,7 @@ def get_translation(obj, attribute, language):
     """Get the translation from an object, for an attribute.
 
     The `obj` object is expected to have an attribute or key named `translations`
-    and its value should be of type `dict[str, dict[str, str]]`.
+    and its value should be of type `dict[str,dict[str,str]]`.
 
     If the translation can't be found in the translations mapping,
     get the attribute on the object itself and raise

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -475,13 +475,13 @@ class ExecuteTest(unittest.TestCase):
             output,
             './ows:Identifier')[0].text)
 
-        self.assertEqual(' 15  50 ', xpath_ns(
-            output,
-            './wps:Data/ows:WGS84BoundingBox/ows:LowerCorner')[0].text)
+        lower_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:LowerCorner')[0].text
+        lower_corner = lower_corner.strip().replace('  ', ' ')
+        self.assertEqual('15 50', lower_corner)
 
-        self.assertEqual(' 16  51 ', xpath_ns(
-            output,
-            './wps:Data/ows:WGS84BoundingBox/ows:UpperCorner')[0].text)
+        upper_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:UpperCorner')[0].text
+        upper_corner = upper_corner.strip().replace('  ', ' ')
+        self.assertEqual('16 51', upper_corner)
 
     def test_output_response_dataType(self):
         client = client_for(Service(processes=[create_greeter()]))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -32,6 +32,7 @@ from pywps.inout.basic import UOM
 from pywps._compat import PY2
 from pywps.inout.storage.file import FileStorageBuilder
 from pywps.tests import service_ok
+from pywps.translations import get_translation
 
 from lxml import etree
 
@@ -244,6 +245,7 @@ class SerializationComplexInputTest(unittest.TestCase):
             metadata=[Metadata("special data")],
             default="/some/file/path",
             default_type=SOURCE_TYPE.FILE,
+            translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
         )
         complex.as_reference = False
         complex.method = "GET"
@@ -262,6 +264,7 @@ class SerializationComplexInputTest(unittest.TestCase):
         self.assertEqual(complex_1.max_occurs, complex_2.max_occurs)
         self.assertEqual(complex_1.valid_mode, complex_2.valid_mode)
         self.assertEqual(complex_1.as_reference, complex_2.as_reference)
+        self.assertEqual(complex_1.translations, complex_2.translations)
 
         self.assertEqual(complex_1.prop, complex_2.prop)
 
@@ -463,7 +466,9 @@ class ComplexOutputTest(unittest.TestCase):
             workdir=tmp_dir,
             data_format=data_format,
             supported_formats=[data_format],
-            mode=MODE.NONE)
+            mode=MODE.NONE,
+            translations={"fr-CA": {"title": "Mon output", "abstract": "Une description"}},
+            )
 
         self.complex_out_nc = inout.outputs.ComplexOutput(
             identifier="netcdf",
@@ -546,6 +551,11 @@ class ComplexOutputTest(unittest.TestCase):
     def test_json(self):
         new_output = inout.outputs.ComplexOutput.from_json(self.complex_out.json)
         self.assertEqual(new_output.identifier, 'complexoutput')
+        self.assertEqual(
+            new_output.translations,
+            {"fr-ca": {"title": "Mon output", "abstract": "Une description"}},
+            'translations does not exist'
+        )
 
 
 class SimpleHandlerTest(unittest.TestCase):
@@ -576,7 +586,9 @@ class LiteralInputTest(unittest.TestCase):
             mode=2,
             allowed_values=(1, 2, (3, 3, 12)),
             default=6,
-            uoms=(UOM("metre"),))
+            uoms=(UOM("metre"),),
+            translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
+        )
 
     def test_contruct(self):
         self.assertIsInstance(self.literal_input, LiteralInput)
@@ -621,6 +633,11 @@ class LiteralInputTest(unittest.TestCase):
         self.assertEqual(out['type'], 'literal', 'it\'s literal input')
         self.assertEqual(len(out['allowed_values']), 3, '3 allowed values')
         self.assertEqual(out['allowed_values'][0]['value'], 1, 'allowed value 1')
+        self.assertEqual(
+            out['translations'],
+            {"fr-ca": {"title": "Mon input", "abstract": "Une description"}},
+            'translations does not exist'
+        )
 
     def test_json_out_datetime(self):
         inpt = inout.inputs.LiteralInput(
@@ -652,6 +669,13 @@ class LiteralInputTest(unittest.TestCase):
         out = inpt.json
         self.assertEqual(out['data'], '2017-04-20', 'date set')
 
+    def test_translations(self):
+        title_fr = get_translation(self.literal_input, "title", "fr-CA")
+        assert title_fr == "Mon input"
+        abstract_fr = get_translation(self.literal_input, "abstract", "fr-CA")
+        assert abstract_fr == "Une description"
+        identifier = get_translation(self.literal_input, "identifier", "fr-CA")
+        assert identifier == self.literal_input.identifier
 
 class LiteralOutputTest(unittest.TestCase):
     """LiteralOutput test cases"""
@@ -659,7 +683,11 @@ class LiteralOutputTest(unittest.TestCase):
     def setUp(self):
 
         self.literal_output = inout.outputs.LiteralOutput(
-            "literaloutput", data_type="integer", title="Literal Output")
+            "literaloutput", 
+            data_type="integer", 
+            title="Literal Output",
+            translations={"fr-CA": {"title": "Mon output", "abstract": "Une description"}},
+        )
 
     def test_contruct(self):
         self.assertIsInstance(self.literal_output, LiteralOutput)
@@ -674,6 +702,11 @@ class LiteralOutputTest(unittest.TestCase):
     def test_json(self):
         new_output = inout.outputs.LiteralOutput.from_json(self.literal_output.json)
         self.assertEqual(new_output.identifier, 'literaloutput')
+        self.assertEqual(
+            new_output.translations,
+            {"fr-ca": {"title": "Mon output", "abstract": "Une description"}},
+            'translations does not exist'
+        )
 
 
 class BBoxInputTest(unittest.TestCase):
@@ -681,7 +714,12 @@ class BBoxInputTest(unittest.TestCase):
 
     def setUp(self):
 
-        self.bbox_input = inout.inputs.BoundingBoxInput("bboxinput", title="BBox input", dimensions=2)
+        self.bbox_input = inout.inputs.BoundingBoxInput(
+            "bboxinput", 
+            title="BBox input", 
+            dimensions=2,
+            translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
+        )
         self.bbox_input.data = [0, 1, 2, 4]
 
     def test_contruct(self):
@@ -697,6 +735,11 @@ class BBoxInputTest(unittest.TestCase):
         # self.assertTupleEqual(out['bbox'], ([0, 1], [2, 4]), 'data are there')
         self.assertEqual(out['bbox'], [0, 1, 2, 4], 'data are there')
         self.assertEqual(out['dimensions'], 2, 'Dimensions set')
+        self.assertEqual(
+            out['translations'],
+            {"fr-ca": {"title": "Mon input", "abstract": "Une description"}},
+            'translations does not exist'
+        )
 
 
 class BBoxOutputTest(unittest.TestCase):
@@ -707,7 +750,9 @@ class BBoxOutputTest(unittest.TestCase):
             "bboxoutput",
             title="BBox output",
             dimensions=2,
-            crss=['epsg:3857', 'epsg:4326'])
+            crss=['epsg:3857', 'epsg:4326'],
+            translations={"fr-CA": {"title": "Mon output", "abstract": "Une description"}},
+        )
 
     def test_contruct(self):
         self.assertIsInstance(self.bbox_out, BBoxOutput)
@@ -722,6 +767,11 @@ class BBoxOutputTest(unittest.TestCase):
     def test_json(self):
         new_bbox = inout.outputs.BoundingBoxOutput.from_json(self.bbox_out.json)
         self.assertEqual(new_bbox.identifier, 'bboxoutput')
+        self.assertEqual(
+            new_bbox.translations,
+            {"fr-ca": {"title": "Mon output", "abstract": "Une description"}},
+            'translations does not exist'
+        )
 
 
 class TestMetaLink(unittest.TestCase):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -14,6 +14,7 @@ from pywps.inout import LiteralInput
 from pywps.inout import BoundingBoxInput
 from pywps.inout import ComplexInput
 from pywps.inout import FORMATS
+from pywps.translations import get_translation
 
 
 class DoNothing(Process):
@@ -22,12 +23,14 @@ class DoNothing(Process):
             self.donothing,
             "process",
             title="Process",
+            abstract="Process description",
             inputs=[LiteralInput("length", title="Length"),
                     BoundingBoxInput("bbox", title="BBox", crss=[]),
                     ComplexInput("vector", title="Vector", supported_formats=[FORMATS.GML])],
             outputs=[],
             metadata=[Metadata('process metadata 1', 'http://example.org/1'),
-                      Metadata('process metadata 2', 'http://example.org/2')]
+                      Metadata('process metadata 2', 'http://example.org/2')],
+            translations={"fr-CA": {"title": "Processus", "abstract": "Une description"}}
         )
 
     @staticmethod
@@ -62,6 +65,13 @@ class ProcessTestCase(unittest.TestCase):
         self.assertEqual("BBox", new_inputs["bbox"])
         self.assertEqual("Vector", new_inputs["vector"])
 
+    def test_get_translations(self):
+        title_fr = get_translation(self.process, "title", "fr-CA")
+        assert title_fr == "Processus"
+        abstract_fr = get_translation(self.process, "abstract", "fr-CA")
+        assert abstract_fr == "Une description"
+        identifier = get_translation(self.process, "identifier", "fr-CA")
+        assert identifier == self.process.identifier
 
 def load_tests(loader=None, tests=None, pattern=None):
     """Load local tests


### PR DESCRIPTION
# Overview

The 3 requests types are translated (GetCapabilities, DescribeProcess, Execute). 

I translated only the title and abstract attributes for processes, inputs and outputs. Should something else be translated?

See the changes to `docs/process.rst` for an example of the interface.

# Contribution Agreement

- [x] I'd like to contribute this feature to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
