### PR TITLE
fix metalink size for url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -336,6 +336,11 @@ class FileHandler(IOHandler):
         import pathlib
         return pathlib.PurePosixPath(self.file).as_uri()
 
+    @property
+    def size(self):
+        """Length of the linked content in octets."""
+        return os.stat(self.file).st_size
+
     def _openmode(self, data=None):
         openmode = 'r'
         # in Python 3 we need to open binary files in binary mode.
@@ -482,6 +487,16 @@ class UrlHandler(FileHandler):
     @post_data.setter
     def post_data(self, value):
         self._post_data = value
+
+    @property
+    def size(self):
+        """Get content-length of URL without download"""
+        req = requests.head(self.url)
+        if req.ok:
+            size = int(req.headers.get('content-length', '0'))
+        else:
+            size = 0
+        return size
 
     @staticmethod
     def _openurl(href, data=None):

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -361,7 +361,7 @@ class MetaFile:
     @property
     def size(self):
         """Length of the linked content in octets."""
-        return os.stat(self.file).st_size
+        return self._output.size
 
     @property
     def urls(self):
@@ -430,6 +430,7 @@ class MetaLink:
         :param tuple files: Sequence of files to include in Metalink. Can also be added using `append`.
         :param str workdir: Work directory to store temporary files.
         :param bool checksums: Whether to compute checksums on files.
+        :param bool check_size: Whether to compute size on files.
 
         To use, first append `MetaFile` instances, then write the metalink using the `xml`
         property.

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -430,7 +430,6 @@ class MetaLink:
         :param tuple files: Sequence of files to include in Metalink. Can also be added using `append`.
         :param str workdir: Work directory to store temporary files.
         :param bool checksums: Whether to compute checksums on files.
-        :param bool check_size: Whether to compute size on files.
 
         To use, first append `MetaFile` instances, then write the metalink using the `xml`
         property.

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -772,6 +772,12 @@ class TestMetaLink(unittest.TestCase):
         mf._set_workdir(self.tmp_dir)
         return mf
 
+    def metafile_with_url(self):
+        mf = MetaFile('identifier', 'title', fmt=FORMATS.JSON)
+        mf.url = "https://pywps.org/"
+        mf._set_workdir(self.tmp_dir)
+        return mf
+
     def test_metafile(self):
         mf = self.metafile()
         self.assertEqual('identifier', mf.identity)
@@ -820,6 +826,11 @@ class TestMetaLink(unittest.TestCase):
 
         ml4.checksums = True
         assert 'hash' in ml4.xml
+
+    def test_size(self):
+        ml4 = self.metalink4()
+        ml4.append(self.metafile_with_url())
+        assert 'size' in ml4.xml
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview

This PR adds a "size" checker in `URLHandler`. 

When the metalink document is created it is checking the "file" size of a metafile item. When the metafile is representing an external URL it is using the `URLHandler`.

Issue: when we were calculating the size of an "URL" it was first *downloading* the URL and the calculating the file size. We did not recognize ... files were small before ;) This is probably the root cause for issue #571. 

Now, the `URLHandler` and the `FileHandler` have their own methods to calculate "size". Avoiding unwanted downloads.

# Related Issue / Discussion

#571 #580 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
