### PR TITLE
Customize URL as a function of the data format

### DIFF
--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -53,3 +53,6 @@ region=us-east-1
 prefix=appname/coolapp/
 public=true
 encrypt=false
+
+
+[services]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,6 +22,7 @@ The configuration file has several sections:
     * `grass` for *optional* configuration to support `GRASS GIS
       <https://grass.osgeo.org>`_
     * `s3` for *optional* configuration to support AWS S3 storage
+    * `services` for custom output URLs based on output's mime-type
 
 PyWPS ships with a sample configuration file (``default-sample.cfg``).
 A similar file is also available in the `flask` service as
@@ -96,7 +97,7 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
     the URL of the WPS service endpoint
 
 :language:
-    a comma-separated list of ISO 639-1 language and ISO 3166-1 alpha2 country 
+    a comma-separated list of ISO 639-1 language and ISO 3166-1 alpha2 country
     code of the service
     (e.g. ``en-CA``, ``fr-CA``, ``en-US``)
 
@@ -210,7 +211,7 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
   <https://grass.osgeo.org/grass73/manuals/variables.html>`_
 
 [jobqueue]
---------
+----------
 
 :pause:
   pausing in seconds between periodical check for new stored requests
@@ -232,6 +233,14 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
 
 :encrypt:
   Set this to ``true`` if encryption at rest is desired. Defaults to ``false``
+
+
+[services]
+----------
+
+:<format>:
+  The URL for outputs whose requested mime-type matches one of the :py:const:`pywps.FORMATS`.
+
 
 -----------
 Sample file
@@ -299,3 +308,6 @@ Sample file
   prefix=appname/coolapp/
   public=true
   encrypt=false
+
+  [services]
+  NETCDF=http://localhost/thredds/fileServer/outputs

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -5,7 +5,7 @@ Deployment to a production server
 
 PyWPS consists from two main parts:
 * PyWPS :py:class:`pywps.app.Service` the main process to accept client requests,
-* :py:module:`pywps.queue` responsible for calling the stored requests in the asynchronous mode.
+* :py:mod:`pywps.queue` responsible for calling the stored requests in the asynchronous mode.
 
 --------------
 Service module
@@ -15,10 +15,8 @@ request executions: GetCapabilites, DescribeProcess and Execute in sync. mode,
 in this case, the Service class will
 
 1. Accept request
-2a. In case, the request is to be executed in *synchronous* mode, it will be
-        directly executed - sync requests are immediately executed.
-2b. In case, the request is to be executed as *asynchronous* mode, request
-    will be stored in to the database.
+2a. In case, the request is to be executed in *synchronous* mode, it will be directly executed - sync requests are immediately executed.
+2b. In case, the request is to be executed as *asynchronous* mode, request will be stored in to the database.
 
 This means: asynchronous requests are not executed by the Service class, they
 will be just stored into database.
@@ -26,7 +24,7 @@ will be just stored into database.
 ------------
 Queue module
 ------------
-The :py:module:`pywps.queue` has a `JobQueueService` to be started separately - it will
+The :py:mod:`pywps.queue` has a `JobQueueService` to be started separately - it will
 start a process, which will periodically check for the database stored
 requests and in case, some process is there, it will removed and executed.
 
@@ -93,7 +91,7 @@ Start the pywps with the following command::
 You can also start the pywps service and the job queue as seperated processes::
 
     $ pywps -c pywps.cfg start --no-jobqueue
-    $ pywps -c pywps.cfg jobqueue 
+    $ pywps -c pywps.cfg jobqueue
 
 Creating a PyWPS `WSGI` instance
 --------------------------------
@@ -300,6 +298,8 @@ The job queue has to be started from command line::
 
 .. _deployment-testing:
 
+
+------------------------------------------
 Testing the deployment of a PyWPS instance
 ------------------------------------------
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -99,3 +99,16 @@ Docker Container Extension
 .. todo:: This extension is on our wish list. In can be used to encapsulate
   and control the execution of a process. It enhances also the use case of
   Web Processing Services in a cloud computing infrastructure.
+
+
+--------------------------------
+Running PyWPS with other servers
+--------------------------------
+PyWPS is often run in conjunction with other servers providing endpoints for
+OGC protocol such as WMS, WMS, WFS or DAP. PyWPS can be configured so that
+process outputs URL points to these services instead of the standard file URL.
+For example, if an output has a DODS mime-type (Data Access Protocol), the
+configuration file could include a line in the ``services`` section with::
+
+  DODS=http://localhost/thredds/dodsC/outputs
+

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -138,6 +138,10 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('s3', 'encrypt', 'false')
     CONFIG.set('s3', 'region', '')
 
+    # Configure URL endpoints based on the data format. Keyed by pywps.FORMATS._fields
+    # Will default to outputurl if no mapping is found for a given format.
+    CONFIG.add_section('services')
+
     config_files = _get_default_config_files_location()
 
     if cfgfiles:

--- a/pywps/inout/storage/__init__.py
+++ b/pywps/inout/storage/__init__.py
@@ -46,10 +46,10 @@ class StorageAbstract(object, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def url(self, destination):
+    def url(self, destination, output_url=None):
         """
-        :param destination: the name of the output to calculate
-                            the url for
+        :param destination: the name of the output to calculate the url for
+        :param output_url: Custom base URL.
         :returns: URL where file_name can be reached
         """
         raise NotImplementedError

--- a/tests/test_filestorage.py
+++ b/tests/test_filestorage.py
@@ -25,7 +25,6 @@ class FileStorageTests(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
 
     def test_build_output_name(self):
-        storage = FileStorageBuilder().build()
         output = ComplexOutput('testme', 'Test', supported_formats=[FORMATS.TEXT], workdir=self.tmp_dir)
         output.data = "Hello World!"
         output_name, suffix = _build_output_name(output)
@@ -86,7 +85,8 @@ class FileStorageTests(unittest.TestCase):
         output.uuid = '595129f0-1a6c-11ea-a30c-acde48001122'
         store_type, store_str, url = storage.store(output)
 
-        self.assertEqual('http://localhost/textserver' + self.tmp_dir + '/595129f0-1a6c-11ea-a30c-acde48001122' + '/input.txt', url)
+        self.assertEqual('http://localhost/textserver' + self.tmp_dir +
+                         '/595129f0-1a6c-11ea-a30c-acde48001122' + '/input.txt', url)
 
         file_name = 'test.txt'
         url = storage.url(file_name)

--- a/tests/test_filestorage.py
+++ b/tests/test_filestorage.py
@@ -85,8 +85,8 @@ class FileStorageTests(unittest.TestCase):
         output.uuid = '595129f0-1a6c-11ea-a30c-acde48001122'
         store_type, store_str, url = storage.store(output)
 
-        self.assertEqual('http://localhost/textserver' + self.tmp_dir +
-                         '/595129f0-1a6c-11ea-a30c-acde48001122' + '/input.txt', url)
+        self.assertEqual('http://localhost/textserver' + self.tmp_dir
+                         + '/595129f0-1a6c-11ea-a30c-acde48001122' + '/input.txt', url)
 
         file_name = 'test.txt'
         url = storage.url(file_name)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -17,7 +17,6 @@ class StorageBuilderTests(unittest.TestCase):
         storage = StorageBuilder.buildStorage()
         self.assertIsInstance(storage, FileStorage)
 
-
     def test_s3_storage(self):
         configuration.CONFIG.set('server', 'storagetype', 's3')
         storage = StorageBuilder.buildStorage()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,7 @@ from pywps import configuration
 
 import unittest
 
+
 class StorageBuilderTests(unittest.TestCase):
 
     def test_default_storage(self):
@@ -21,6 +22,7 @@ class StorageBuilderTests(unittest.TestCase):
         configuration.CONFIG.set('server', 'storagetype', 's3')
         storage = StorageBuilder.buildStorage()
         self.assertIsInstance(storage, S3Storage)
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     """Load local tests


### PR DESCRIPTION
# Overview
This PR proposes a mechanism that customizes the URL of an output based on its data format. By default the standard outputurl is used, but if the data format (identified by the field of the FORMATS tuple) is included in the `services` section of the configuration, then this is substituted. 

# Related Issue / Discussion
Fixes #512 

The use case for this is to run a THREDDS server or GeoServer alongside a PyWPS server, and serve some of the process outputs using dedicated services instead of a simple file url. 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
