### PR TITLE
Fix a namespace warning when importing gdal directly [rebase on PyWPS 4.4]

### DIFF
--- a/pywps/dependencies.py
+++ b/pywps/dependencies.py
@@ -6,6 +6,7 @@
 import warnings
 
 try:
+    import osgeo
     from osgeo import gdal, ogr
 except ImportError:
     warnings.warn('Complex validation requires GDAL/OGR support.')

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -367,8 +367,8 @@ def validategeotiff(data_input, mode):
     if mode >= MODE.STRICT:
 
         try:
-            from pywps.dependencies import gdal
-            data_source = gdal.Open(data_input.file)
+            from pywps.dependencies import osgeo # noqa
+            data_source = osgeo.gdal.Open(data_input.file)
             passed = (data_source.GetDriver().ShortName == "GTiff")
         except ImportError:
             passed = False


### PR DESCRIPTION
# Overview

This is a very small fix needed to squelch a warning that shows up with GDAL:
```
../../miniconda3/envs/raven-dev/lib/python3.8/site-packages/osgeo/gdal.py:106
  /home/tjs/miniconda3/envs/raven-dev/lib/python3.8/site-packages/osgeo/gdal.py:106: DeprecationWarning: gdal.py was placed in a namespace, it is now available as osgeo.gdal
    warn('%s.py was placed in a namespace, it is now available as osgeo.%s' % (module,module),
```

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines