### PR TITLE
resovle invalid Exception.msg unknown attribute

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -108,7 +108,7 @@ class WPSRequest(object):
             try:
                 doc = etree.fromstring(self.http_request.get_data())
             except Exception as e:
-                raise NoApplicableCode(e.msg)
+                raise NoApplicableCode(str(e))
             operation = doc.tag
             version = get_version_from_ns(doc.nsmap[doc.prefix])
             self.set_version(version)
@@ -122,7 +122,7 @@ class WPSRequest(object):
             try:
                 jdoc = json.loads(self.http_request.get_data())
             except Exception as e:
-                raise NoApplicableCode(e.msg)
+                raise NoApplicableCode(str(e))
             if self.identifier is not None:
                 jdoc = {'inputs': jdoc}
             else:


### PR DESCRIPTION
# Overview

Exception object does not have `msg` attribute. The real exceptions are therefore not reported because they are masked away by raised `AttributeError`. 

Replace invalid `.msg` by `str()` operation to let it resolve the appropriate error cause string representation as implemented by any exception derived class.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
