### PR TITLE
Fix kvp decoding to follow specification

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -18,6 +18,7 @@ from pywps import configuration
 from pywps import get_version_from_ns
 
 import json
+from urllib.parse import unquote
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -509,15 +510,15 @@ def get_data_from_kvp(data, part=None):
             # First field is identifier and its value
             (identifier, val) = fields[0].split("=")
             io['identifier'] = identifier
-            io['data'] = val
+            io['data'] = unquote(val)
 
             # Get the attributes of the data
             for attr in fields[1:]:
                 (attribute, attr_val) = attr.split('=', 1)
                 if attribute == 'xlink:href':
-                    io['href'] = attr_val
+                    io['href'] = unquote(attr_val)
                 else:
-                    io[attribute] = attr_val
+                    io[attribute] = unquote(attr_val)
 
             # Add the input/output with all its attributes and values to the
             # dictionary


### PR DESCRIPTION
# Overview

In the specification of WPS 1.0.0 the specification state in section 10.2.2.1:

6. All field values and attribute values shall be encoded using the standard Internet
practice for encoding URLs [IETF RFC 1738].

Thus unquote values and attribute values as expected.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
