### PR TITLE
fixed file size check for outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,7 +113,13 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
     number of processor cores. -1 for no limit.
 
 :maxrequestsize:
-    maximal request size. 0 for no limit
+    maximal request size. 0 for no limit.
+
+:maxsingleinputsize:
+    maximal request size for a single input. 0 for no limit.
+
+:maxsingleoutputsize:
+    maximal size for a single output. 0 for no limit.
 
 :maxprocesses:
     maximal number of requests being stored in queue, waiting till they can be

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -118,9 +118,6 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
 :maxsingleinputsize:
     maximal request size for a single input. 0 for no limit.
 
-:maxsingleoutputsize:
-    maximal size for a single output. 0 for no limit.
-
 :maxprocesses:
     maximal number of requests being stored in queue, waiting till they can be
     processed (see ``parallelprocesses`` configuration option). -1 for no limit.

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -71,6 +71,7 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('server', 'language', 'en-US')
     CONFIG.set('server', 'url', 'http://localhost/wps')
     CONFIG.set('server', 'maxprocesses', '30')
+    CONFIG.set('server', 'maxsingleoutputsize', '0')
     CONFIG.set('server', 'maxsingleinputsize', '1mb')
     CONFIG.set('server', 'maxrequestsize', '3mb')
     CONFIG.set('server', 'temp_path', tempfile.gettempdir())

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -71,7 +71,6 @@ def load_configuration(cfgfiles=None):
     CONFIG.set('server', 'language', 'en-US')
     CONFIG.set('server', 'url', 'http://localhost/wps')
     CONFIG.set('server', 'maxprocesses', '30')
-    CONFIG.set('server', 'maxsingleoutputsize', '0')
     CONFIG.set('server', 'maxsingleinputsize', '1mb')
     CONFIG.set('server', 'maxrequestsize', '3mb')
     CONFIG.set('server', 'temp_path', tempfile.gettempdir())

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -517,7 +517,8 @@ class UrlHandler(FileHandler):
 
         return req
 
-    def max_size(self):
+    @staticmethod
+    def max_size():
         """Calculates maximal size for input file based on configuration
         and units.
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -521,8 +521,7 @@ class UrlHandler(FileHandler):
         :return: maximum file size in bytes
         """
         ms = config.get_config_value('server', 'maxsingleinputsize')
-        mb_size = config.get_size_mb(ms)
-        byte_size = mb_size * 1024**2
+        byte_size = config.get_size_mb(ms) * 1024**2
         return byte_size
 
 
@@ -1030,14 +1029,3 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
         (_, _, url) = self.storage.store(self)
         # url = self.storage.url(self)
         return url
-
-    def max_size(self):
-        """Calculates maximal size for inout file based on configuration
-        and units.
-
-        :return: maximum file size in bytes and megabytes
-        """
-        ms = config.get_config_value('server', 'maxsingleinputsize')
-        mb_size = config.get_size_mb(ms)
-        byte_size = mb_size * 1024**2
-        return byte_size, mb_size

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -447,6 +447,9 @@ class UrlHandler(FileHandler):
 
     @property
     def file(self):
+        """Downloads URL and return file pointer.
+        Checks if size is allowed before download.
+        """
         if self._file is not None:
             return self._file
 

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -336,6 +336,11 @@ class FileHandler(IOHandler):
         import pathlib
         return pathlib.PurePosixPath(self.file).as_uri()
 
+    @property
+    def size(self):
+        """Length of the linked content in octets."""
+        return os.stat(self.file).st_size
+
     def _openmode(self, data=None):
         openmode = 'r'
         # in Python 3 we need to open binary files in binary mode.
@@ -482,6 +487,16 @@ class UrlHandler(FileHandler):
     @post_data.setter
     def post_data(self, value):
         self._post_data = value
+
+    @property
+    def size(self):
+        """Get content-length of URL without download"""
+        req = requests.head(self.url)
+        if req.ok:
+            size = int(req.headers.get('content-length', '0'))
+        else:
+            size = 0
+        return size
 
     @staticmethod
     def _openurl(href, data=None):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -1031,12 +1031,12 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
         return url
 
     def max_size(self):
-        """Calculates maximal size for output file based on configuration
+        """Calculates maximal size for inout file based on configuration
         and units.
 
         :return: maximum file size in bytes and megabytes
         """
-        ms = config.get_config_value('server', 'maxsingleoutputsize')
+        ms = config.get_config_value('server', 'maxsingleinputsize')
         mb_size = config.get_size_mb(ms)
         byte_size = mb_size * 1024**2
         return byte_size, mb_size

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -451,7 +451,7 @@ class UrlHandler(FileHandler):
 
         self._file = self._build_file_name(href=self.url)
 
-        max_byte_size = self.max_input_size()
+        max_byte_size, max_mb_size = self.max_size()
 
         # Create request
         try:
@@ -461,20 +461,23 @@ class UrlHandler(FileHandler):
             raise NoApplicableCode('File reference error: {}'.format(e))
 
         error_message = 'File size for input "{}" exceeded. Maximum allowed: {} megabytes'.format(
-            self.inpt.get('identifier', '?'), max_byte_size)
+            self.inpt.get('identifier', '?'), max_mb_size)
 
-        if int(data_size) > int(max_byte_size):
-            raise FileSizeExceeded(error_message)
+        if int(max_byte_size) > 0:
+            if int(data_size) > int(max_byte_size):
+                raise FileSizeExceeded(error_message)
 
         try:
             with open(self._file, 'wb') as f:
                 data_size = 0
                 for chunk in reference_file.iter_content(chunk_size=1024):
                     data_size += len(chunk)
-                    if int(data_size) > int(max_byte_size):
-                        raise FileSizeExceeded(error_message)
+                    if int(max_byte_size) > 0:
+                        if int(data_size) > int(max_byte_size):
+                            raise FileSizeExceeded(error_message)
                     f.write(chunk)
-
+        except FileSizeExceeded:
+            raise
         except Exception as e:
             raise NoApplicableCode(e)
 
@@ -510,15 +513,16 @@ class UrlHandler(FileHandler):
 
         return req
 
-    @staticmethod
-    def max_input_size():
+    def max_size(self):
         """Calculates maximal size for input file based on configuration
         and units.
 
-        :return: maximum file size in bytes
+        :return: maximum file size in bytes and megabytes
         """
         ms = config.get_config_value('server', 'maxsingleinputsize')
-        return config.get_size_mb(ms) * 1024**2
+        mb_size = config.get_size_mb(ms)
+        byte_size = mb_size * 1024**2
+        return byte_size, mb_size
 
 
 class SimpleHandler(DataHandler):
@@ -1025,3 +1029,14 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
         (_, _, url) = self.storage.store(self)
         # url = self.storage.url(self)
         return url
+
+    def max_size(self):
+        """Calculates maximal size for output file based on configuration
+        and units.
+
+        :return: maximum file size in bytes and megabytes
+        """
+        ms = config.get_config_value('server', 'maxsingleoutputsize')
+        mb_size = config.get_size_mb(ms)
+        byte_size = mb_size * 1024**2
+        return byte_size, mb_size

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -30,6 +30,7 @@ import base64
 from collections import namedtuple
 from copy import deepcopy
 from io import BytesIO
+import humanize
 
 
 _SOURCE_TYPE = namedtuple('SOURCE_TYPE', 'MEMORY, FILE, STREAM, DATA, URL')
@@ -451,7 +452,7 @@ class UrlHandler(FileHandler):
 
         self._file = self._build_file_name(href=self.url)
 
-        max_byte_size, max_mb_size = self.max_size()
+        max_byte_size = self.max_size()
 
         # Create request
         try:
@@ -461,7 +462,7 @@ class UrlHandler(FileHandler):
             raise NoApplicableCode('File reference error: {}'.format(e))
 
         error_message = 'File size for input "{}" exceeded. Maximum allowed: {} megabytes'.format(
-            self.inpt.get('identifier', '?'), max_mb_size)
+            self.inpt.get('identifier', '?'), humanize.naturalsize(max_byte_size))
 
         if int(max_byte_size) > 0:
             if int(data_size) > int(max_byte_size):
@@ -522,7 +523,7 @@ class UrlHandler(FileHandler):
         ms = config.get_config_value('server', 'maxsingleinputsize')
         mb_size = config.get_size_mb(ms)
         byte_size = mb_size * 1024**2
-        return byte_size, mb_size
+        return byte_size
 
 
 class SimpleHandler(DataHandler):

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -461,7 +461,7 @@ class UrlHandler(FileHandler):
         except Exception as e:
             raise NoApplicableCode('File reference error: {}'.format(e))
 
-        error_message = 'File size for input "{}" exceeded. Maximum allowed: {} megabytes'.format(
+        error_message = 'File size for input "{}" exceeded. Maximum allowed: {}'.format(
             self.inpt.get('identifier', '?'), humanize.naturalsize(max_byte_size))
 
         if int(max_byte_size) > 0:
@@ -518,7 +518,7 @@ class UrlHandler(FileHandler):
         """Calculates maximal size for input file based on configuration
         and units.
 
-        :return: maximum file size in bytes and megabytes
+        :return: maximum file size in bytes
         """
         ms = config.get_config_value('server', 'maxsingleinputsize')
         mb_size = config.get_size_mb(ms)

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -361,7 +361,7 @@ class MetaFile:
     @property
     def size(self):
         """Length of the linked content in octets."""
-        return os.stat(self.file).st_size
+        return self._output.size
 
     @property
     def urls(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dateutil
 requests
 SQLAlchemy
 werkzeug
+humanize

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -772,6 +772,12 @@ class TestMetaLink(unittest.TestCase):
         mf._set_workdir(self.tmp_dir)
         return mf
 
+    def metafile_with_url(self):
+        mf = MetaFile('identifier', 'title', fmt=FORMATS.JSON)
+        mf.url = "https://pywps.org/"
+        mf._set_workdir(self.tmp_dir)
+        return mf
+
     def test_metafile(self):
         mf = self.metafile()
         self.assertEqual('identifier', mf.identity)
@@ -820,6 +826,11 @@ class TestMetaLink(unittest.TestCase):
 
         ml4.checksums = True
         assert 'hash' in ml4.xml
+
+    def test_size(self):
+        ml4 = self.metalink4()
+        ml4.append(self.metafile_with_url())
+        assert 'size' in ml4.xml
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

This PR fixes the file size check for outputs.

The creation of an output with metalink failed when the output file exceeded the `maxsingleinputsize` value.
* updated docs
* fixed exception catch of `FileSizeExceeded`
* using https://pypi.org/project/humanize/

The root cause for this error is fixed in the PR #581.

# Related Issue / Discussion

Fix #571 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
