### PR TITLE
 Simplify the implementation of IOHandler 

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -302,6 +302,12 @@ class IOHandler(object):
         return self._iohandler.base64
 
     @property
+    def size(self):
+        """Return object size in bytes.
+        """
+        return self._iohandler.size
+
+    @property
     def file(self):
         """Return a file name"""
         return self._iohandler.file

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -356,18 +356,6 @@ class IOHandler(object):
     def prop(self):
         return self._iohandler.prop
 
-    @prop.setter
-    def prop(self, value):
-        LOGGER.warning("Deprecated use of IOHandler.prop, prefer self.value = self.value")
-        if value == "file":
-            self._iohandler = FileHandler(self._iohandler.file, self)
-        elif value == "data":
-            self._iohandler = DataHandler(self._iohandler.data, self)
-        elif value == "stream":
-            self._iohandler = StreamHandler(self._iohandler.stream, self)
-        elif value == "url":
-            self._iohandler = UrlHandler(self._iohandler.url, self)
-
 
 class FileHandler(NoneIOHandler):
     prop = 'file'

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -57,13 +57,6 @@ def _is_textfile(filename):
     return is_text
 
 
-def extend_instance(obj, cls):
-    """Apply mixins to a class instance after creation."""
-    base_cls = obj.__class__
-    base_cls_name = obj.__class__.__name__
-    obj.__class__ = type(base_cls_name, (cls, base_cls), {})
-
-
 class UOM(object):
     """
     :param uom: unit of measure
@@ -994,8 +987,6 @@ class ComplexInput(BasicIO, BasicComplex, IOHandler):
     def file_handler(self, inpt):
         """<wps:Reference /> handler.
         Used when href is a file url."""
-        extend_instance(self, FileHandler)
-
         # check if file url is allowed
         self._validate_file_input(href=inpt.get('href'))
         # save the file reference input in workdir

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -260,15 +260,6 @@ class SerializationComplexInputTest(unittest.TestCase):
         self.assertEqual(complex_1.as_reference, complex_2.as_reference)
         self.assertEqual(complex_1.translations, complex_2.translations)
 
-        self.assertEqual(complex_1.prop, complex_2.prop)
-
-        if complex_1.prop != 'url':
-            # don't download the file when running tests
-            self.assertEqual(complex_1.file, complex_2.file)
-            self.assertEqual(complex_1.data, complex_2.data)
-
-        self.assertEqual(complex_1.url, complex_2.url)
-
     def test_complex_input_file(self):
         complex = self.make_complex_input()
         some_file = os.path.join(self.tmp_dir, "some_file.txt")
@@ -278,6 +269,9 @@ class SerializationComplexInputTest(unittest.TestCase):
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
         self.assert_complex_equals(complex, complex2)
         self.assertEqual(complex.prop, 'file')
+        self.assertEqual(complex2.prop, 'file')
+        self.assertEqual(complex.file, complex2.file)
+        self.assertEqual(complex.data, complex2.data)
 
     def test_complex_input_data(self):
         complex = self.make_complex_input()
@@ -286,11 +280,11 @@ class SerializationComplexInputTest(unittest.TestCase):
         assert complex.json['data'] == '<![CDATA[some data]]>'
         # dump to json and load it again
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
-        # it's expected that the file path changed
-        complex._file = complex2.file
 
         self.assert_complex_equals(complex, complex2)
         self.assertEqual(complex.prop, 'data')
+        self.assertEqual(complex2.prop, 'data')
+        self.assertEqual(complex.data, complex2.data)
 
     def test_complex_input_stream(self):
         complex = self.make_complex_input()
@@ -300,12 +294,10 @@ class SerializationComplexInputTest(unittest.TestCase):
         # dump to json and load it again
         complex2 = inout.inputs.ComplexInput.from_json(complex.json)
         # the serialized stream becomes a data type
-        # we hard-code it for the testing comparison
-        complex.prop = 'data'
-        # it's expected that the file path changed
-        complex._file = complex2.file
-
+        self.assertEqual(complex.prop, 'stream')
+        self.assertEqual(complex2.prop, 'data')
         self.assert_complex_equals(complex, complex2)
+        self.assertEqual(complex.data, complex2.data)
 
     def test_complex_input_url(self):
         complex = self.make_complex_input()


### PR DESCRIPTION
# Overview

The current implementation use a tricks that manipulate the __mro__.
This trick do not have any obvious benefit and make the code much more
complicated than necessary. This patch simplifier the implementation by
replacing the tricky class change to a change in mamber's variable.

# Related Issue / Discussion

Following discussion in #598, Here is my proposal of refactoring the IOHandler. It come in two flavor, one with is a basic one and a second using weakref. I thought of another way using only class object without instantiating them like the previous implementation but I don't like too much the idea.

The code pass all the test excluding two. the two failed test a due to the fact that the test use private API to trick the test checking, thus IMO this just the test that is invalid.

Best regards.

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
