### PR TITLE
pywps/inout/basic.py, pywps/app/Service.py - replace ':' with os.pathsep

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -378,7 +378,7 @@ def _validate_file_input(href):
     file_path = os.path.abspath(file_path)
     # build allowed paths list
     inputpaths = config.get_config_value('server', 'allowedinputpaths')
-    allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
+    allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(os.pathsep) if p.strip()]
     for allowed_path in allowed_paths:
         if file_path.startswith(allowed_path):
             LOGGER.debug("Accepted file url as input.")

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -932,7 +932,7 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
         file_path = os.path.abspath(file_path)
         # build allowed paths list
         inputpaths = config.get_config_value('server', 'allowedinputpaths')
-        allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(':') if p.strip()]
+        allowed_paths = [os.path.abspath(p.strip()) for p in inputpaths.split(os.pathsep) if p.strip()]
         for allowed_path in allowed_paths:
             if file_path.startswith(allowed_path):
                 LOGGER.debug("Accepted file url as input.")


### PR DESCRIPTION
... (colon on Linux, semicolon on Windows) to allow path list separation also on Windows with full paths that include colon (i.e.. c:\maps)

# Overview

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
