### PR TITLE
fix invalid Exception e.msg

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -87,7 +87,7 @@ class WPSRequest(object):
         try:
             doc = etree.fromstring(self.http_request.get_data())
         except Exception as e:
-            raise NoApplicableCode(e.msg)
+            raise NoApplicableCode(str(e))
 
         operation = doc.tag
         version = get_version_from_ns(doc.nsmap[doc.prefix])


### PR DESCRIPTION
# Overview

This replaces the invalid use of Exception message `e.msg` by `str(e)`. 

This fix is a backport of PR #629.

# Related Issue / Discussion

#629

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
