### PR TITLE
Use bump2version to track version changes

### DIFF
--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -9,7 +9,7 @@ import os
 
 from lxml.builder import ElementMaker
 
-__version__ = '4.2.2'
+__version__ = "4.2.4"
 
 LOGGER = logging.getLogger('PYWPS')
 LOGGER.debug('setting core variables')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pylint
 Sphinx
 twine
 wheel
+bump2version

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,8 @@ serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:pywps/__init__.py]
-search = VERSION = "{current_version}"
-replace = VERSION = "{new_version}"
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
 
 [bumpversion:file:VERSION.txt]
 search = {current_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,19 @@
 ignore=F401,E402,W606
 max-line-length=120
 exclude=tests, pywps/alembic/versions
+
+[bumpversion]
+current_version = 4.2.4
+commit = False
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)
+serialize =
+	{major}.{minor}.{patch}
+
+[bumpversion:file:pywps/__init__.py]
+search = VERSION = "{current_version}"
+replace = VERSION = "{new_version}"
+
+[bumpversion:file:VERSION.txt]
+search = {current_version}
+replace = {new_version}


### PR DESCRIPTION
# Overview
This PR adds `bump2version` (a maintained fork of `bumpversion`) to the repository to manage version changes. This works by setting the standard version number in the `setup.cfg` and performs the changes based on semantic versioning scheme. From the command line:
```
bump2version patch --> +0.0.1
bump2version minor --> +0.1.x # where x is reset to 0
bump2version major --> +1.x.x # where x is reset to 0
```
`bump2version` can also do things like tag versions and create commits when tagging. These have are not enabled in this PR.

# Related Issue / Discussion
https://github.com/geopython/pywps/issues/525

# Additional Information
https://pypi.org/project/bump2version/

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
