### PR TITLE
using storage_copy_function

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -156,6 +156,15 @@ configuration file <https://docs.pycsw.org/en/latest/configuration.html>`_.
 :storagetype:
     The type of storage to use when storing status and results. Possible values are: ``file``, ``s3``. Defaults to ``file``.
 
+:storage_copy_function:
+    When using file storage you can choose the copy function. Possible values are:
+
+    * ``copy``: using ``shutil.copy2``,
+    * ``move``: using ``shutil.move``,
+    * ``link``: using ``os.link`` (hardlink).
+
+    Default: ``copy``.
+
 [processing]
 ------------
 

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -89,6 +89,10 @@ def load_configuration(cfgfiles=None):
     # after process has finished.
     CONFIG.set('server', 'cleantempdir', 'true')
     CONFIG.set('server', 'storagetype', 'file')
+    # File storage outputs can be copied, moved or linked
+    # from the workdir to the output folder.
+    # Allowed functions: "copy", "move", "link" (default "copy")
+    CONFIG.set('server', 'storage_copy_function', 'copy')
 
     CONFIG.add_section('processing')
     CONFIG.set('processing', 'mode', 'default')

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -115,7 +115,13 @@ class StorageNotSupported(NoApplicableCode):
 
 
 class NotEnoughStorage(NoApplicableCode):
-    """Storage not supported exception implementation
+    """Not enough storage exception implementation
+    """
+    code = 400
+
+
+class FileStorageError(NoApplicableCode):
+    """File storage exception implementation
     """
     code = 400
 

--- a/pywps/inout/storage/file.py
+++ b/pywps/inout/storage/file.py
@@ -135,7 +135,7 @@ class FileStorage(CachedStorage):
                 os.link(src, dst)
             except Exception:
                 LOGGER.warn("Could not create hardlink. Fallback to copy.")
-                self.copy(src, dst)
+                FileStorage.copy(src, dst)
         else:
             shutil.copy2(src, dst)
 

--- a/pywps/inout/storage/file.py
+++ b/pywps/inout/storage/file.py
@@ -6,7 +6,7 @@
 import logging
 import os
 from urllib.parse import urljoin
-from pywps.exceptions import NotEnoughStorage
+from pywps.exceptions import NotEnoughStorage, FileStorageError
 from pywps import configuration as config
 from pywps.inout.basic import IOHandler
 
@@ -22,7 +22,8 @@ class FileStorageBuilder(StorageImplementationBuilder):
     def build(self):
         file_path = config.get_config_value('server', 'outputpath')
         base_url = config.get_config_value('server', 'outputurl')
-        return FileStorage(file_path, base_url)
+        copy_function = config.get_config_value('server', 'storage_copy_function')
+        return FileStorage(file_path, base_url, copy_function=copy_function)
 
 
 def _build_output_name(output):
@@ -59,17 +60,17 @@ class FileStorage(CachedStorage):
     True
     """
 
-    def __init__(self, output_path, output_url):
+    def __init__(self, output_path, output_url, copy_function=None):
         """
         """
         CachedStorage.__init__(self)
         self.target = output_path
         self.output_url = output_url
+        self.copy_function = copy_function
 
     def _do_store(self, output):
         import platform
         import math
-        import shutil
         import tempfile
         import uuid
 
@@ -103,8 +104,12 @@ class FileStorage(CachedStorage):
                                            dir=target)[1]
 
         full_output_name = os.path.join(target, output_name)
-        LOGGER.info('Storing file output to {}'.format(full_output_name))
-        shutil.copy2(output.file, full_output_name)
+        LOGGER.info(f'Storing file output to {full_output_name} ({self.copy_function}).')
+        try:
+            self.copy(output.file, full_output_name, self.copy_function)
+        except Exception:
+            LOGGER.exception(f"Could not copy {output_name}.")
+            raise FileStorageError("Could not copy output file.")
 
         just_file_name = os.path.basename(output_name)
 
@@ -112,6 +117,27 @@ class FileStorage(CachedStorage):
         LOGGER.info('File output URI: {}'.format(url))
 
         return (STORE_TYPE.PATH, output_name, url)
+
+    @staticmethod
+    def copy(src, dst, copy_function=None):
+        """Copy file from source to destination using `copy_function`.
+
+        Values of `copy_function` (default=`copy`):
+        * copy: using `shutil.copy2`
+        * move: using `shutil.move`
+        * link: using `os.link`  (hardlink)
+        """
+        import shutil
+        if copy_function == 'move':
+            shutil.move(src, dst)
+        elif copy_function == 'link':
+            try:
+                os.link(src, dst)
+            except Exception:
+                LOGGER.warn("Could not create hardlink. Fallback to copy.")
+                self.copy(src, dst)
+        else:
+            shutil.copy2(src, dst)
 
     def write(self, data, destination, data_format=None):
         """


### PR DESCRIPTION
# Overview

This PR adds a new server option `storage_copy_function`. You can choose the `copy_function` in `FileStorage` when copying outputs to the destination folder: `copy`, `move` or `link`. Default=`copy` (as it was already).

Motivation: when having large output files we don't want to copy them ... preferred method is `link` making a hardlink using `os.link`. `move` would be an alternative using `shutil.move`. Fallback is always `copy` with `shutil.copy2`. 

# Related Issue / Discussion

# Additional Information

The `link` was also implemented in pywps 3.x:
https://github.com/geopython/pywps/blob/f18c0fdcb32cc354c856edde56fbdcb8db87394f/pywps/Wps/Execute/__init__.py#L1157-L1164

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
