### PR TITLE
fix bbox parsing for get and post request

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -270,10 +270,12 @@ class Service(object):
 
         outinputs = deque(maxlen=source.max_occurs)
 
-        for datainput in inputs:
+        for inpt in inputs:
             newinpt = source.clone()
-            newinpt.data = [datainput.minx, datainput.miny,
-                            datainput.maxx, datainput.maxy]
+            newinpt.data = inpt.get('data')
+            LOGGER.debug(f'newinpt bbox data={newinpt.data}')
+            newinpt.crs = inpt.get('crs')
+            newinpt.dimensions = inpt.get('dimensions')
             outinputs.append(newinpt)
 
         if len(outinputs) < source.min_occurs:

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -450,10 +450,15 @@ def get_inputs_from_xml(doc):
         bbox_datas = xpath_ns(input_el, './wps:Data/wps:BoundingBoxData')
         if bbox_datas:
             for bbox_data in bbox_datas:
-                bbox_data_el = bbox_data
-                bbox = BoundingBox(bbox_data_el)
-                the_inputs[identifier].append(bbox)
-                LOGGER.debug("parse bbox: {},{},{},{}".format(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy))
+                bbox = BoundingBox(bbox_data)
+                LOGGER.debug("parse bbox: minx={}, miny={}, maxx={},maxy={}".format(
+                    bbox.minx, bbox.miny, bbox.maxx, bbox.maxy))
+                inpt = {}
+                inpt['identifier'] = identifier_el.text
+                inpt['data'] = [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy]
+                inpt['crs'] = bbox.crs
+                inpt['dimensions'] = bbox.dimensions
+                the_inputs[identifier].append(inpt)
     return the_inputs
 
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -677,22 +677,34 @@ class BasicBoundingBox(object):
     """
 
     def __init__(self, crss=None, dimensions=2):
+        self._data = None
         self.crss = crss or ['epsg:4326']
         self.crs = self.crss[0]
         self.dimensions = dimensions
 
     @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        if isinstance(value, list):
+            self._data = [float(number) for number in value]
+        elif isinstance(value, str):
+            self._data = [float(number) for number in value.split(',')[:4]]
+        else:
+            self._data = None
+
+    @property
     def ll(self):
-        data = getattr(self, 'data', None)
-        if data:
-            return data[:2]
+        if self.data:
+            return self.data[:2]
         return []
 
     @property
     def ur(self):
-        data = getattr(self, 'data', None)
-        if data:
-            return data[2:]
+        if self.data:
+            return self.data[2:]
         return []
 
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -105,7 +105,7 @@ def create_bbox_process():
         coords = request.inputs['mybbox'][0].data
         assert isinstance(coords, list)
         assert len(coords) == 4
-        assert coords[0] == '15'
+        assert coords[0] == 15.0
         response.outputs['outbbox'].data = coords
         return response
 
@@ -459,8 +459,8 @@ class ExecuteTest(unittest.TestCase):
                 WPS.Input(
                     OWS.Identifier('mybbox'),
                     WPS.Data(WPS.BoundingBoxData(
-                        OWS.LowerCorner('15 50'),
-                        OWS.UpperCorner('16 51'),
+                        OWS.LowerCorner('15.0 50.0'),
+                        OWS.UpperCorner('16.0 51.0'),
                     ))
                 )
             ),
@@ -477,11 +477,11 @@ class ExecuteTest(unittest.TestCase):
 
         lower_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:LowerCorner')[0].text
         lower_corner = lower_corner.strip().replace('  ', ' ')
-        self.assertEqual('15 50', lower_corner)
+        self.assertEqual('15.0 50.0', lower_corner)
 
         upper_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:UpperCorner')[0].text
         upper_corner = upper_corner.strip().replace('  ', ' ')
-        self.assertEqual('16 51', upper_corner)
+        self.assertEqual('16.0 51.0', upper_corner)
 
     def test_output_response_dataType(self):
         client = client_for(Service(processes=[create_greeter()]))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -381,18 +381,18 @@ class SerializationBoundingBoxInputTest(unittest.TestCase):
 
     def make_bbox_input(self):
         bbox = inout.inputs.BoundingBoxInput(
-            identifier="complexinput",
-            title='MyComplex',
+            identifier="bbox",
+            title='BBox',
             crss=['epsg:3857', 'epsg:4326'],
             abstract="some description",
             keywords=['kw1', 'kw2'],
             dimensions=2,
             workdir=self.tmp_dir,
-            metadata=[Metadata("special data")],
+            metadata=[Metadata("bbox")],
             min_occurs=2,
             max_occurs=5,
             mode=MODE.NONE,
-            default="something else",
+            default="0,50,20,70",
             default_type=SOURCE_TYPE.DATA,
         )
         bbox.as_reference = False
@@ -411,7 +411,6 @@ class SerializationBoundingBoxInputTest(unittest.TestCase):
         self.assertEqual(bbox_1.max_occurs, bbox_2.max_occurs)
         self.assertEqual(bbox_1.valid_mode, bbox_2.valid_mode)
         self.assertEqual(bbox_1.as_reference, bbox_2.as_reference)
-
         self.assertEqual(bbox_1.ll, bbox_2.ll)
         self.assertEqual(bbox_1.ur, bbox_2.ur)
 


### PR DESCRIPTION
# Overview

This PR refactors the bbox parsing code so that it works for `Post` and `Get` requests.

# Related Issue / Discussion

#404 #405 

# Additional Information

Test with Emu WPS:
https://github.com/bird-house/emu/blob/master/emu/processes/wps_bbox.py

Example `Get` request:
```
http://localhost:5000/wps?service=wps&version=1.0.0&request=Execute&identifier=bbox&DataInputs=bbox=46,102,47,103,urn:ogc:def:crs:EPSG:6.6:4326,2&lineage=true
```

Example `Post` request with OWSLib:
```python
from owslib.wps import WebProcessingService, BoundingBoxDataInput
wps = WebProcessingService('http://localhost:5000/wps')
bbox = BoundingBoxDataInput(data=[10, 50, 20, 60])
wps.execute(identifier='bbox', inputs=[('bbox', bbox)])
```

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
