### PR TITLE
fix cdata deserialzation

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -214,7 +214,11 @@ class ComplexInput(basic.ComplexInput):
         elif json_input.get('href'):
             instance.url = json_input['href']
         elif json_input.get('data'):
-            instance.data = json_input['data']
+            data = json_input['data']
+            # remove cdata tag if it exists (issue #553)
+            if 'CDATA' in data:
+                data = data.replace("<![CDATA[", "").replace("]]>", "")
+            instance.data = data
 
         return instance
 

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -3,6 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import re
 import lxml.etree as etree
 import six
 
@@ -13,6 +14,8 @@ from pywps.inout import basic
 from copy import deepcopy
 from pywps.validator.mode import MODE
 from pywps.inout.literaltypes import AnyValue, NoValue, ValuesReference, AllowedValue
+
+CDATA_PATTERN = re.compile(r'<!\[CDATA\[(.*?)\]\]>')
 
 
 class BoundingBoxInput(basic.BBoxInput):
@@ -216,8 +219,9 @@ class ComplexInput(basic.ComplexInput):
         elif json_input.get('data'):
             data = json_input['data']
             # remove cdata tag if it exists (issue #553)
-            if 'CDATA' in data:
-                data = data.replace("<![CDATA[", "").replace("]]>", "")
+            match = CDATA_PATTERN.match(data)
+            if match:
+                data = match.group(1)
             instance.data = data
 
         return instance

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -288,9 +288,10 @@ class SerializationComplexInputTest(unittest.TestCase):
     def test_complex_input_data(self):
         complex = self.make_complex_input()
         complex.data = "some data"
+        # the data is enclosed by a CDATA tag in json
+        assert complex.json['data'] == '<![CDATA[some data]]>'
+        # dump to json and load it again
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
-        # the data is enclosed by a CDATA tag
-        complex._data = u'<![CDATA[{}]]>'.format(complex.data)
         # it's expected that the file path changed
         complex._file = complex2.file
 
@@ -300,13 +301,13 @@ class SerializationComplexInputTest(unittest.TestCase):
     def test_complex_input_stream(self):
         complex = self.make_complex_input()
         complex.stream = StringIO("some data")
+        # the data is enclosed by a CDATA tag in json
+        assert complex.json['data'] == '<![CDATA[some data]]>'
+        # dump to json and load it again
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
-
         # the serialized stream becomes a data type
         # we hard-code it for the testing comparison
         complex.prop = 'data'
-        # the data is enclosed by a CDATA tag
-        complex._data = u'<![CDATA[{}]]>'.format(complex.data)
         # it's expected that the file path changed
         complex._file = complex2.file
 
@@ -682,8 +683,8 @@ class LiteralOutputTest(unittest.TestCase):
     def setUp(self):
 
         self.literal_output = inout.outputs.LiteralOutput(
-            "literaloutput", 
-            data_type="integer", 
+            "literaloutput",
+            data_type="integer",
             title="Literal Output",
             translations={"fr-CA": {"title": "Mon output", "abstract": "Une description"}},
         )
@@ -714,8 +715,8 @@ class BBoxInputTest(unittest.TestCase):
     def setUp(self):
 
         self.bbox_input = inout.inputs.BoundingBoxInput(
-            "bboxinput", 
-            title="BBox input", 
+            "bboxinput",
+            title="BBox input",
             dimensions=2,
             translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
         )

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -300,9 +300,9 @@ class SerializationComplexInputTest(unittest.TestCase):
 
     def test_complex_input_stream(self):
         complex = self.make_complex_input()
-        complex.stream = StringIO("some data")
+        complex.stream = StringIO("{'name': 'test', 'input1': ']]'}")
         # the data is enclosed by a CDATA tag in json
-        assert complex.json['data'] == '<![CDATA[some data]]>'
+        assert complex.json['data'] == "<![CDATA[{'name': 'test', 'input1': ']]'}]]>"
         # dump to json and load it again
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
         # the serialized stream becomes a data type


### PR DESCRIPTION
# Overview

This PR fixes issue #553. It removes the `CDATA` tag when loading an input from json.

# Related Issue / Discussion

#553 

# Additional Information

https://github.com/roocs/rook/pull/72

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
