### PR TITLE
Give a nicer name of the output file in rawdtata mode using Content-Disposition

### DIFF
--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -14,6 +14,7 @@ from werkzeug.wrappers import Response
 from pywps.response.status import WPS_STATUS
 from pywps.response import WPSResponse
 from pywps.inout.formats import FORMATS
+from pywps.inout.outputs import ComplexOutput
 
 import urllib.parse as urlparse
 from urllib.parse import urlencode
@@ -202,9 +203,14 @@ class ExecuteResponse(WPSResponse):
                 wps_output_value = self.outputs[wps_output_identifier]
                 if wps_output_value.source_type is None:
                     return NoApplicableCode("Expected output was not generated")
+                suffix = ''
+                if isinstance(wps_output_value, ComplexOutput):
+                    if wps_output_value.data_format.extension is not None:
+                        suffix = wps_output_value.data_format.extension
                 return Response(wps_output_value.data,
                                 mimetype=wps_output_value.data_format.mime_type,
-                                headers={'Content-Disposition': 'attachment; filename="{}"'.format(wps_output_identifier)})
+                                headers={'Content-Disposition': 'attachment; filename="{}"'
+                                         .format(wps_output_identifier + suffix)})
         else:
             if not self.doc:
                 return NoApplicableCode("Output was not generated")

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -203,7 +203,8 @@ class ExecuteResponse(WPSResponse):
                 if wps_output_value.source_type is None:
                     return NoApplicableCode("Expected output was not generated")
                 return Response(wps_output_value.data,
-                                mimetype=wps_output_value.data_format.mime_type)
+                                mimetype=wps_output_value.data_format.mime_type,
+                                headers={'Content-Disposition': 'attachment; filename="{}"'.format(wps_output_identifier)})
         else:
             if not self.doc:
                 return NoApplicableCode("Output was not generated")


### PR DESCRIPTION
# Overview

Give a nicer name of the output file in rawdtata mode using Content-Disposition

The file name is the identifier of the output plus the file extension if it available.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
