### PR TITLE
Fix ComplexInput.from_json to handle data_format.encoding="base64"

### DIFF
--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Open Source Geospatial Foundation and others    #
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
-
+import base64
 import re
 from pywps import xml_util as etree
 
@@ -220,12 +220,15 @@ class ComplexInput(basic.ComplexInput):
             instance.url = json_input['href']
         elif json_input.get('data'):
             data = json_input['data']
-            # remove cdata tag if it exists (issue #553)
-            if isinstance(data, str):
-                match = CDATA_PATTERN.match(data)
-                if match:
-                    data = match.group(1)
-            instance.data = data
+            if data_format.encoding == 'base64':
+                instance.data = base64.b64decode(data)
+            else:
+                # remove cdata tag if it exists (issue #553)
+                if isinstance(data, str):
+                    match = CDATA_PATTERN.match(data)
+                    if match:
+                        data = match.group(1)
+                instance.data = data
 
         return instance
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -291,6 +291,34 @@ class SerializationComplexInputTest(unittest.TestCase):
         assert complex.json['data'] == '<![CDATA[some data]]>'
         self.assertEqual(complex.prop, 'data')
 
+    def test_complex_input_data_with_binary_data_format(self):
+        complex = inout.inputs.ComplexInput(
+            identifier="complexinput",
+            title='MyComplex',
+            abstract='My complex input',
+            keywords=['kw1', 'kw2'],
+            workdir=self.tmp_dir,
+            supported_formats=[FORMATS.ZIP],
+            metadata=[Metadata("special data")],
+            default="/some/file/path",
+            default_type=SOURCE_TYPE.FILE,
+            translations={"fr-CA": {"title": "Mon input", "abstract": "Une description"}},
+            data_format=FORMATS.ZIP
+        )
+        complex.as_reference = False
+        complex.method = "GET"
+        complex.max_size = 1000
+        complex.data = b"some data"
+        # the data is enclosed by a CDATA tag in json
+        assert complex.json['data'] == 'c29tZSBkYXRh'
+        # dump to json and load it again
+        complex2 = inout.inputs.ComplexInput.from_json(complex.json)
+
+        self.assert_complex_equals(complex, complex2)
+        self.assertEqual(complex.prop, 'data')
+        self.assertEqual(complex2.prop, 'data')
+        self.assertEqual(complex.data, complex2.data)
+
     def test_complex_input_stream(self):
         complex = self.make_complex_input()
         complex.stream = StringIO("{'name': 'test', 'input1': ']]'}")


### PR DESCRIPTION
# Overview

Fix the serialization/de-serialisation of input data when they are binary and base64 encoding.

Add the corresponding test.

The issue may be triggered when the binary file is send using base64 encoding within the XML request as instance:

```
    <wps:Input>
        <ows:Identifier>someidentifier</ows:Identifier>
        <wps:Data><wps:ComplexData mimeType="application/zip" encoding="base64" >
            SOMEDATA IN BASE64
        </wps:ComplexData></wps:Data>
    </wps:Input>
```
Note I did not actually checked the issue, I just triggered it with test case in the patch series.

# Related Issue / Discussion

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
