### PR TITLE
WPSRequest.json() better error handling

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -491,8 +491,13 @@ class WPSRequest(object):
                     inpt_def = {"data": inpt_def}
                 if 'identifier' not in inpt_def:
                     inpt_def['identifier'] = identifier
-                inpt = input_from_json(inpt_def)
-                self.inputs[identifier].append(inpt)
+                try:
+                    inpt = input_from_json(inpt_def)
+                    self.inputs[identifier].append(inpt)
+                except Exception as e:
+                    LOGGER.warning(e)
+                    LOGGER.warning(f'skipping input: {identifier}')
+                    pass
 
 
 def get_inputs_from_xml(doc):


### PR DESCRIPTION
# Overview

pywps/app/WPSRequest.py - gaurd WPSRequest.json() with try...except to better handle some inputs.
especially inputs with "complex" extra fields, which otherwise would raise 500 error.
If someone wants to pass a complex input parameter:
```
    "extent": {
        "type": "bbox",
        "bbox": [32, 34.7, 32.1, 34.8]
    }
```
As there are no remarks in JSON, I normally add an underscore to the parameter name if I want it to be ignored.
if "_extent" is not a parameter for the request then without this fix error 500 would be returned.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [X] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
