### PR TITLE
allow custom UOM reference for literal IO

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -65,12 +65,16 @@ class UOM(object):
     :param uom: unit of measure
     """
 
-    def __init__(self, uom=''):
+    def __init__(self, uom='', reference=None):
         self.uom = uom
+        self.reference = reference
+
+        if self.reference is None:
+            self.reference = OGCUNIT[self.uom]
 
     @property
     def json(self):
-        return {"reference": OGCUNIT[self.uom],
+        return {"reference": self.reference,
                 "uom": self.uom}
 
     def __eq__(self, other):

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -338,7 +338,10 @@ class LiteralInput(basic.LiteralInput):
 
         json_input_copy = deepcopy(json_input)
         json_input_copy['allowed_values'] = allowed_values
-        json_input_copy['uoms'] = [basic.UOM(uom.get('uom')) for uom in json_input.get('uoms', [])]
+        json_input_copy['uoms'] = [
+            basic.UOM(uom['uom'], uom['reference'])
+            for uom in json_input.get('uoms', [])
+        ]
 
         data = json_input_copy.pop('data', None)
         uom = json_input_copy.pop('uom', None)
@@ -352,7 +355,7 @@ class LiteralInput(basic.LiteralInput):
         instance.metadata = [Metadata.from_json(d) for d in metadata]
         instance.data = data
         if uom:
-            instance.uom = basic.UOM(uom['uom'])
+            instance.uom = basic.UOM(uom['uom'], uom['reference'])
 
         return instance
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -281,7 +281,10 @@ class LiteralOutput(basic.LiteralOutput):
 
     @classmethod
     def from_json(cls, json_output):
-        uoms = [basic.UOM(uom.get('uom')) for uom in json_output.get('uoms', [])]
+        uoms = [
+            basic.UOM(uom['uom'], uom['reference'])
+            for uom in json_output.get('uoms', [])
+        ]
         uom = json_output.get('uom')
 
         instance = cls(
@@ -296,7 +299,7 @@ class LiteralOutput(basic.LiteralOutput):
 
         instance.data = json_output.get('data')
         if uom:
-            instance.uom = basic.UOM(uom['uom'])
+            instance.uom = basic.UOM(uom['uom'], uom['reference'])
 
         return instance
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -569,7 +569,7 @@ class LiteralInputTest(unittest.TestCase):
             mode=2,
             allowed_values=(1, 2, (3, 3, 12)),
             default=6,
-            uoms=(UOM("metre"),),
+            uoms=(UOM("metre"), UOM("km / h", "custom reference")),
             translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
         )
 
@@ -603,8 +603,10 @@ class LiteralInputTest(unittest.TestCase):
         self.literal_input.data = 9
         out = self.literal_input.json
 
-        self.assertTrue('uoms' in out, 'UOMs does not exist')
-        self.assertTrue('uom' in out, 'uom does not exist')
+        self.assertEqual(out['uoms'][0]["uom"], "metre")
+        self.assertEqual(out['uoms'][1]["uom"], "km / h")
+        self.assertEqual(out['uoms'][1]["reference"], "custom reference")
+        self.assertEqual(out['uom']["uom"], "metre")
         self.assertFalse(out['workdir'], 'Workdir exist')
         self.assertEqual(out['data_type'], 'integer', 'Data type is integer')
         self.assertFalse(out['abstract'], 'abstract exist')
@@ -669,6 +671,7 @@ class LiteralOutputTest(unittest.TestCase):
             "literaloutput",
             data_type="integer",
             title="Literal Output",
+            uoms=[UOM("km / h", "custom reference"), UOM("m / s", "other reference")],
             translations={"fr-CA": {"title": "Mon output", "abstract": "Une description"}},
         )
 
@@ -685,6 +688,8 @@ class LiteralOutputTest(unittest.TestCase):
     def test_json(self):
         new_output = inout.outputs.LiteralOutput.from_json(self.literal_output.json)
         self.assertEqual(new_output.identifier, 'literaloutput')
+        self.assertEqual(new_output.uom, self.literal_output.uom)
+        self.assertEqual(new_output.uoms, self.literal_output.uoms)
         self.assertEqual(
             new_output.translations,
             {"fr-ca": {"title": "Mon output", "abstract": "Une description"}},


### PR DESCRIPTION
# Overview

Currently, the only UOMs allowed when serializing an input are `degree`, `meter` and `unity` (see `pywps.OGCUNIT`). With the new 'watchdog' process, the inputs are always serialized, so these units are the only ones allowed.

I think that leaving the responsibility to the PYWPS service implementation to provide the UOM reference could be a simple solution to this.

# Contribution Agreement

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
