### PR TITLE
added long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ CONFIG = {
     'version': VERSION,
     'description': DESCRIPTION,
     'long_description': LONG_DESCRIPTION,
+    'long_description_content_type': 'text/markdown',
     'keywords': KEYWORDS,
     'license': 'MIT',
     'platforms': 'all',


### PR DESCRIPTION
# Overview

Adding `long_description_content_type` to `setup.py`. We use markdown ... but pypi assumes as default rst.

# Related Issue / Discussion

Fix #533 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
