### PR TITLE
don't sleep in drmaa session

### DIFF
--- a/pywps/processing/scheduler.py
+++ b/pywps/processing/scheduler.py
@@ -61,8 +61,6 @@ class Scheduler(Processing):
                 jobid = session.runJob(jt)
                 LOGGER.info('Your job has been submitted with ID {}'.format(jobid))
                 # show status
-                import time
-                time.sleep(1)
                 LOGGER.info('Job status: {}'.format(session.jobStatus(jobid)))
                 # Cleaning up
                 session.deleteJobTemplate(jt)


### PR DESCRIPTION
# Overview

The scheduler can only submit one job after the other ... so, don't have a `time.sleep` in the drmaa session.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
