### PR TITLE
fix output stream of scheduler

### DIFF
--- a/pywps/processing/scheduler.py
+++ b/pywps/processing/scheduler.py
@@ -54,7 +54,8 @@ class Scheduler(Processing):
                 drmaa_native_specification = config.get_config_value('processing', 'drmaa_native_specification')
                 if drmaa_native_specification:
                     jt.nativeSpecification = drmaa_native_specification
-                jt.joinFiles = True
+                jt.joinFiles = False
+                jt.errorPath = ":{}".format(os.path.join(self.job.workdir, "job-error.txt"))
                 jt.outputPath = ":{}".format(os.path.join(self.job.workdir, "job-output.txt"))
                 # run job
                 jobid = session.runJob(jt)


### PR DESCRIPTION
# Overview

This PR splits the output stream for `error` and `stdout` in different files. This is necessary on some parallel filesystems.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
