### PR TITLE
OGC API - Processes / REST API implementation

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -252,7 +252,7 @@ class Process(object):
             if wps_response.status != WPS_STATUS.SUCCEEDED and wps_response.status != WPS_STATUS.FAILED:
                 # if (not wps_response.status_percentage) or (wps_response.status_percentage != 100):
                 LOGGER.debug('Updating process status to 100% if everything went correctly')
-                wps_response._update_status(WPS_STATUS.SUCCEEDED, 'PyWPS Process {} finished'.format(self.title), 100)
+                wps_response._update_status(WPS_STATUS.SUCCEEDED, f'PyWPS Process {self.title} finished', 100)
         except Exception as e:
             traceback.print_exc()
             LOGGER.debug('Retrieving file and line number where exception occurred')

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -7,8 +7,10 @@ XML tools
 """
 
 import logging
+from typing import Optional, Tuple
+
 from werkzeug.wrappers import Response
-from pywps import __version__
+import pywps.configuration as config
 
 LOGGER = logging.getLogger('PYWPS')
 
@@ -33,8 +35,113 @@ def get_xpath_ns(version):
     return xpath_ns
 
 
-def xml_response(doc):
-    """XML response serializer"""
-    response = Response(doc, content_type='text/xml')
+def make_response(doc, content_type):
+    """response serializer"""
+    if not content_type:
+        content_type = get_default_response_mimetype()
+    response = Response(doc, content_type=content_type)
     response.status_percentage = 100
     return response
+
+
+def get_default_response_mimetype():
+    default_mimetype = config.get_config_value('server', 'default_mimetype')
+    return default_mimetype
+
+
+def get_json_indent():
+    json_ident = int(config.get_config_value('server', 'json_indent'))
+    return json_ident if json_ident >= 0 else None
+
+
+def get_response_type(accept_mimetypes, default_mimetype) -> Tuple[bool, str]:
+    """
+    This function determinate if the response should be JSON or XML based on
+    the accepted mimetypes of the request and the default mimetype provided,
+    which will be used in case both are equally accepted.
+
+    :param accept_mimetypes: determinate which mimetypes are accepted
+    :param default_mimetype: "text/xml", "application/json"
+    :return: Tuple[bool, str] -
+        bool - True: The response type is JSON, False: Otherwise - XML
+        str - The output mimetype
+    """
+    accept_json = \
+        accept_mimetypes.accept_json or \
+        accept_mimetypes.best is None or \
+        'json' in accept_mimetypes.best.lower()
+    accept_xhtml = \
+        accept_mimetypes.accept_xhtml or \
+        accept_mimetypes.best is None or \
+        'xml' in accept_mimetypes.best.lower()
+    if not default_mimetype:
+        default_mimetype = get_default_response_mimetype()
+    json_is_default = 'json' in default_mimetype or '*' in default_mimetype
+    json_response = (accept_json and (not accept_xhtml or json_is_default)) or \
+                    (json_is_default and accept_json == accept_xhtml)
+    mimetype = 'application/json' if json_response else 'text/xml' if accept_xhtml else ''
+    return json_response, mimetype
+
+
+def parse_http_url(http_request) -> dict:
+    """
+    This function parses the request URL and extracts the following:
+        default operation, process identifier, output_ids, default mimetype
+        info that cannot be terminated from the URL will be None (default)
+
+        The url is expected to be in the following format, all the levels are optional.
+        [base_url]/[identifier]/[output_ids]
+
+    :param http_request: the request URL
+    :return: dict with the extracted info listed:
+        base_url - [wps|processes|jobs|api/api_level]
+        default_mimetype - determinate by the base_url part:
+            XML - if the base url == 'wps',
+            JSON - if the base URL in ['api'|'jobs'|'processes']
+        operation - also determinate by the base_url part:
+            ['api'|'jobs'] -> 'execute'
+            processes -> 'describeprocess' or 'getcapabilities'
+                'describeprocess' if identifier is present as the next item, 'getcapabilities' otherwise
+        api - api level, only expected if base_url=='api'
+        identifier - the process identifier
+        output_ids - if exist then it selects raw output with the name output_ids
+    """
+    operation = api = identifier = output_ids = default_mimetype = base_url = None
+    if http_request:
+        parts = str(http_request.path[1:]).split('/')
+        i = 0
+        if len(parts) > i:
+            base_url = parts[i].lower()
+            if base_url == 'wps':
+                default_mimetype = 'xml'
+            elif base_url in ['api', 'processes', 'jobs']:
+                default_mimetype = 'json'
+            i += 1
+            if base_url == 'api':
+                api = parts[i]
+                i += 1
+            if len(parts) > i:
+                identifier = parts[i]
+                i += 1
+                if len(parts) > i:
+                    output_ids = parts[i]
+                    if not output_ids:
+                        output_ids = None
+    if base_url in ['jobs', 'api']:
+        operation = 'execute'
+    elif base_url == 'processes':
+        operation = 'describeprocess' if identifier else 'getcapabilities'
+    d = {}
+    if operation:
+        d['operation'] = operation
+    if identifier:
+        d['identifier'] = identifier
+    if output_ids:
+        d['output_ids'] = output_ids
+    if default_mimetype:
+        d['default_mimetype'] = default_mimetype
+    if api:
+        d['api'] = api
+    if base_url:
+        d['base_url'] = base_url
+    return d

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -24,8 +24,10 @@ RAW_OPTIONS = [('logging', 'format'), ]
 CONFIG = None
 LOGGER = logging.getLogger("PYWPS")
 
+wps_strict = True
 
-def get_config_value(section, option):
+
+def get_config_value(section, option, default_value=''):
     """Get desired value from  configuration files
 
     :param section: section in configuration files
@@ -38,7 +40,7 @@ def get_config_value(section, option):
     if not CONFIG:
         load_configuration()
 
-    value = ''
+    value = default_value
 
     if CONFIG.has_section(section):
         if CONFIG.has_option(section, option):
@@ -95,6 +97,13 @@ def load_configuration(cfgfiles=None):
     # from the workdir to the output folder.
     # Allowed functions: "copy", "move", "link" (default "copy")
     CONFIG.set('server', 'storage_copy_function', 'copy')
+
+    # handles the default mimetype for requests.
+    # available options: "text/xml", "application/json"
+    CONFIG.set("server", "default_mimetype", "text/xml")
+
+    # default json indentation for responses.
+    CONFIG.set("server", "json_indent", "2")
 
     CONFIG.add_section('processing')
     CONFIG.set('processing', 'mode', 'default')

--- a/pywps/inout/array_encode.py
+++ b/pywps/inout/array_encode.py
@@ -1,0 +1,14 @@
+##################################################################
+# Copyright 2018 Open Source Geospatial Foundation and others    #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+from json import JSONEncoder
+
+
+class ArrayEncoder(JSONEncoder):
+    def default(self, obj):
+        if hasattr(obj, 'tolist'):
+            # this will work for array.array and numpy.ndarray
+            return obj.tolist()
+        return JSONEncoder.default(self, obj)

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -4,6 +4,8 @@
 ##################################################################
 from pathlib import PurePath
 
+from pywps.inout.formats import Supported_Formats
+from pywps.inout.types import Translations
 from pywps.translations import lower_case_dict
 from io import StringIO
 import os
@@ -203,11 +205,12 @@ class IOHandler(object):
         """
 
         validate = self.validator
-        _valid = validate(self, self.valid_mode)
-        if not _valid:
-            self.data_set = False
-            raise InvalidParameterValue('Input data not valid using '
-                                        'mode {}'.format(self.valid_mode))
+        if validate is not None:
+            _valid = validate(self, self.valid_mode)
+            if not _valid:
+                self.data_set = False
+                raise InvalidParameterValue('Input data not valid using '
+                                            'mode {}'.format(self.valid_mode))
         self.data_set = True
 
     @property
@@ -644,7 +647,7 @@ class BasicIO:
         self.abstract = abstract
         self.keywords = keywords
         self.min_occurs = int(min_occurs)
-        self.max_occurs = int(max_occurs)
+        self.max_occurs = int(max_occurs) if max_occurs is not None else None
         self.metadata = metadata
         self.translations = lower_case_dict(translations)
 
@@ -715,7 +718,7 @@ class BasicComplex(object):
     def validator(self):
         """Return the proper validator for given data_format
         """
-        return self.data_format.validate
+        return None if self.data_format is None else self.data_format.validate
 
     @property
     def supported_formats(self):
@@ -1071,8 +1074,8 @@ class ComplexOutput(BasicIO, BasicComplex, IOHandler):
     """
 
     def __init__(self, identifier, title=None, abstract=None, keywords=None,
-                 workdir=None, data_format=None, supported_formats=None,
-                 mode=MODE.NONE, translations=None):
+                 workdir=None, data_format=None, supported_formats: Supported_Formats = None,
+                 mode=MODE.NONE, translations: Translations = None):
         BasicIO.__init__(self, identifier, title, abstract, keywords, translations=translations)
         IOHandler.__init__(self, workdir=workdir, mode=mode)
         BasicComplex.__init__(self, data_format, supported_formats)

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -13,7 +13,7 @@
 
 from collections import namedtuple
 import mimetypes
-
+from typing import Optional, Sequence, Union
 
 _FORMATS = namedtuple('FORMATS', 'GEOJSON, JSON, SHP, GML, GPX, METALINK, META4, KML, KMZ, GEOTIFF,'
                                  'WCS, WCS100, WCS110, WCS20, WFS, WFS100,'
@@ -160,6 +160,9 @@ class Format(object):
         self.encoding = jsonin['encoding']
         self.schema = jsonin['schema']
         self.extension = jsonin['extension']
+
+
+Supported_Formats = Optional[Sequence[Union[str, Format]]]
 
 
 FORMATS = _FORMATS(

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -186,6 +186,14 @@ class ComplexInput(basic.ComplexInput):
 
     @classmethod
     def from_json(cls, json_input):
+        data_format = json_input.get('data_format')
+        if data_format is not None:
+            data_format = Format(
+                schema=data_format.get('schema'),
+                extension=data_format.get('extension'),
+                mime_type=data_format.get('mime_type', ""),
+                encoding=data_format.get('encoding')
+            )
         instance = cls(
             identifier=json_input['identifier'],
             title=json_input.get('title'),
@@ -193,19 +201,14 @@ class ComplexInput(basic.ComplexInput):
             keywords=json_input.get('keywords', []),
             workdir=json_input.get('workdir'),
             metadata=[Metadata.from_json(data) for data in json_input.get('metadata', [])],
-            data_format=Format(
-                schema=json_input['data_format'].get('schema'),
-                extension=json_input['data_format'].get('extension'),
-                mime_type=json_input['data_format']['mime_type'],
-                encoding=json_input['data_format'].get('encoding')
-            ),
+            data_format=data_format,
             supported_formats=[
                 Format(
                     schema=infrmt.get('schema'),
                     extension=infrmt.get('extension'),
-                    mime_type=infrmt['mime_type'],
+                    mime_type=infrmt.get('mime_type'),
                     encoding=infrmt.get('encoding')
-                ) for infrmt in json_input['supported_formats']
+                ) for infrmt in json_input.get('supported_formats', [])
             ],
             mode=json_input.get('mode', MODE.NONE),
             translations=json_input.get('translations'),
@@ -331,7 +334,7 @@ class LiteralInput(basic.LiteralInput):
     @classmethod
     def from_json(cls, json_input):
         allowed_values = []
-        for allowed_value in json_input['allowed_values']:
+        for allowed_value in json_input.get('allowed_values', []):
             if allowed_value['type'] == 'anyvalue':
                 allowed_values.append(AnyValue())
             elif allowed_value['type'] == 'novalue':
@@ -351,7 +354,7 @@ class LiteralInput(basic.LiteralInput):
         data = json_input_copy.pop('data', None)
         uom = json_input_copy.pop('uom', None)
         metadata = json_input_copy.pop('metadata', [])
-        json_input_copy.pop('type')
+        json_input_copy.pop('type', None)
         json_input_copy.pop('any_value', None)
         json_input_copy.pop('values_reference', None)
 
@@ -371,8 +374,8 @@ class LiteralInput(basic.LiteralInput):
 
 
 def input_from_json(json_data):
-    data_type = json_data['type']
-    if data_type == 'complex':
+    data_type = json_data.get('type', 'literal')
+    if data_type in ['complex', 'reference']:
         inpt = ComplexInput.from_json(json_data)
     elif data_type == 'literal':
         inpt = LiteralInput.from_json(json_data)

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -5,7 +5,6 @@
 
 """Literaltypes are used for LiteralInputs, to make sure, input data are OK
 """
-
 from urllib.parse import urlparse
 from dateutil.parser import parse as date_parser
 import datetime
@@ -19,7 +18,7 @@ LOGGER = logging.getLogger('PYWPS')
 LITERAL_DATA_TYPES = ('float', 'boolean', 'integer', 'string',
                       'positiveInteger', 'anyURI', 'time', 'date', 'dateTime',
                       'scale', 'angle',
-                      'nonNegativeInteger')
+                      'nonNegativeInteger', None)
 
 # currently we are supporting just ^^^ data types, feel free to add support for
 # more

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -5,6 +5,7 @@
 """
 WPS Output classes
 """
+from typing import Optional, Sequence, Dict, Union
 
 import lxml.etree as etree
 import os
@@ -13,9 +14,10 @@ from pywps.app.Common import Metadata
 from pywps.exceptions import InvalidParameterValue
 from pywps.inout import basic
 from pywps.inout.storage.file import FileStorageBuilder
+from pywps.inout.types import Translations
 from pywps.validator.mode import MODE
 from pywps import configuration as config
-from pywps.inout.formats import Format
+from pywps.inout.formats import Format, Supported_Formats
 
 
 class BoundingBoxOutput(basic.BBoxOutput):
@@ -109,9 +111,10 @@ class ComplexOutput(basic.ComplexOutput):
         e.g. {"fr-CA": {"title": "Mon titre", "abstract": "Une description"}}
     """
 
-    def __init__(self, identifier, title, supported_formats=None,
-                 data_format=None, abstract='', keywords=[], workdir=None, metadata=None,
-                 as_reference=False, mode=MODE.NONE, translations=None):
+    def __init__(self, identifier: str, title: str, supported_formats: Supported_Formats = None,
+                 data_format=None, abstract: str = '', keywords=[], workdir=None,
+                 metadata: Optional[Sequence[Metadata]] = None,
+                 as_reference=False, mode: MODE = MODE.NONE, translations: Translations = None):
         if metadata is None:
             metadata = []
 
@@ -539,13 +542,14 @@ class MetaLink4(MetaLink):
 
 
 def output_from_json(json_data):
-    if json_data['type'] == 'complex':
+    data_type = json_data.get('type', 'literal')
+    if data_type == 'complex':
         output = ComplexOutput.from_json(json_data)
-    elif json_data['type'] == 'literal':
+    elif data_type == 'literal':
         output = LiteralOutput.from_json(json_data)
-    elif json_data['type'] == 'bbox':
+    elif data_type == 'bbox':
         output = BoundingBoxOutput.from_json(json_data)
     else:
-        raise InvalidParameterValue("Output type not recognized: {}".format(json_data['type']))
+        raise InvalidParameterValue("Output type not recognized: {}".format(data_type))
 
     return output

--- a/pywps/inout/types.py
+++ b/pywps/inout/types.py
@@ -1,0 +1,8 @@
+##################################################################
+# Copyright 2018 Open Source Geospatial Foundation and others    #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+from typing import Optional, Dict
+
+Translations = Optional[Dict[str, Dict[str, str]]]

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -1,6 +1,8 @@
+import json
+
 from werkzeug.wrappers import Request
 import pywps.configuration as config
-from pywps.app.basic import xml_response
+from pywps.app.basic import make_response, get_response_type, get_json_indent
 from pywps.exceptions import NoApplicableCode
 from pywps.exceptions import MissingParameterValue
 from pywps.exceptions import InvalidParameterValue
@@ -41,23 +43,31 @@ class DescribeResponse(WPSResponse):
             'language': self.wps_request.language,
         }
 
-    def _construct_doc(self):
+    @staticmethod
+    def _render_json_response(jdoc):
+        return jdoc
 
+    def _construct_doc(self):
         if not self.identifiers:
             raise MissingParameterValue('Missing parameter value "identifier"', 'identifier')
 
-        template = self.template_env.get_template(self.version + '/describe/main.xml')
-        max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
-        doc = template.render(max_size=max_size, **self.json)
-
-        return doc
+        doc = self.json
+        json_response, mimetype = get_response_type(
+            self.wps_request.http_request.accept_mimetypes, self.wps_request.default_mimetype)
+        if json_response:
+            doc = json.dumps(self._render_json_response(doc), indent=get_json_indent())
+        else:
+            template = self.template_env.get_template(self.version + '/describe/main.xml')
+            max_size = int(config.get_size_mb(config.get_config_value('server', 'maxsingleinputsize')))
+            doc = template.render(max_size=max_size, **doc)
+        return doc, mimetype
 
     @Request.application
     def __call__(self, request):
         # This function must return a valid response.
         try:
-            doc = self.get_response_doc()
-            return xml_response(doc)
+            doc, content_type = self.get_response_doc()
+            return make_response(doc, content_type=content_type)
         except NoApplicableCode as e:
             return e
         except Exception as e:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -15,7 +15,6 @@ from pywps import configuration
 import pywps.processing
 from pywps.processing.job import Job
 from pywps.processing.basic import MultiProcessing
-from pywps import Process
 from pywps.app import WPSRequest
 from pywps.response.execute import ExecuteResponse
 


### PR DESCRIPTION
# Overview

This PR adds partial support for the [OGC API - Processes](https://github.com/opengeospatial/wps-rest-binding) / REST API and allows requests and responses in JSON format.
I'd be happy to get a review.
Full backwards compatibility was maintained to allow both XML and JSON input/output, the correct format is determinate by the `mimetype`/`content-type` and the `accept` headers (POST) and `f` argument in GET.

I've add a `/processes` and `/jobs` end points that default to JSON input/output. The original `/wps` endpoint defaults to XML as before.

I've yet to add an open-api/swagger interface, but I've tried to make it as compatible as possible to these APIs:

[ZOO-Project WPS](https://demo.mapmint.com/swagger-ui/dist/#/Execute%20Endpoint/post_processes__id__jobs)

[52°North](https://demo.pygeoapi.io/master/openapi?f=html)

# Example JSON requests:

I've taken the internal JSON format and tried to make it a valid request (which now work). 

Original XML request:

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<wps:Execute service="WPS" version="1.0.0" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 ../wpsExecute_request.xsd">
	<!-- <ows:Identifier>say_hello</ows:Identifier> -->

    <wps:ResponseForm>
        <wps:RawDataOutput>
          <ows:Identifier>output</ows:Identifier>
        </wps:RawDataOutput>
    </wps:ResponseForm>

    <wps:DataInputs>
        <wps:Input>
            <ows:Identifier>name</ows:Identifier>
            <wps:Data>
                <wps:LiteralData>Idan</wps:LiteralData>
            </wps:Data>
        </wps:Input>
	</wps:DataInputs>
    
</wps:Execute>
```

JSON request taken from internal pywps (which now accepted as a valid request):

```
{
	"operation": "execute",
	"version": "1.0.0",
	"language": "en-US",
	"identifier": "say_hello",
	"identifiers": null,
	"store_execute": "false",
	"status": "false",
	"lineage": "false",
	"inputs": {
		"name": [
			{
				"identifier": "name",
				"title": "Input name",
				"abstract": "",
				"keywords": [],
				"metadata": [],
				"type": "literal",
				"data_type": "string",
				"workdir": "D:\\dev\\gis\\wps-flask\\workdir\\pywps_process_uxjnrc6i",
				"allowed_values": [],
				"any_value": false,
				"mode": 1,
				"min_occurs": 1,
				"max_occurs": 1,
				"translations": null,
				"data": "Idan"
			}
		]
	},
	"outputs": {
		"output": {
			"output": "",
			"mimetype": "",
			"encoding": "",
			"schema": "",
			"uom": ""
		}
	},
	"raw": true
}
```
Then I wanted to make a much more minimalistic request also valid as follows, so the following also works:

```
{
	"identifier": "say_hello",
	"outputs": "output",
	"inputs": {
		"name":"Idan"
	}
}
```

It is also possible to set the `identifier` in the endpoint url, so posting to `/processes/say_hello` is possible with the following input:
```
{
	"outputs": "output",
	"inputs": {
		"name":"Idan"
	}
}
```
Also possible to post to `/processes/say_hello/output` to indicate a raw output (for the output named `output` in this case), then such case the following is a valid input:
```
{
	"name":"Idan"
}
```

`outputs` can be a string (which implies raw output), or a list or a dict.
Each `input` inside `inputs` can be a string (which implies literal input) or a dict.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
