### PR TITLE
Fix scheduler

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -69,7 +69,7 @@ class Process(object):
         self.inputs = inputs
         self.outputs = outputs
         self.uuid = None
-        self.status_store = None
+        self._status_store = None
         # self.status_location = ''
         # self.status_url = ''
         self.workdir = None
@@ -161,7 +161,13 @@ class Process(object):
             outpt.uuid = uuid
 
     def _setup_status_storage(self):
-        self.status_store = StorageBuilder.buildStorage()
+        self._status_store = StorageBuilder.buildStorage()
+
+    @property
+    def status_store(self):
+        if self._status_store is None:
+            self._setup_status_storage()
+        return self._status_store
 
     @property
     def status_location(self):

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -149,9 +149,9 @@ def load_configuration(cfgfiles=None):
         cfgfiles = [cfgfiles]
 
     if 'PYWPS_CFG' in os.environ:
-        config_files.append(os.environ['PYWPS_CFG'])
+        cfgfiles.append(os.environ['PYWPS_CFG'])
 
-    loaded_files = CONFIG.read(config_files, encoding='utf-8')
+    loaded_files = CONFIG.read(cfgfiles, encoding='utf-8')
     if loaded_files:
         LOGGER.info('Configuration file(s) {} loaded'.format(loaded_files))
     else:


### PR DESCRIPTION
# Overview

This PR is a quick fix for scheduler extension. It make sure that `process.status_store` is not None.

It also fixes the `cfgfiles` in `configuration.py` ... a bug introduced by PR #532.

# Related Issue / Discussion

#532 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
