### PR TITLE
Initial support for requests in JSON format

### DIFF
--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -5,6 +5,8 @@
 
 import logging
 import tempfile
+from typing import Sequence, Optional, Dict
+
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Request, Response
 from pywps._compat import PY2
@@ -41,9 +43,10 @@ class Service(object):
     :param cfgfiles: A list of configuration files
     """
 
-    def __init__(self, processes=[], cfgfiles=None):
+    def __init__(self, processes: Sequence = [], cfgfiles=None, preprocessors: Optional[Dict] = None):
         # ordered dict of processes
         self.processes = OrderedDict((p.identifier, p) for p in processes)
+        self.preprocessors = preprocessors or dict()
 
         if cfgfiles:
             config.load_configuration(cfgfiles)
@@ -308,7 +311,7 @@ class Service(object):
                 LOGGER.debug('Setting PYWPS_CFG to {}'.format(environ_cfg))
                 os.environ['PYWPS_CFG'] = environ_cfg
 
-            wps_request = WPSRequest(http_request)
+            wps_request = WPSRequest(http_request, self.preprocessors)
             LOGGER.info('Request: {}'.format(wps_request.operation))
             if wps_request.operation in ['getcapabilities',
                                          'describeprocess',

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -88,7 +88,13 @@ class WPSRequest(object):
         mimetype = self.http_request.mimetype if self.http_request.mimetype is not None else self.http_request.content_type
         json_input = 'json' in mimetype
         if json_input:
-            jdoc = json.loads(self.http_request.get_data())
+            try:
+                jdoc = json.loads(self.http_request.get_data())
+            except Exception as e:
+                if PY2:
+                    raise NoApplicableCode(e.message)
+                else:
+                    raise NoApplicableCode(e.msg)
             self.json = jdoc
             operation = jdoc.get('operation', 'execute')
             version = jdoc.get('version', default_version)

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -519,7 +519,7 @@ def get_inputs_from_xml(doc):
             complex_data_el = complex_data[0]
             inpt = {}
             inpt['identifier'] = identifier_el.text
-            inpt['mimeType'] = complex_data_el.attrib.get('mimeType', '')
+            inpt['mimeType'] = complex_data_el.attrib.get('mimeType', None)
             inpt['encoding'] = complex_data_el.attrib.get('encoding', '').lower()
             inpt['schema'] = complex_data_el.attrib.get('schema', '')
             inpt['method'] = complex_data_el.attrib.get('method', 'GET')
@@ -540,7 +540,7 @@ def get_inputs_from_xml(doc):
             inpt[identifier_el.text] = reference_data_el.text
             inpt['href'] = reference_data_el.attrib.get(
                 '{http://www.w3.org/1999/xlink}href', '')
-            inpt['mimeType'] = reference_data_el.attrib.get('mimeType', '')
+            inpt['mimeType'] = reference_data_el.attrib.get('mimeType', None)
             inpt['method'] = reference_data_el.attrib.get('method', 'GET')
             header_element = xpath_ns(reference_data_el, './wps:Header')
             if header_element:
@@ -584,7 +584,7 @@ def get_output_from_xml(doc):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
             outpt = {}
             outpt[identifier_el.text] = ''
-            outpt['mimetype'] = output_el.attrib.get('mimeType', '')
+            outpt['mimetype'] = output_el.attrib.get('mimeType', None)
             outpt['encoding'] = output_el.attrib.get('encoding', '')
             outpt['schema'] = output_el.attrib.get('schema', '')
             outpt['uom'] = output_el.attrib.get('uom', '')
@@ -596,7 +596,7 @@ def get_output_from_xml(doc):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
             outpt = {}
             outpt[identifier_el.text] = ''
-            outpt['mimetype'] = output_el.attrib.get('mimeType', '')
+            outpt['mimetype'] = output_el.attrib.get('mimeType', None)
             outpt['encoding'] = output_el.attrib.get('encoding', '')
             outpt['schema'] = output_el.attrib.get('schema', '')
             outpt['uom'] = output_el.attrib.get('uom', '')
@@ -628,7 +628,7 @@ def get_inputs_from_json(jdoc):
             if data_type == 'complex':
                 inpt = {}
                 inpt['identifier'] = identifier
-                inpt['mimeType'] = inpt_def.get('mimeType', '')
+                inpt['mimeType'] = inpt_def.get('mimeType', None)
                 inpt['encoding'] = inpt_def.get('encoding', '').lower()
                 inpt['schema'] = inpt_def.get('schema', '')
                 inpt['method'] = inpt_def.get('method', 'GET')
@@ -646,7 +646,7 @@ def get_inputs_from_json(jdoc):
                 inpt['identifier'] = identifier
                 inpt[identifier] = inpt_def
                 inpt['href'] = inpt_def.get('href', '')
-                inpt['mimeType'] = inpt_def.get('mimeType', '')
+                inpt['mimeType'] = inpt_def.get('mimeType', None)
                 inpt['method'] = inpt_def.get('method', 'GET')
                 inpt['header'] = inpt_def.get('header', '')
                 inpt['body'] = inpt_def.get('body', '')
@@ -680,7 +680,7 @@ def get_output_from_dict(output_ids, raw):
             output_el = output_el[0]
         outpt = {}
         outpt[identifier] = ''
-        outpt['mimetype'] = output_el.get('mimeType', '')
+        outpt['mimetype'] = output_el.get('mimeType', None)
         outpt['encoding'] = output_el.get('encoding', '')
         outpt['schema'] = output_el.get('schema', '')
         outpt['uom'] = output_el.get('uom', '')

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -459,17 +459,14 @@ class WPSRequest(object):
             inpt_defs = value['inputs'][identifier]
             if not isinstance(inpt_defs, (list, tuple)):
                 inpt_defs = [inpt_defs]
+            self.inputs[identifier] = []
             for inpt_def in inpt_defs:
                 if not isinstance(inpt_def, dict):
                     inpt_def = {"data": inpt_def}
                 if 'identifier' not in inpt_def:
                     inpt_def['identifier'] = identifier
                 inpt = input_from_json(inpt_def)
-
-                if identifier in self.inputs:
-                    self.inputs[identifier].append(inpt)
-                else:
-                    self.inputs[identifier] = [inpt]
+                self.inputs[identifier].append(inpt)
 
 
 def get_inputs_from_xml(doc):

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -85,8 +85,9 @@ class WPSRequest(object):
             raise FileSizeExceeded('File size for input exceeded.'
                                    ' Maximum request size allowed: {} megabytes'.format(maxsize / 1024 / 1024))
 
-        input_is_xml = self.http_request.content_type != 'application/json'
-        if not input_is_xml:
+        mimetype = self.http_request.mimetype if self.http_request.mimetype is not None else self.http_request.content_type
+        json_input = 'json' in mimetype
+        if json_input:
             jdoc = json.loads(self.http_request.get_data())
             self.json = jdoc
             operation = jdoc.get('operation', 'execute')

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -55,16 +55,24 @@ def get_json_indent():
     return json_ident if json_ident >= 0 else None
 
 
-def get_response_type(accept_mimetypes, selected_type):
-    if not selected_type:
-        selected_type = get_default_response_mimetype()
-    json_is_default = 'json' in selected_type
+def get_response_type(accept_mimetypes, default_mimetype):
+    if not default_mimetype:
+        default_mimetype = get_default_response_mimetype()
+    json_is_default = 'json' in default_mimetype
+    accept_json = \
+        accept_mimetypes.accept_json or \
+        accept_mimetypes.best is None or \
+        'json' in accept_mimetypes.best.lower()
+    accept_xhtml = \
+        accept_mimetypes.accept_xhtml or \
+        accept_mimetypes.best is None or \
+        'xml' in accept_mimetypes.best.lower()
     json_response = (
-            (accept_mimetypes.accept_json and (not accept_mimetypes.accept_xhtml or json_is_default)) or
-            (json_is_default and accept_mimetypes.accept_json == accept_mimetypes.accept_xhtml)
+            (accept_json and (not accept_xhtml or json_is_default)) or
+            (json_is_default and accept_json == accept_xhtml)
     )
-    content_type = 'application/json' if json_response else 'text/xml'
-    return json_response, content_type
+    mimetype = 'application/json' if json_response else 'text/xml'
+    return json_response, mimetype
 
 
 def parse_http_url(http_request) -> dict:

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -27,7 +27,7 @@ CONFIG = None
 LOGGER = logging.getLogger("PYWPS")
 
 
-def get_config_value(section, option):
+def get_config_value(section, option, default_value=''):
     """Get desired value from  configuration files
 
     :param section: section in configuration files
@@ -40,7 +40,7 @@ def get_config_value(section, option):
     if not CONFIG:
         load_configuration()
 
-    value = ''
+    value = default_value
 
     if CONFIG.has_section(section):
         if CONFIG.has_option(section, option):

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -75,7 +75,7 @@ class NoApplicableCode(HTTPException):
         default_mimetype = None if not request else request.args.get('f', None)
         if default_mimetype is None:
             default_mimetype = parse_http_url(request).get('default_mimetype')
-        json_response, content_type = get_response_type(accept_mimetypes, default_mimetype)
+        json_response, mimetype = get_response_type(accept_mimetypes, default_mimetype)
         if json_response:
             doc = json.dumps(args, indent=get_json_indent())
         else:
@@ -89,7 +89,7 @@ class NoApplicableCode(HTTPException):
                 u'</ows:ExceptionReport>'
             ).format(**args))
 
-        return Response(doc, self.code, mimetype=content_type)
+        return Response(doc, self.code, mimetype=mimetype)
 
 
 class InvalidParameterValue(NoApplicableCode):

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -23,7 +23,7 @@ from werkzeug.utils import escape
 import logging
 
 from pywps import __version__
-from pywps.app.basic import get_default_response_mimetype, get_json_indent, get_response_type
+from pywps.app.basic import get_json_indent, get_response_type, parse_http_url
 
 __author__ = "Alex Morega & Calin Ciociu"
 
@@ -71,7 +71,11 @@ class NoApplicableCode(HTTPException):
             'description': self.get_description(environ)
         }
         accept_mimetypes = parse_accept_header(environ.get("HTTP_ACCEPT"), MIMEAccept)
-        json_response, content_type = get_response_type(accept_mimetypes)
+        request = environ.get('werkzeug.request', None)
+        default_mimetype = None if not request else request.args.get('f', None)
+        if default_mimetype is None:
+            default_mimetype = parse_http_url(request).get('default_mimetype')
+        json_response, content_type = get_response_type(accept_mimetypes, default_mimetype)
         if json_response:
             doc = json.dumps(args, indent=get_json_indent())
         else:

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -164,11 +164,12 @@ class IOHandler(object):
         """
 
         validate = self.validator
-        _valid = validate(self, self.valid_mode)
-        if not _valid:
-            self.data_set = False
-            raise InvalidParameterValue('Input data not valid using '
-                                        'mode {}'.format(self.valid_mode))
+        if validate is not None:
+            _valid = validate(self, self.valid_mode)
+            if not _valid:
+                self.data_set = False
+                raise InvalidParameterValue('Input data not valid using '
+                                            'mode {}'.format(self.valid_mode))
         self.data_set = True
 
     @property
@@ -623,7 +624,7 @@ class BasicComplex(object):
     def validator(self):
         """Return the proper validator for given data_format
         """
-        return self.data_format.validate
+        return None if self.data_format is None else self.data_format.validate
 
     @property
     def supported_formats(self):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -553,7 +553,7 @@ class BasicIO:
         self.abstract = abstract
         self.keywords = keywords
         self.min_occurs = int(min_occurs)
-        self.max_occurs = int(max_occurs)
+        self.max_occurs = int(max_occurs) if max_occurs is not None else None
         self.metadata = metadata
         self.translations = lower_case_dict(translations)
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -187,6 +187,14 @@ class ComplexInput(basic.ComplexInput):
 
     @classmethod
     def from_json(cls, json_input):
+        data_format = json_input.get('data_format')
+        if data_format is not None:
+            data_format = Format(
+                schema=data_format.get('schema'),
+                extension=data_format.get('extension'),
+                mime_type=data_format.get('mime_type', ""),
+                encoding=data_format.get('encoding')
+            )
         instance = cls(
             identifier=json_input['identifier'],
             title=json_input.get('title'),
@@ -194,19 +202,14 @@ class ComplexInput(basic.ComplexInput):
             keywords=json_input.get('keywords', []),
             workdir=json_input.get('workdir'),
             metadata=[Metadata.from_json(data) for data in json_input.get('metadata', [])],
-            data_format=Format(
-                schema=json_input['data_format'].get('schema'),
-                extension=json_input['data_format'].get('extension'),
-                mime_type=json_input['data_format']['mime_type'],
-                encoding=json_input['data_format'].get('encoding')
-            ),
+            data_format=data_format,
             supported_formats=[
                 Format(
                     schema=infrmt.get('schema'),
                     extension=infrmt.get('extension'),
-                    mime_type=infrmt['mime_type'],
+                    mime_type=infrmt.get('mime_type'),
                     encoding=infrmt.get('encoding')
-                ) for infrmt in json_input['supported_formats']
+                ) for infrmt in json_input.get('supported_formats', [])
             ],
             mode=json_input.get('mode', MODE.NONE),
             translations=json_input.get('translations'),
@@ -332,7 +335,7 @@ class LiteralInput(basic.LiteralInput):
     @classmethod
     def from_json(cls, json_input):
         allowed_values = []
-        for allowed_value in json_input['allowed_values']:
+        for allowed_value in json_input.get('allowed_values', []):
             if allowed_value['type'] == 'anyvalue':
                 allowed_values.append(AnyValue())
             elif allowed_value['type'] == 'novalue':
@@ -349,7 +352,7 @@ class LiteralInput(basic.LiteralInput):
         data = json_input_copy.pop('data', None)
         uom = json_input_copy.pop('uom', None)
         metadata = json_input_copy.pop('metadata', [])
-        json_input_copy.pop('type')
+        json_input_copy.pop('type', None)
         json_input_copy.pop('any_value', None)
         json_input_copy.pop('values_reference', None)
 
@@ -369,8 +372,8 @@ class LiteralInput(basic.LiteralInput):
 
 
 def input_from_json(json_data):
-    data_type = json_data['type']
-    if data_type == 'complex':
+    data_type = json_data.get('type', 'literal')
+    if data_type in ['complex', 'reference']:
         inpt = ComplexInput.from_json(json_data)
     elif data_type == 'literal':
         inpt = LiteralInput.from_json(json_data)

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -5,6 +5,7 @@
 
 """Literaltypes are used for LiteralInputs, to make sure, input data are OK
 """
+import numpy as np
 
 from pywps._compat import urlparse
 from dateutil.parser import parse as date_parser
@@ -20,7 +21,7 @@ LOGGER = logging.getLogger('PYWPS')
 LITERAL_DATA_TYPES = ('float', 'boolean', 'integer', 'string',
                       'positiveInteger', 'anyURI', 'time', 'date', 'dateTime',
                       'scale', 'angle',
-                      'nonNegativeInteger')
+                      'nonNegativeInteger', None)
 
 # currently we are supporting just ^^^ data types, feel free to add support for
 # more

--- a/pywps/inout/numpy_array_encode.py
+++ b/pywps/inout/numpy_array_encode.py
@@ -1,0 +1,14 @@
+from json import JSONEncoder
+
+numpy_available = True
+try:
+    import numpy
+except (ImportError, AttributeError):
+    numpy_available = False
+
+
+class NumpyArrayEncoder(JSONEncoder):
+    def default(self, obj):
+        if numpy_available and isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+        return JSONEncoder.default(self, obj)

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -5,6 +5,7 @@
 """
 WPS Output classes
 """
+from typing import Optional, Sequence, Dict
 
 import lxml.etree as etree
 import os
@@ -108,9 +109,9 @@ class ComplexOutput(basic.ComplexOutput):
         e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
-    def __init__(self, identifier, title, supported_formats=None,
-                 data_format=None, abstract='', keywords=[], workdir=None, metadata=None,
-                 as_reference=False, mode=MODE.NONE, translations=None):
+    def __init__(self, identifier: str, title: str, supported_formats: Optional[Sequence[str]] = None,
+                 data_format=None, abstract: str = '', keywords=[], workdir=None, metadata: Optional[Sequence[Metadata]] = None,
+                 as_reference=False, mode: MODE = MODE.NONE, translations: Optional[Dict[str, Dict[str, str]]] = None):
         if metadata is None:
             metadata = []
 

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -501,13 +501,14 @@ class MetaLink4(MetaLink):
 
 
 def output_from_json(json_data):
-    if json_data['type'] == 'complex':
+    data_type = json_data.get('type', 'literal')
+    if data_type == 'complex':
         output = ComplexOutput.from_json(json_data)
-    elif json_data['type'] == 'literal':
+    elif data_type == 'literal':
         output = LiteralOutput.from_json(json_data)
-    elif json_data['type'] == 'bbox':
+    elif data_type == 'bbox':
         output = BoundingBoxOutput.from_json(json_data)
     else:
-        raise InvalidParameterValue("Output type not recognized: {}".format(json_data['type']))
+        raise InvalidParameterValue("Output type not recognized: {}".format(data_type))
 
     return output

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -35,6 +35,7 @@ class WPSResponse(object):
         self.status = WPS_STATUS.ACCEPTED
         self.status_percentage = 0
         self.doc = None
+        self.content_type = None
         self.version = version
         self.template_env = RelEnvironment(
             loader=PackageLoader('pywps', 'templates'),
@@ -59,7 +60,7 @@ class WPSResponse(object):
 
     def get_response_doc(self):
         try:
-            self.doc = self._construct_doc()
+            self.doc, self.content_type = self._construct_doc()
         except Exception as e:
             if hasattr(e, "description"):
                 msg = e.description
@@ -71,4 +72,4 @@ class WPSResponse(object):
         else:
             self._update_status(WPS_STATUS.SUCCEEDED, u"Response generated", 100)
 
-            return self.doc
+            return self.doc, self.content_type

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -1,3 +1,8 @@
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pywps import WPSRequest
+
 from pywps.dblog import store_status
 from pywps.response.status import WPS_STATUS
 from pywps.translations import get_translation
@@ -27,7 +32,7 @@ def get_response(operation):
 
 class WPSResponse(object):
 
-    def __init__(self, wps_request, uuid=None, version="1.0.0"):
+    def __init__(self, wps_request: 'WPSRequest', uuid=None, version="1.0.0"):
 
         self.wps_request = wps_request
         self.uuid = uuid
@@ -57,6 +62,10 @@ class WPSResponse(object):
         self.status = status
         self.status_percentage = status_percentage
         store_status(self.uuid, self.status, self.message, self.status_percentage)
+
+    @abstractmethod
+    def _construct_doc(self):
+        ...
 
     def get_response_doc(self):
         try:

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -68,14 +68,14 @@ class CapabilitiesResponse(WPSResponse):
 
     def _construct_doc(self):
         doc = self.json
-        json_response, content_type = get_response_type(
+        json_response, mimetype = get_response_type(
             self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
         if json_response:
             doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
         else:
             template = self.template_env.get_template(self.version + '/capabilities/main.xml')
             doc = template.render(**doc)
-        return doc, content_type
+        return doc, mimetype
 
     @Request.application
     def __call__(self, request):

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -1,6 +1,8 @@
+import json
+
 from werkzeug.wrappers import Request
 import pywps.configuration as config
-from pywps.app.basic import xml_response
+from pywps.app.basic import make_response, get_response_type, get_json_indent
 from pywps.response import WPSResponse
 from pywps import __version__
 from pywps.exceptions import NoApplicableCode
@@ -60,20 +62,25 @@ class CapabilitiesResponse(WPSResponse):
             'processes': processes
         }
 
+    def _render_json_response(self, jdoc):
+        return jdoc
+
     def _construct_doc(self):
-
-        template = self.template_env.get_template(self.version + '/capabilities/main.xml')
-
-        doc = template.render(**self.json)
-
-        return doc
+        doc = self.json
+        json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
+        if json_response:
+            doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
+        else:
+            template = self.template_env.get_template(self.version + '/capabilities/main.xml')
+            doc = template.render(**doc)
+        return doc, content_type
 
     @Request.application
     def __call__(self, request):
         # This function must return a valid response.
         try:
-            doc = self.get_response_doc()
-            return xml_response(doc)
+            doc, content_type = self.get_response_doc()
+            return make_response(doc, content_type=content_type)
         except NoApplicableCode as e:
             return e
         except Exception as e:

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -62,12 +62,14 @@ class CapabilitiesResponse(WPSResponse):
             'processes': processes
         }
 
-    def _render_json_response(self, jdoc):
+    @staticmethod
+    def _render_json_response(jdoc):
         return jdoc
 
     def _construct_doc(self):
         doc = self.json
-        json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
+        json_response, content_type = get_response_type(
+            self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
         if json_response:
             doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
         else:

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -43,7 +43,8 @@ class DescribeResponse(WPSResponse):
             'language': self.wps_request.language,
         }
 
-    def _render_json_response(self, jdoc):
+    @staticmethod
+    def _render_json_response(jdoc):
         return jdoc
 
     def _construct_doc(self):
@@ -51,7 +52,8 @@ class DescribeResponse(WPSResponse):
             raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
 
         doc = self.json
-        json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
+        json_response, content_type = get_response_type(
+            self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
         if json_response:
             doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
         else:

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -52,7 +52,7 @@ class DescribeResponse(WPSResponse):
             raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
 
         doc = self.json
-        json_response, content_type = get_response_type(
+        json_response, mimetype = get_response_type(
             self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
         if json_response:
             doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
@@ -60,7 +60,7 @@ class DescribeResponse(WPSResponse):
             template = self.template_env.get_template(self.version + '/describe/main.xml')
             max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
             doc = template.render(max_size=max_size, **doc)
-        return doc, content_type
+        return doc, mimetype
 
     @Request.application
     def __call__(self, request):

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -1,6 +1,8 @@
+import json
+
 from werkzeug.wrappers import Request
 import pywps.configuration as config
-from pywps.app.basic import xml_response
+from pywps.app.basic import make_response, get_response_type, get_json_indent
 from pywps.exceptions import NoApplicableCode
 from pywps.exceptions import MissingParameterValue
 from pywps.exceptions import InvalidParameterValue
@@ -41,23 +43,29 @@ class DescribeResponse(WPSResponse):
             'language': self.wps_request.language,
         }
 
-    def _construct_doc(self):
+    def _render_json_response(self, jdoc):
+        return jdoc
 
+    def _construct_doc(self):
         if not self.identifiers:
             raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
 
-        template = self.template_env.get_template(self.version + '/describe/main.xml')
-        max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
-        doc = template.render(max_size=max_size, **self.json)
-
-        return doc
+        doc = self.json
+        json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
+        if json_response:
+            doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
+        else:
+            template = self.template_env.get_template(self.version + '/describe/main.xml')
+            max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
+            doc = template.render(max_size=max_size, **doc)
+        return doc, content_type
 
     @Request.application
     def __call__(self, request):
         # This function must return a valid response.
         try:
-            doc = self.get_response_doc()
-            return xml_response(doc)
+            doc, content_type = self.get_response_doc()
+            return make_response(doc, content_type=content_type)
         except NoApplicableCode as e:
             return e
         except Exception as e:

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -196,7 +196,8 @@ class ExecuteResponse(WPSResponse):
             data["outputs"] = [self.outputs[o].json for o in self.outputs]
         return data
 
-    def _render_json_response(self, jdoc):
+    @staticmethod
+    def _render_json_response(jdoc):
         response = dict()
         response['status'] = jdoc['status']
         out = jdoc['process']['outputs']
@@ -207,7 +208,8 @@ class ExecuteResponse(WPSResponse):
         if self.status == WPS_STATUS.SUCCEEDED and self.wps_request.preprocess_response:
             self.outputs = self.wps_request.preprocess_response(self.outputs)
         doc = self.json
-        json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
+        json_response, content_type = get_response_type(
+            self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
         if json_response:
             doc = json.dumps(self._render_json_response(doc), cls=NumpyArrayEncoder, indent=get_json_indent())
         else:

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -13,6 +13,7 @@ from pywps.exceptions import NoApplicableCode
 import pywps.configuration as config
 from werkzeug.wrappers import Response
 
+from pywps.inout.numpy_array_encode import NumpyArrayEncoder
 from pywps.response.status import WPS_STATUS
 from pywps.response import WPSResponse
 from pywps.inout.formats import FORMATS
@@ -206,7 +207,7 @@ class ExecuteResponse(WPSResponse):
         doc = self.json
         json_response, content_type = get_response_type(self.wps_request.http_request.accept_mimetypes)
         if json_response:
-            doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
+            doc = json.dumps(self._render_json_response(doc), cls=NumpyArrayEncoder, indent=get_json_indent())
         else:
             template = self.template_env.get_template(self.version + '/execute/main.xml')
             doc = template.render(**doc)

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,1 +1,2 @@
 netCDF4
+numpy


### PR DESCRIPTION
# Overview

This PR adds initial support for requests in JSON format 

# Related Issue / Discussion

This might have something to do with [wps-rest-binding](https://github.com/opengeospatial/wps-rest-binding)
But I didn't get to check it out yet.

# Example JSON requests:

I've taken the internal JSON format and tried to make it a valid request (which now work). 

Original XML request:

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsExecute_request.xsd">
	<!-- <ows:Identifier>say_hello</ows:Identifier> -->

    <wps:ResponseForm>
        <wps:RawDataOutput>
          <ows:Identifier>output</ows:Identifier>
        </wps:RawDataOutput>
    </wps:ResponseForm>

    <wps:DataInputs>
        <wps:Input>
            <ows:Identifier>name</ows:Identifier>
            <wps:Data>
                <wps:LiteralData>Idan</wps:LiteralData>
            </wps:Data>
        </wps:Input>
	</wps:DataInputs>
    
</wps:Execute>
```

JSON request taken from internal pywps (which now accepted as a valid request):

```
{
	"operation": "execute",
	"version": "1.0.0",
	"language": "en-US",
	"identifier": "say_hello",
	"identifiers": null,
	"store_execute": "false",
	"status": "false",
	"lineage": "false",
	"inputs": {
		"name": [
			{
				"identifier": "name",
				"title": "Input name",
				"abstract": "",
				"keywords": [],
				"metadata": [],
				"type": "literal",
				"data_type": "string",
				"workdir": "D:\\dev\\gis\\wps-flask\\workdir\\pywps_process_uxjnrc6i",
				"allowed_values": [],
				"any_value": false,
				"mode": 1,
				"min_occurs": 1,
				"max_occurs": 1,
				"translations": null,
				"data": "Idan"
			}
		]
	},
	"outputs": {
		"output": {
			"output": "",
			"mimetype": "",
			"encoding": "",
			"schema": "",
			"uom": ""
		}
	},
	"raw": true
}
```
Then I wanted to make a much more minimalistic request also valid as follows, so the following also works:

```
{
	"identifier": "say_hello",
	"outputs": "output",
	"inputs": {
		"name":"Idan"
	}
}
```
`outputs` can be a string (which implies raw output), or a list or a dict.
Each `input` inside `inputs` can be a string (which implies literal input) or a dict.


# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
