### PR TITLE
ext_autodoc: support RST anonymous link

### DIFF
--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -8,6 +8,21 @@ from pywps import Process
 from pywps.app.Common import Metadata
 
 
+class MetadataUrl(Metadata):
+    """Metadata subclass to allow anonymous links generation.
+
+    Useful to avoid Sphinx "Duplicate explicit target name" warning.
+
+    See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks.
+    """
+
+    def __init__(self, title, href=None, role=None, type_='simple',
+                 anonymous=False):
+        super().__init__(title, href=href, role=role, type_=type_)
+        self.anonymous = anonymous
+        "Whether to create anonymous link (boolean)."
+
+
 class ProcessDocumenter(ClassDocumenter):
     """Sphinx autodoc ClassDocumenter subclass that understands the
     pywps.Process class.
@@ -126,8 +141,11 @@ class ProcessDocumenter(ClassDocumenter):
                 title, href = m['title'], m['href']
             else:
                 title, href = None, None
+            extra_underscore = ""
+            if isinstance(m, MetadataUrl):
+                extra_underscore = "_" if m.anonymous else ""
             if title and href:
-                ref.append(u" - `{} <{}>`_".format(title, href))
+                ref.append(u" - `{} <{}>`_{}".format(title, href, extra_underscore))
                 hasref = True
 
         ref.append('')

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -12,6 +12,7 @@ from pywps import Process
 from pywps.inout import LiteralInput, LiteralOutput, ComplexInput, ComplexOutput, BoundingBoxInput, BoundingBoxOutput
 from pywps.inout import Format
 from pywps.app.Common import Metadata
+from pywps.ext_autodoc import MetadataUrl
 
 import re
 
@@ -75,7 +76,10 @@ class DocExampleProcess(Process):
             version="4.0",
             metadata=[Metadata('PyWPS docs', 'https://pywps.org'),
                       Metadata('NumPy docstring conventions',
-                               'https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt')],
+                               'https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt'),
+                      MetadataUrl('Duplicate label', 'http://one.example.com', anonymous=True),
+                      MetadataUrl('Duplicate label', 'http://two.example.com', anonymous=True),
+                      ],
             inputs=inputs,
             outputs=outputs,
         )


### PR DESCRIPTION
# Overview

Sphinx "Duplicate explicit target name" warning is problematic when
warning are turned into errors (`sphinx-build -W`).

And we would want warnings to turn into error because autodoc import
failure are treated as warnings only, resulting into silent
documentation build failure if those warnings do not fail the build.

# Related Issue / Discussion

See PR https://github.com/bird-house/cookiecutter-birdhouse/pull/96 with the silent doc build error.

See commit https://github.com/bird-house/flyingpigeon/pull/336/commits/c97ebca73792c1fb0c32d7b6079385fcd84a73b0 for actual real usage of this change.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
