### PR TITLE
Fix WPS execute outputs parsing assuming string

### DIFF
--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -458,6 +458,9 @@ class Process(object):
 
                 is_reference = wps_request.outputs[wps_outpt].get('asReference', 'false')
                 mimetype = wps_request.outputs[wps_outpt].get('mimetype', '')
+                if not isinstance(mimetype, str):
+                    mimetype = ''
+
                 if is_reference.lower() == 'true':
                     # check if store is supported
                     if self.store_supported == 'false':


### PR DESCRIPTION
# Related Issue / Discussion

When parsing the XML of the WPS execute request (in `parse_post_execute`): 
https://github.com/geopython/pywps/blob/88d2d4d5d0b4c1d1c39b0eaacf3e22d0b835d01b/pywps/app/WPSRequest.py#L280
The outputs that do not provide a `mimetype` explicitly are defaulted to `None`: 
https://github.com/geopython/pywps/blob/88d2d4d5d0b4c1d1c39b0eaacf3e22d0b835d01b/pywps/app/WPSRequest.py#L590

When those output definitions eventually reach the following call, the field `mimetype` exists and is `None`, making both the `mimetype != ''` compare and `'MimeType ' + mimetype + ' not valid'` fail (raises cannot concatenate non-string). 
https://github.com/geopython/pywps/blob/cd71ee76c0f425e1267c842713bb634f800e7e2a/pywps/app/Process.py#L453-L479

This PR simply sets it to the default `''`

# Additional Information



# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
