### PR TITLE
Metalink: optimize size calculation

### DIFF
--- a/pywps/dependencies.py
+++ b/pywps/dependencies.py
@@ -10,6 +10,7 @@ try:
     from osgeo import gdal, ogr
 except ImportError:
     warnings.warn('Complex validation requires GDAL/OGR support.')
+    ogr = None
 
 try:
     import netCDF4

--- a/pywps/dependencies.py
+++ b/pywps/dependencies.py
@@ -10,7 +10,6 @@ try:
     from osgeo import gdal, ogr
 except ImportError:
     warnings.warn('Complex validation requires GDAL/OGR support.')
-    ogr = None
 
 try:
     import netCDF4

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -498,7 +498,7 @@ class UrlHandler(FileHandler):
     @property
     def size(self):
         """Get content-length of URL without download"""
-        req = requests.head(self.url)
+        req = self._openurl(self.url)
         if req.ok:
             size = int(req.headers.get('content-length', '0'))
         else:

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -320,6 +320,7 @@ class MetaFile:
         The metalink document is created by a `MetaLink` instance, which
         holds a number of `MetaFile` instances.
         """
+        self._size = None
         self._output = ComplexOutput(
             identifier=identity or '',
             title=description or '',
@@ -360,8 +361,15 @@ class MetaFile:
 
     @property
     def size(self):
-        """Length of the linked content in octets."""
-        return self._output.size
+        """Size of the linked content in bytes."""
+        if self._size is None:
+            self._size = self._output.size
+        return self._size
+
+    @size.setter
+    def size(self, value):
+        """Set size to avoid size calculation."""
+        self._size = int(value)
 
     @property
     def urls(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -832,6 +832,20 @@ class TestMetaLink(unittest.TestCase):
         ml4.append(self.metafile_with_url())
         assert 'size' in ml4.xml
 
+    def test_no_size(self):
+        ml4 = self.metalink4()
+        mf = self.metafile_with_url()
+        mf.size = 0
+        ml4.files = [mf]
+        assert 'size' not in ml4.xml
+
+    def test_set_size(self):
+        ml4 = self.metalink4()
+        mf = self.metafile_with_url()
+        mf.size = 100
+        ml4.files = [mf]
+        assert '<size>100</size>' in ml4.xml
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:


### PR DESCRIPTION
# Overview

This PR is an update of PR #581.

Changes:
* Using `_openurl` with requests stream to get content-length. Faster than `head` request.
* The `size` of a metafile can be set from outside to avoid calculation. Size might already be know and/or it takes long too calculate it when the metalink document has many files (>100).

# Related Issue / Discussion

#581 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
