### PR TITLE
Added validation for GPX files, fixes issue (#535)

### DIFF
--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 import mimetypes
 
 
-_FORMATS = namedtuple('FORMATS', 'GEOJSON, JSON, SHP, GML, METALINK, META4, KML, KMZ, GEOTIFF,'
+_FORMATS = namedtuple('FORMATS', 'GEOJSON, JSON, SHP, GML, GPX, METALINK, META4, KML, KMZ, GEOTIFF,'
                                  'WCS, WCS100, WCS110, WCS20, WFS, WFS100,'
                                  'WFS110, WFS20, WMS, WMS130, WMS110,'
                                  'WMS100, TEXT, DODS, NETCDF, NCML, LAZ, LAS, ZIP,'
@@ -167,6 +167,7 @@ FORMATS = _FORMATS(
     Format('application/json', extension='.json'),
     Format('application/x-zipped-shp', extension='.zip', encoding='base64'),
     Format('application/gml+xml', extension='.gml'),
+    Format('application/gpx+xml', extension='.gpx'),
     Format('application/metalink+xml; version=3.0', extension='.metalink', schema="metalink/3.0/metalink.xsd"),
     Format('application/metalink+xml; version=4.0', extension='.meta4', schema="metalink/4.0/metalink4.xsd"),
     Format('application/vnd.google-earth.kml+xml', extension='.kml'),

--- a/pywps/validator/__init__.py
+++ b/pywps/validator/__init__.py
@@ -9,7 +9,7 @@
 
 import logging
 from pywps.validator.complexvalidator import validategml, validateshapefile, validatejson, validategeojson, \
-    validategeotiff, validatenetcdf, validatedods
+    validategeotiff, validatenetcdf, validatedods, validategpx
 from pywps.validator.base import emptyvalidator
 
 LOGGER = logging.getLogger('PYWPS')
@@ -19,6 +19,7 @@ _VALIDATORS = {
     'application/json': validatejson,
     'application/x-zipped-shp': validateshapefile,
     'application/gml+xml': validategml,
+    'application/gpx+xml': validategpx,
     'image/tiff; subtype=geotiff': validategeotiff,
     'application/x-netcdf': validatenetcdf,
     'application/x-ogc-dods': validatedods,

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -75,6 +75,63 @@ def validategml(data_input, mode):
     return passed
 
 
+def validategpx(data_input, mode):
+    """GPX validation function
+
+    :param data_input: :class:`ComplexInput`
+    :param pywps.validator.mode.MODE mode:
+
+    This function validates GPX input based on given validation mode. Following
+    happens, if `mode` parameter is given:
+
+    `MODE.NONE`
+        it will return always `True`
+    `MODE.SIMPLE`
+        the mimetype will be checked
+    `MODE.STRICT`
+        `GDAL/OGR <http://gdal.org/>`_ is used for getting the proper format.
+    `MODE.VERYSTRICT`
+        the :class:`lxml.etree` is used along with given input `schema` and the
+        GPX file is properly validated against given schema.
+    """
+
+    LOGGER.info('validating GPX; Mode: {}'.format(mode))
+    passed = False
+
+    if mode >= MODE.NONE:
+        passed = True
+
+    if mode >= MODE.SIMPLE:
+
+        name = data_input.file
+        (mtype, encoding) = mimetypes.guess_type(name, strict=False)
+        passed = data_input.data_format.mime_type in {mtype, FORMATS.GPX.mime_type}
+
+    if mode >= MODE.STRICT:
+
+        from pywps.dependencies import ogr
+        data_source = ogr.Open(data_input.file)
+        if data_source:
+            passed = (data_source.GetDriver().GetName() == "GPX")
+        else:
+            passed = False
+
+    if mode >= MODE.VERYSTRICT:
+
+        from lxml import etree
+
+        try:
+            schema_url = data_input.data_format.schema
+            gpxschema_doc = etree.parse(urlopen(schema_url))
+            gpxschema = etree.XMLSchema(gpxschema_doc)
+            passed = gpxschema.validate(etree.parse(data_input.stream))
+        except Exception as e:
+            LOGGER.warning(e)
+            passed = False
+
+    return passed
+
+
 def validatexml(data_input, mode):
     """XML validation function
 


### PR DESCRIPTION
# Overview

Adds validation for GPX files. 
An alternate way of doing it to reduce code re-use would be to make validategml() check for either GPX or GML. Though coupling validation of different formats in that way might not be ideal.

# Related Issue / Discussion

Issue #535 #536 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ X ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
