### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,7 @@
 
 import sys
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 with open("VERSION.txt") as ff:
     VERSION = ff.read().strip()


### PR DESCRIPTION
# Overview
`setup.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

Because `setup_requires` is deprecated, [PEP 517 (`pyproject.toml`)](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement) is used for the build time dependencies.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute these changes to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
