### PR TITLE
fix for embedded json in wps request

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -588,6 +588,8 @@ def _get_rawvalue_value(data, encoding=None):
     try:
         if encoding is None or encoding == "":
             return data
+        elif encoding == "utf-8":
+            return data
         elif encoding == 'base64':
             return base64.b64decode(data)
         return base64.b64decode(data)

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -586,6 +586,7 @@ def _get_rawvalue_value(data, encoding=None):
     """Return real value of CDATA section"""
 
     try:
+        LOGGER.debug("encoding={}".format(encoding))
         if encoding is None or encoding == "":
             return data
         elif encoding == "utf-8":
@@ -594,6 +595,7 @@ def _get_rawvalue_value(data, encoding=None):
             return base64.b64decode(data)
         return base64.b64decode(data)
     except Exception:
+        LOGGER.warning("failed to decode base64")
         return data
 
 


### PR DESCRIPTION
# Overview

This PR is a quick fix to parse an embedded json (complex type) from the wps execute request (xml). 

Probably there is more work to do for embedding json in OWSLib and PyWPS. Using `CDATA` or always use base64 encoding?

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
