### PR TITLE
process error with formatting

### DIFF
--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -9,7 +9,7 @@ Process exceptions raised intentionally in processes to provide information for 
 
 import re
 
-DEFAULT_ALLOWED_CHARS = ".:!?=,;_/"
+DEFAULT_ALLOWED_CHARS = ".:!?=,;-_/"
 
 import logging
 
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger('PYWPS')
 def format_message(text, min_length=3, max_length=300, allowed_chars=None):
     allowed_chars = allowed_chars or DEFAULT_ALLOWED_CHARS
     special = re.escape(allowed_chars)
-    pattern = rf'[\w{allowed_chars}]+'
+    pattern = rf'[\w{special}]+'
     msg = ' '.join(re.findall(pattern, text))
     msg.strip()
     if len(msg) >= min_length:

--- a/tests/test_app_exceptions.py
+++ b/tests/test_app_exceptions.py
@@ -1,0 +1,35 @@
+##################################################################
+# Copyright 2018 Open Source Geospatial Foundation and others    #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+import unittest
+from pywps.app.exceptions import format_message, ProcessError
+
+
+class AppExceptionsTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_format_message(self):
+        assert format_message('no data available') == 'no data available'
+        assert format_message(' no data available! ') == 'no data available!'
+        assert format_message('no') == ''
+        assert format_message('no data available', max_length=7) == 'no data'
+        assert format_message('no &data% available') == 'no data available'
+        assert format_message(".:!?=,;_/") == ".:!?=,;_/"
+
+    def test_process_error(self):
+        assert ProcessError(' no &data available!').message == 'no data available!'
+        assert ProcessError('no', min_length=2).message == 'no'
+        assert ProcessError('0 data available', max_length=6).message == '0 data'
+        assert ProcessError('no data? not available!', allowed_chars='?').message == 'no data? not available'
+        assert ProcessError('').message == 'Sorry, process failed. Please check server error log.'
+        assert ProcessError(1234).message == 'Sorry, process failed. Please check server error log.'
+        try:
+            raise ProcessError('no data!!')
+        except ProcessError as e:
+            assert f"{e}" == 'no data!!'
+        else:
+            assert False

--- a/tests/test_app_exceptions.py
+++ b/tests/test_app_exceptions.py
@@ -4,7 +4,7 @@
 ##################################################################
 
 import unittest
-from pywps.app.exceptions import format_message, ProcessError
+from pywps.app.exceptions import format_message, ProcessError, DEFAULT_ALLOWED_CHARS
 
 
 class AppExceptionsTest(unittest.TestCase):
@@ -18,7 +18,7 @@ class AppExceptionsTest(unittest.TestCase):
         assert format_message('no') == ''
         assert format_message('no data available', max_length=7) == 'no data'
         assert format_message('no &data% available') == 'no data available'
-        assert format_message(".:!?=,;_/") == ".:!?=,;_/"
+        assert format_message(DEFAULT_ALLOWED_CHARS) == DEFAULT_ALLOWED_CHARS
 
     def test_process_error(self):
         assert ProcessError(' no &data available!').message == 'no data available!'


### PR DESCRIPTION
# Overview

This PR updates the app exception `ProcessError`. Instead of validation and skipping invalid messages it formats  the message with only valid characters and length.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
