### PR TITLE
avoid ogr import failure when running tests

### DIFF
--- a/pywps/dependencies.py
+++ b/pywps/dependencies.py
@@ -10,6 +10,7 @@ try:
     from osgeo import gdal, ogr
 except ImportError:
     warnings.warn('Complex validation requires GDAL/OGR support.')
+    ogr = None
 
 try:
     import netCDF4


### PR DESCRIPTION
# Overview

This is a quick-fix to avoid `import ogr` exception when running tests without gdal.

# Related Issue / Discussion

GDAL issue: #398

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
