### PR TITLE
Fix tests/test_capabilities.py with correct check of request case

### DIFF
--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -97,11 +97,12 @@ class CapabilitiesTest(unittest.TestCase):
         assert len(metadatas) == 2
 
     def test_get_request(self):
-        resp = self.client.get('?Request=GetCapabilities&service=WpS')
+        # Check service=WPS (parameters values are case sensitive)
+        resp = self.client.get('?Request=GetCapabilities&service=WPS')
         self.check_capabilities_response(resp)
 
-        # case insesitive check
-        resp = self.client.get('?request=getcapabilities&service=wps')
+        # Check service=WPS (parameters name are not sensitive to case)
+        resp = self.client.get('?ReQuest=GetCapabilities&SeRviCe=WPS')
         self.check_capabilities_response(resp)
 
     def test_post_request(self):
@@ -110,7 +111,7 @@ class CapabilitiesTest(unittest.TestCase):
         self.check_capabilities_response(resp)
 
     def test_get_bad_version(self):
-        resp = self.client.get('?request=getcapabilities&service=wps&acceptversions=2001-123')
+        resp = self.client.get('?request=getcapabilities&service=WPS&acceptversions=2001-123')
         exception = resp.xpath('/ows:ExceptionReport'
                                '/ows:Exception')
         assert resp.status_code == 400
@@ -164,7 +165,7 @@ class CapabilitiesTranslationsTest(unittest.TestCase):
         configuration.CONFIG.set('server', 'language', 'en-US')
 
     def test_get_translated(self):
-        resp = self.client.get('?Request=GetCapabilities&service=wps&language=fr-CA')
+        resp = self.client.get('?Request=GetCapabilities&service=WPS&language=fr-CA')
 
         assert resp.xpath('/wps:Capabilities/@xml:lang')[0] == "fr-CA"
 


### PR DESCRIPTION
As far as I know, the OGC standard state that request parameters name such as 'service' or 'request' are not case sensitive, but the values of those are case sensitive [1].

[1] OGC 06-121r3 §11.5.1

# Overview

# Related Issue / Discussion

# Additional Information

This contribution is supported by MINES ParisTech.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
