### PR TITLE
pywps/app/Service.py - allow inputpaths to accept full windows paths …

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -372,23 +372,7 @@ def _build_input_file_name(href, workdir, extension=None):
     return input_file_name
 
 
-def _validate_file_input(href):
-    href = href or ''
-    parsed_url = urlparse(href)
-    if parsed_url.scheme != 'file':
-        raise FileURLNotSupported('Invalid URL scheme')
-    file_path = parsed_url.path
-    if not file_path:
-        raise FileURLNotSupported('Invalid URL path')
-    file_path = os.path.abspath(file_path)
-    # build allowed paths list
-    inputpaths = config.get_config_value('server', 'allowedinputpaths')
-    allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
-    for allowed_path in allowed_paths:
-        if file_path.startswith(allowed_path):
-            LOGGER.debug("Accepted file url as input.")
-            return
-    raise FileURLNotSupported()
+_validate_file_input = ComplexInput._validate_file_input
 
 
 def _extension(complexinput):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -935,7 +935,7 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
         file_path = os.path.abspath(file_path)
         # build allowed paths list
         inputpaths = config.get_config_value('server', 'allowedinputpaths')
-        allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
+        allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(os.pathsep) if p.strip()]
         for allowed_path in allowed_paths:
             if file_path.startswith(allowed_path):
                 LOGGER.debug("Accepted file url as input.")


### PR DESCRIPTION
…that include colon (i.e. c:\inputs)

* pywps/inout/basic.py - allow inputpaths to accept full windows paths that include colon by using os.pathsep instead of ':'. os.pathsep is ':' on unix and ';' on windows.
pywps/app/Service.py - remove duplicated code, use pywps.inout.basic.ComplexInput._validate_file_input

# Overview
With this bugfix one can now provide full windows paths (with colon) as follows:
allowedinputpaths=./static/;d:\Maps
The path separator on windows is a semicolon, and the path separator on Linux is a colon (which is a valid character in a windows path)

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [bugfix] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
