### PR TITLE
fix JSON encoding of CRS type (#610) 

### DIFF
--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -11,7 +11,6 @@ from werkzeug.exceptions import MethodNotAllowed
 from pywps import get_ElementMakerForVersion
 import base64
 import datetime
-from owslib.crs import Crs
 from pywps.app.basic import get_xpath_ns, parse_http_url
 from pywps.inout.inputs import input_from_json
 from pywps.exceptions import NoApplicableCode, OperationNotSupported, MissingParameterValue, VersionNegotiationFailed, \
@@ -439,8 +438,6 @@ class WPSRequest(object):
             def default(self, obj):
                 if isinstance(obj, datetime.date) or isinstance(obj, datetime.time):
                     encoded_object = obj.isoformat()
-                elif isinstance(obj, Crs):
-                    encoded_object = str(obj)
                 else:
                     encoded_object = json.JSONEncoder.default(self, obj)
                 return encoded_object
@@ -578,7 +575,8 @@ def get_inputs_from_xml(doc):
                 inpt = {}
                 inpt['identifier'] = identifier_el.text
                 inpt['data'] = [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy]
-                inpt['crs'] = bbox.crs
+                # The BBox crs is not returned as a string but as oswlib.crs.Crs. This would cause JSON encoding errors
+                inpt['crs'] = str(bbox.crs)
                 inpt['dimensions'] = bbox.dimensions
                 the_inputs[identifier].append(inpt)
     return the_inputs

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import MethodNotAllowed
 from pywps import get_ElementMakerForVersion
 import base64
 import datetime
+from owslib.crs import Crs
 from pywps.app.basic import get_xpath_ns, parse_http_url
 from pywps.inout.inputs import input_from_json
 from pywps.exceptions import NoApplicableCode, OperationNotSupported, MissingParameterValue, VersionNegotiationFailed, \
@@ -438,6 +439,8 @@ class WPSRequest(object):
             def default(self, obj):
                 if isinstance(obj, datetime.date) or isinstance(obj, datetime.time):
                     encoded_object = obj.isoformat()
+                elif isinstance(obj, Crs):
+                    encoded_object = str(obj)
                 else:
                     encoded_object = json.JSONEncoder.default(self, obj)
                 return encoded_object

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -575,7 +575,7 @@ def get_inputs_from_xml(doc):
                 inpt = {}
                 inpt['identifier'] = identifier_el.text
                 inpt['data'] = [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy]
-                inpt['crs'] = bbox.crs.getcodeurn()
+                inpt['crs'] = bbox.crs.getcodeurn() if bbox.crs else None
                 inpt['dimensions'] = bbox.dimensions
                 the_inputs[identifier].append(inpt)
     return the_inputs

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -575,8 +575,7 @@ def get_inputs_from_xml(doc):
                 inpt = {}
                 inpt['identifier'] = identifier_el.text
                 inpt['data'] = [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy]
-                # The BBox crs is not returned as a string but as oswlib.crs.Crs. This would cause JSON encoding errors
-                inpt['crs'] = str(bbox.crs)
+                inpt['crs'] = bbox.crs.getcodeurn()
                 inpt['dimensions'] = bbox.dimensions
                 the_inputs[identifier].append(inpt)
     return the_inputs

--- a/tests/processes/__init__.py
+++ b/tests/processes/__init__.py
@@ -4,7 +4,7 @@
 ##################################################################
 
 from pywps import Process
-from pywps.inout import LiteralInput, LiteralOutput
+from pywps.inout import LiteralInput, LiteralOutput, BoundingBoxInput, BoundingBoxOutput
 from pywps.inout.literaltypes import ValuesReference
 
 
@@ -70,4 +70,32 @@ class InOut(Process):
     def inout(request, response):
         a_string = request.inputs['string'][0].data
         response.outputs['string'].data = "".format(a_string)
+        return response
+
+
+class BBox(Process):
+    def __init__(self):
+        super(BBox, self).__init__(
+            self.bbox,
+            identifier='bbox_test',
+            title='BBox Test',
+            inputs=[
+                BoundingBoxInput(
+                    'area',
+                    'An area',
+                    abstract='Define the area of interest',
+                    crss=['epsg:4326', 'epsg:3857'],
+                    min_occurs=1,
+                    max_occurs=1
+                ),
+            ],
+            outputs=[
+                BoundingBoxOutput('extent', 'Extent', crss=['epsg:4326', 'epsg:3857'])
+            ]
+        )
+
+    @staticmethod
+    def bbox(request, response):
+        area = request.inputs['area'][0].data
+        response.outputs['extent'].data = area
         return response

--- a/tests/test_wpsrequest.py
+++ b/tests/test_wpsrequest.py
@@ -8,6 +8,7 @@ from pywps.app import WPSRequest
 import tempfile
 import datetime
 import json
+from owslib.crs import Crs
 
 from pywps.inout.literaltypes import AnyValue
 
@@ -115,6 +116,46 @@ class WPSRequestTest(unittest.TestCase):
         self.assertEqual(self.request.inputs['datetime'][0].data, datetime.datetime(2017, 4, 20, 12), 'Datatime set')
         self.assertEqual(self.request.inputs['date'][0].data, datetime.date(2017, 4, 20), 'Data set')
         self.assertEqual(self.request.inputs['time'][0].data, datetime.time(9, 0, 0), 'Time set')
+
+    def test_json_inout_bbox(self):
+        obj = {
+            'operation': 'getcapabilities',
+            'version': '1.0.0',
+            'language': 'eng',
+            'identifier': 'arghhhh',
+            'identifiers': 'arghhhh',  # TODO: why identifierS?
+            'store_execute': True,
+            'status': True,
+            'lineage': True,
+            'inputs': {
+                'bbox': [{
+                    'identifier': 'bbox',
+                    'type': 'bbox',
+                    'bbox': '6.117602,46.176194,6.22283,46.275832',
+                    'crs': 'urn:ogc:def:crs:EPSG::4326',
+                    'crss': ['epsg:4326'],
+                    'dimensions': 2,
+                    'translations': None
+                }],
+            },
+            'outputs': {},
+            'raw': False
+        }
+
+        self.request = WPSRequest()
+        self.request.json = obj
+
+        self.assertEqual(self.request.inputs['bbox'][0].data, [6.117602, 46.176194, 6.22283, 46.275832], 'BBox data set')
+        self.assertTrue(isinstance(self.request.inputs['bbox'][0].crs, str), 'CRS is a string')
+        self.assertEqual(self.request.inputs['bbox'][0].crs, 'epsg:4326', 'CRS data correctly parsed')
+
+        # dump to json and reload
+        dump = self.request.json
+        self.request.json = json.loads(dump)
+
+        self.assertEqual(self.request.inputs['bbox'][0].data, [6.117602, 46.176194, 6.22283, 46.275832], 'BBox data set')
+        self.assertTrue(isinstance(self.request.inputs['bbox'][0].crs, str), 'CRS is a string')
+        self.assertEqual(self.request.inputs['bbox'][0].crs, 'epsg:4326', 'CRS data correctly parsed')
 
 
 def load_tests(loader=None, tests=None, pattern=None):


### PR DESCRIPTION
# Overview
Fixed the JSON encoding of the CRS type which crashed an execution request when the request was serialized

# Related Issue / Discussion
This should fix the problem described in #610 

# Additional Information
The type `owslib.crs.Crs` cannot be encoded by the default JSON encoding

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
