### PR TITLE
move MetadataUrl to pywps.app.Common to avoid dependencies on sphinx

### DIFF
--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -63,3 +63,21 @@ class Metadata(object):
             self.role == other.role,
             self.type == other.type,
         ])
+
+
+class MetadataUrl(Metadata):
+    """Metadata subclass to allow anonymous links generation in documentation.
+
+    Useful to avoid Sphinx "Duplicate explicit target name" warning.
+
+    See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks.
+
+    Meant to use in documentation only, not needed in the xml response, nor being serialized or
+    deserialized to/from json.  So that's why it is not directly in the base class.
+    """
+
+    def __init__(self, title, href=None, role=None, type_='simple',
+                 anonymous=False):
+        super().__init__(title, href=href, role=role, type_=type_)
+        self.anonymous = anonymous
+        "Whether to create anonymous link (boolean)."

--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -5,22 +5,7 @@ from sphinx.util.docstrings import prepare_docstring
 from sphinx.util import force_decode
 from docutils.parsers.rst import directives
 from pywps import Process
-from pywps.app.Common import Metadata
-
-
-class MetadataUrl(Metadata):
-    """Metadata subclass to allow anonymous links generation.
-
-    Useful to avoid Sphinx "Duplicate explicit target name" warning.
-
-    See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks.
-    """
-
-    def __init__(self, title, href=None, role=None, type_='simple',
-                 anonymous=False):
-        super().__init__(title, href=href, role=role, type_=type_)
-        self.anonymous = anonymous
-        "Whether to create anonymous link (boolean)."
+from pywps.app.Common import Metadata, MetadataUrl
 
 
 class ProcessDocumenter(ClassDocumenter):

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -11,8 +11,7 @@ from pywps import __version__
 from pywps import Process
 from pywps.inout import LiteralInput, LiteralOutput, ComplexInput, ComplexOutput, BoundingBoxInput, BoundingBoxOutput
 from pywps.inout import Format
-from pywps.app.Common import Metadata
-from pywps.ext_autodoc import MetadataUrl
+from pywps.app.Common import Metadata, MetadataUrl
 
 import re
 


### PR DESCRIPTION
Fixes https://github.com/geopython/pywps/issues/564

Tried the same steps as in the original issues, the error is gone.

```bash
$ python                                                                                                                                        
Python 3.8.5 (default, Sep  4 2020, 07:30:14)                                                                                                         
[GCC 7.3.0] :: Anaconda, Inc. on linux                                                                                                                
Type "help", "copyright", "credits" or "license" for more information.                                                                                
>>> from pywps import tests                                                                                                                           
>>>              
```
Also tested this change in project using `MetadataUrl` at the old location:
```bash
cd <flyingpigeon checkout>
conda env update -f environment-docs.yml
conda activate flyingpigeon-docs
pip install git+https://github.com/geopython/pywps@fix-pywps.ext_autodoc.MetadataUrl-wrong-location --upgrade
make docs
```

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
