### PR TITLE
Fix invalide use of encode on bytes object

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -247,7 +247,7 @@ class ComplexInput(basic.ComplexInput):
                 else:
                     # Otherwise we assume all other formats are unsafe and need to be enclosed in a CDATA tag.
                     if isinstance(self.data, bytes):
-                        out = self.data.encode(self.data_format.encoding or 'utf-8')
+                        out = self.data.decode(self.data_format.encoding or 'utf-8')
                     else:
                         out = self.data
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -284,6 +284,13 @@ class SerializationComplexInputTest(unittest.TestCase):
         self.assertEqual(complex2.prop, 'data')
         self.assertEqual(complex.data, complex2.data)
 
+    def test_complex_input_binary_data(self):
+        complex = self.make_complex_input()
+        complex.data = b"some data"
+        # the data is enclosed by a CDATA tag in json
+        assert complex.json['data'] == '<![CDATA[some data]]>'
+        self.assertEqual(complex.prop, 'data')
+
     def test_complex_input_stream(self):
         complex = self.make_complex_input()
         complex.stream = StringIO("{'name': 'test', 'input1': ']]'}")


### PR DESCRIPTION
Within the pywps.inout.inputs.ComplexInput the json convertion function
use encode where decode should be used. The patch fix this issue.

same as #647 but main branch as base

# Overview

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
