### PR TITLE
fix incorrect use of self.__class__ in super

### DIFF
--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -33,7 +33,7 @@ class ExecuteResponse(WPSResponse):
         :param uuid: string this request uuid
         """
 
-        super(self.__class__, self).__init__(wps_request, uuid)
+        super(ExecuteResponse, self).__init__(wps_request, uuid)
 
         self.process = kwargs["process"]
         self.outputs = {o.identifier: o for o in self.process.outputs}


### PR DESCRIPTION
# Overview

Fix incorrect use of `self.__class__` in `super` call.

# Additional Information

In the actual context, it just so happens that `self.__class__` is equal to `ExecuteResponse` and produces the same result. 
When that class is derived though, to add additional functionalities, the value changes and causes endless recursion. 

```
class DerivedExecuteResponse(ExecuteResponse): 
    def __init__(self, wps_request, uuid):
        super(ExecuteResponse, self).__init__(wps_request, uuid)
        # other setup... 

class ExecuteResponse(WPSResponse):
    def __init__(self, wps_request, uuid, **kwargs):
        # here 'self.__class__'  == 'DerivedExecuteResponse'
        # 'super(self.__class__, self)' resolves to 'ExecuteResponse', so it calls itself !
        super(self.__class__, self).__init__(wps_request, uuid)
```


# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
