### PR TITLE
Fix invalide use of encode on bytes object

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -243,7 +243,7 @@ class ComplexInput(basic.ComplexInput):
                 else:
                     # Otherwise we assume all other formats are unsafe and need to be enclosed in a CDATA tag.
                     if isinstance(self.data, bytes):
-                        out = self.data.encode(self.data_format.encoding or 'utf-8')
+                        out = self.data.decode(self.data_format.encoding or 'utf-8')
                     else:
                         out = self.data
 


### PR DESCRIPTION
# Overview

Invalide use of encode on bytes object

Within the pywps.inout.inputs.ComplexInput the json convertion function use encode where decode should be used. The patch fix this issue.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
