### PR TITLE
Modernize CI using Tox, add a "[dev]" recipe, re-enable coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install packages 📦
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libnetcdf-dev libhdf5-dev
       - uses: actions/setup-python@v2
         name: Setup Python 3.7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: build ⚙️
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   main:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,7 @@ jobs:
       run: tox -e ${{ matrix.tox-env }}
     - name: Run coveralls ⚙️
       if: matrix.python-version == 3.7
-      uses: coverallsapp/github-action@master
-      with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: AndreMiras/coveralls-python-action@develop
     - name: Build docs 🏗️
       run: |
         pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github
+        include:
+          - tox-env: py37-extra
+            python-version: 3.7
+          - tox-env: py38-extra
+            python-version: 3.8
+          - tox-env: py39-extra
+            python-version: 3.9
+#    env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        COVERALLS_SERVICE_NAME: github
     steps:
     - uses: actions/checkout@v2
     - name: Install packages
@@ -29,8 +35,8 @@ jobs:
 #        pip install -r requirements-extra.txt
     - name: Install tox
       run: pip install tox
-    - name: Run tests ⚙️
-      run: pytest -v tests --cov
+    - name: Run tests with tox ⚙️
+      run: tox -e ${{ matrix.tox-env }}
     - name: Run coveralls ⚙️
       if: matrix.python-version == 3.7
       uses: coverallsapp/github-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,27 +15,34 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install packages
       run: |
-        sudo apt-get update && sudo apt-get -y install libnetcdf-dev libhdf5-dev
+        sudo apt-get update
+        sudo apt-get -y install libnetcdf-dev libhdf5-dev
     - uses: actions/setup-python@v2
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install requirements 📦
-      run: |
-        pip3 install pip --upgrade
-        pip3 install -r requirements.txt
-        pip3 install -r requirements-dev.txt
-        pip3 install -r requirements-extra.txt
-    - name: run tests ⚙️
-      run: pytest -v tests
-    - name: run coveralls ⚙️
-      run: coveralls
+#    - name: Install requirements 📦
+#      run: |
+#        pip install pip --upgrade
+#        pip install -r requirements.txt
+#        pip install -r requirements-dev.txt
+#        pip install -r requirements-extra.txt
+    - name: Install tox
+      run: pip install tox
+    - name: Run tests ⚙️
+      run: pytest -v tests --cov
+    - name: Run coveralls ⚙️
       if: matrix.python-version == 3.7
-    - name: build docs 🏗️
+      uses: coverallsapp/github-action@master
+      with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build docs 🏗️
       run: |
-        pip3 install -e .
+        pip install -e .
         cd docs && make html
       if: matrix.python-version == 3.7
-    - name: run flake8 ⚙️
-      run: flake8 pywps
+    - name: Run flake8 ⚙️
+      run: |
+        pip install flake8
+        flake8 pywps
       if: matrix.python-version == 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       uses: AndreMiras/coveralls-python-action@develop
     - name: Build docs 🏗️
       run: |
-        pip install -e .
+        pip install -e .[dev]
         cd docs && make html
       if: matrix.python-version == 3.7
     - name: Run flake8 ⚙️

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  main:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,12 +18,9 @@ jobs:
             python-version: 3.8
           - tox-env: py39-extra
             python-version: 3.9
-#    env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        COVERALLS_SERVICE_NAME: github
     steps:
     - uses: actions/checkout@v2
-    - name: Install packages
+    - name: Install packages 📦
       run: |
         sudo apt-get update
         sudo apt-get -y install libnetcdf-dev libhdf5-dev
@@ -31,26 +28,32 @@ jobs:
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
-#    - name: Install requirements 📦
-#      run: |
-#        pip install pip --upgrade
-#        pip install -r requirements.txt
-#        pip install -r requirements-dev.txt
-#        pip install -r requirements-extra.txt
-    - name: Install tox
+    - name: Run flake8 ⚙️
+      run: |
+        pip install flake8
+        flake8 pywps
+      if: matrix.python-version == 3.7
+    - name: Install tox 📦
       run: pip install tox
     - name: Run tests with tox ⚙️
       run: tox -e ${{ matrix.tox-env }}
     - name: Run coveralls ⚙️
       if: matrix.python-version == 3.7
       uses: AndreMiras/coveralls-python-action@develop
-    - name: Build docs 🏗️
-      run: |
-        pip install -e .[dev]
-        cd docs && make html
-      if: matrix.python-version == 3.7
-    - name: Run flake8 ⚙️
-      run: |
-        pip install flake8
-        flake8 pywps
-      if: matrix.python-version == 3.7
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages 📦
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libnetcdf-dev libhdf5-dev
+      - uses: actions/setup-python@v2
+        name: Setup Python 3.7
+        with:
+          python-version: 3.7
+      - name: Build docs 🏗️
+        run: |
+          pip install -e .[dev]
+          cd docs && make html

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2014-2016 PyWPS Development Team, represented by Jachym Cepicky
+Copyright (C) 2014-2021 PyWPS Development Team, represented by Jachym Cepicky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 coverage
 coveralls
 pytest
+pytest-cov
 flake8
 pylint
 Sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,6 @@ parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}
 
-[flake8]
-ignore = F401,E402,W606
-max-line-length = 120
-exclude = tests
-
 [bumpversion:file:pywps/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
@@ -18,3 +13,11 @@ replace = __version__ = "{new_version}"
 [bumpversion:file:VERSION.txt]
 search = {current_version}
 replace = {new_version}
+
+[flake8]
+ignore =
+	F401
+	E402
+	W606
+max-line-length = 120
+exclude = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ replace = __version__ = "{new_version}"
 search = {current_version}
 replace = {new_version}
 
+[coverage:run]
+relative_files = True
+
 [flake8]
 ignore =
 	F401

--- a/setup.py
+++ b/setup.py
@@ -12,57 +12,69 @@ except ImportError:
 
 from setuptools import find_packages
 
-with open('VERSION.txt') as ff:
+with open("VERSION.txt") as ff:
     VERSION = ff.read().strip()
 
-DESCRIPTION = ('PyWPS is an implementation of the Web Processing Service '
-               'standard from the Open Geospatial Consortium. PyWPS is '
-               'written in Python.')
+DESCRIPTION = (
+    "PyWPS is an implementation of the Web Processing Service "
+    "standard from the Open Geospatial Consortium. PyWPS is "
+    "written in Python."
+)
 
-with open('README.md') as ff:
+with open("README.md") as ff:
     LONG_DESCRIPTION = ff.read()
 
-KEYWORDS = 'PyWPS WPS OGC processing'
+KEYWORDS = "PyWPS WPS OGC processing"
 
-with open('requirements.txt') as f:
-    INSTALL_REQUIRES = f.read().splitlines()
+with open("requirements.txt") as fr:
+    INSTALL_REQUIRES = fr.read().splitlines()
+
+with open("requirements-dev.txt") as frd:
+    DEV_REQUIRES = frd.read().splitlines()
 
 CONFIG = {
-    'name': 'pywps',
-    'version': VERSION,
-    'description': DESCRIPTION,
-    'long_description': LONG_DESCRIPTION,
-    'long_description_content_type': 'text/markdown',
-    'keywords': KEYWORDS,
-    'license': 'MIT',
-    'platforms': 'all',
-    'author': 'Jachym Cepicky',
-    'author_email': 'jachym.cepicky@gmail.com',
-    'maintainer': 'Jachym Cepicky',
-    'maintainer_email': 'jachym.cepicky@gmail.com',
-    'url': 'https://pywps.org',
-    'download_url': 'https://github.com/geopython/pywps',
-    'classifiers': [
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
+    "name": "pywps",
+    "version": VERSION,
+    "description": DESCRIPTION,
+    "long_description": LONG_DESCRIPTION,
+    "long_description_content_type": "text/markdown",
+    "keywords": KEYWORDS,
+    "license": "MIT",
+    "platforms": "all",
+    "author": "Jachym Cepicky",
+    "author_email": "jachym.cepicky@gmail.com",
+    "maintainer": "Jachym Cepicky",
+    "maintainer_email": "jachym.cepicky@gmail.com",
+    "url": "https://pywps.org",
+    "download_url": "https://github.com/geopython/pywps",
+    "classifiers": [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        'Topic :: Scientific/Engineering :: GIS'
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Topic :: Scientific/Engineering :: GIS",
     ],
-    'install_requires': INSTALL_REQUIRES,
-    'python_requires': '>=3.6, <4',
-    'packages': find_packages(exclude=["docs", "tests.*", "tests"]),
-    'include_package_data': True,
-    'scripts': [],
-    'entry_points': {
-        'console_scripts': [
-            'joblauncher=pywps.processing.job:launcher', ]},
+    "install_requires": INSTALL_REQUIRES,
+    "extras_require": dict(
+        dev=DEV_REQUIRES,
+    ),
+    "python_requires": ">=3.6, <4",
+    "packages": find_packages(exclude=["docs", "tests.*", "tests"]),
+    "include_package_data": True,
+    "scripts": [],
+    "entry_points": {
+        "console_scripts": [
+            "joblauncher=pywps.processing.job:launcher",
+        ]
+    },
 }
 
 setup(**CONFIG)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ CONFIG = {
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -66,7 +65,7 @@ CONFIG = {
     "extras_require": dict(
         dev=DEV_REQUIRES,
     ),
-    "python_requires": ">=3.6, <4",
+    "python_requires": ">=3.7,<4",
     "packages": find_packages(exclude=["docs", "tests.*", "tests"]),
     "include_package_data": True,
     "scripts": [],

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -10,9 +10,10 @@ from pywps.tests import assert_pywps_version, client_for
 
 import re
 
-VERSION="1.0.0"
+VERSION = "1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)
 xpath_ns = get_xpath_ns(VERSION)
+
 
 class ExceptionsTest(unittest.TestCase):
 
@@ -24,7 +25,7 @@ class ExceptionsTest(unittest.TestCase):
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'InvalidParameterValue'
         assert resp.status_code == 400
-        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
+        assert re.match(r'text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
         assert_pywps_version(resp)
 
     def test_missing_parameter_value(self):
@@ -32,20 +33,21 @@ class ExceptionsTest(unittest.TestCase):
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'MissingParameterValue'
         assert resp.status_code == 400
-        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
+        assert re.match(r'text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
 
     def test_missing_request(self):
         resp = self.client.get("?service=wps")
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception/ows:ExceptionText')[0]
         # should mention something about a request
         assert 'request' in exception_el.text
-        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
+        assert re.match(r'text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
 
     def test_bad_request(self):
         resp = self.client.get("?service=wps&request=xyz")
         exception_el = resp.xpath('/ows:ExceptionReport/ows:Exception')[0]
         assert exception_el.attrib['exceptionCode'] == 'OperationNotSupported'
-        assert re.match('text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
+        assert re.match(r'text/xml(;\s*charset=.*)?', resp.headers['Content-Type'])
+
 
 def load_tests(loader=None, tests=None, pattern=None):
     if not loader:

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,21 @@
 [tox]
-envlist=py36
+envlist = py{36,37,38,39}{-extra,}
+requires = pip >= 20.0
+opts = --verbose
 
 [testenv]
-
-pip_pre=True
-deps=
-    lxml
-    flask
-    owslib
-    simplejson
-    jsonschema
-    geojson
-    shapely
-    unipath
-    werkzeug
-    SQLAlchemy
-    jinja2
-
-commands=
-	# check first which version is installed "gdal-config --version"
-	pip install GDAL==2.1.0 --global-option=build_ext --global-option="-I/usr/include/gdal"
-    python -m unittest tests
+setenv =
+    PYTEST_ADDOPTS = "--color=yes"
+    PYTHONPATH = {toxinidir}
+    COV_CORE_SOURCE =
+passenv = CI GITHUB_* LD_LIBRARY_PATH
+download = True
+install_command =
+    python -m pip install --no-user {opts} {packages}
+extras = dev
+deps =
+    extra: -rrequirements-extra.txt
+commands =
+;    # magic for gathering the GDAL version within tox
+;    sh -c 'pip install GDAL=="$(gdal-config --version)" --global-option=build_ext --global-option="-I/usr/include/gdal"'
+    pytest --cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}{-extra,}
+envlist = py{37,38,39}{-extra,}
 requires = pip >= 20.0
 opts = --verbose
 


### PR DESCRIPTION
# Overview

This PR does a bit of cleanup to the package's CI and current tests. 

* Updates the `tox.ini` to reflect the current state of the package.
* Adds a `[dev]` recipe to the `setup.py` so that developers can install pywps for development with `pip install -e (pywps/.)[dev]`.
* Removes a few warning raised from the test ensemble by specifying that raw strings are being used with regex.
* Update the GitHub CI workflow to use `tox`, re-enabling the Coveralls check (the last successful run was uploaded in July 2020).
* Updates the License to include $CURRENT_YEAR

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
