### PR TITLE
fix bbox in execute template

### DIFF
--- a/pywps/templates/1.0.0/execute/main.xml
+++ b/pywps/templates/1.0.0/execute/main.xml
@@ -48,17 +48,10 @@
 			</wps:Data>
             {% elif input.type == "bbox" %}
 			<wps:Data>
-                {% if input.crs == "EPSG:4326" %}
-                <ows:WGS84BoundingBox dimensions="{{ input.dimensions }}">
+                <wps:BoundingBoxData crs="{{ input.crs }}" dimensions="{{ input.dimensions }}">
                     <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
                     <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
-                </ows:WGS84BoundingBox>
-                {% else %}
-                <ows:BoundingBox crs="{{ input.crs }}" dimensions="{{ input.dimensions }}">
-                    <ows:LowerCorner>{% for c in input.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
-                    <ows:UpperCorner>{% for c in input.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
-                </ows:BoundingBox>
-                {% endif %}
+                </wps:BoundingBoxData>
 			</wps:Data>
             {% elif input.type == "reference" %}
             <wps:Reference xlink:href="{{ input.href }}" method="{{ input.method }}" mimeType="{{ input.mimetype }}" encoding="{{ input.encoding }}" schema="{{ input.schema }}"/>
@@ -102,17 +95,10 @@
 			</wps:Data>
             {% elif output.type == "bbox" %}
 			<wps:Data>
-                    {% if output.crs == "EPSG:4326" %}
-                    <ows:WGS84BoundingBox dimensions="{{ output.dimensions }}">
+                    <wps:BoundingBoxData crs="{{ output.crs }}" dimensions="{{ output.dimensions }}">
                         <ows:LowerCorner>{% for c in output.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
                         <ows:UpperCorner>{% for c in output.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
-                    </ows:WGS84BoundingBox>
-                    {% else %}
-                    <ows:BoundingBox crs="{{ output.crs }}" dimensions="{{ output.dimensions }}">
-                        <ows:LowerCorner>{% for c in output.ll %} {{ c }} {% endfor %}</ows:LowerCorner>
-                        <ows:UpperCorner>{% for c in output.ur %} {{ c }} {% endfor %}</ows:UpperCorner>
-                    </ows:BoundingBox>
-                    {% endif %}
+                    </wps:BoundingBoxData>
 			</wps:Data>
             {% endif %}
 		</wps:Output>

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -475,11 +475,11 @@ class ExecuteTest(unittest.TestCase):
             output,
             './ows:Identifier')[0].text)
 
-        lower_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:LowerCorner')[0].text
+        lower_corner = xpath_ns(output, './wps:Data/wps:BoundingBoxData/ows:LowerCorner')[0].text
         lower_corner = lower_corner.strip().replace('  ', ' ')
         self.assertEqual('15.0 50.0', lower_corner)
 
-        upper_corner = xpath_ns(output, './wps:Data/ows:WGS84BoundingBox/ows:UpperCorner')[0].text
+        upper_corner = xpath_ns(output, './wps:Data/wps:BoundingBoxData/ows:UpperCorner')[0].text
         upper_corner = upper_corner.strip().replace('  ', ' ')
         self.assertEqual('16.0 51.0', upper_corner)
 


### PR DESCRIPTION
# Overview

According to the [wps 1.0.0 schema](http://schemas.opengis.net/wps/1.0.0/) the bbox in the execute response should look like this:
```
<wps:BoundingBoxData crs="epsg:4326" dimensions="2">
          <ows:LowerCorner> -90.0 -180.0</ows:LowerCorner>
           <ows:UpperCorner> 90.0 180.0</ows:UpperCorner>
</wps:BoundingBoxData>
```

The schema has no entry for `WGS84BoundingBox`.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
