### PR TITLE
675 extended env variable interpolation

### DIFF
--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -43,7 +43,7 @@ class EnvInterpolation(configparser.BasicInterpolation):
     ==> http://localhost/wps
 
 
-    See code is an adaption from the configuation parsing in the pycsw
+    This code is an adaption from the configuation parsing in the pycsw
     project.
     See also
     - https://github.com/geopython/pycsw/blob/3.0.0-alpha3/pycsw/core/util.py

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,7 @@ import configparser
 import pywps.configuration as config
 
 from tests import test_capabilities
+from tests import test_configuration
 from tests import test_describe
 from tests import test_execute
 from tests import test_exceptions
@@ -76,6 +77,7 @@ def load_tests(loader=None, tests=None, pattern=None):
 
     return unittest.TestSuite([
         test_capabilities.load_tests(),
+        test_configuration.load_tests(),
         test_execute.load_tests(),
         test_describe.load_tests(),
         test_inout.load_tests(),

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,49 @@
+##################################################################
+# Copyright 2018 Open Source Geospatial Foundation and others    #
+# licensed under MIT, Please consult LICENSE.txt for details     #
+##################################################################
+
+"""Tests for parsing env variables."""
+
+import os
+import unittest
+
+from pywps import configuration
+
+
+class TestEnvInterpolation(unittest.TestCase):
+    """Test cases for env variable interpolation within the configuration."""
+
+    def test_expand_user(self):
+        """Ensure we can parse a value with the $USER entry."""
+        user = os.environ.get("USER")
+        configuration.CONFIG.read_string("[envinterpolationsection]\nuser=$USER")
+        assert user == configuration.CONFIG["envinterpolationsection"]["user"]
+
+    def test_expand_user_with_some_text(self):
+        """Ensure we can parse a value with the $USER entry and some more text."""
+        user = os.environ.get("USER")
+        new_user = "new_" + user
+        configuration.CONFIG.read_string("[envinterpolationsection]\nuser=new_${USER}")
+        assert new_user == configuration.CONFIG["envinterpolationsection"]["user"]
+
+    def test_dont_expand_value_without_env_variable(self):
+        """
+        Ensure we don't expand values that are no env variables.
+
+        Could be an important case for existing config keys that need to
+        contain the $symbol.
+        """
+        key = "$example_key_that_hopefully_will_never_be_a_real_env_variable"
+        configuration.CONFIG.read_string("[envinterpolationsection]\nuser=" + key)
+        assert key == configuration.CONFIG["envinterpolationsection"]["user"]
+
+
+def load_tests(loader=None, tests=None, pattern=None):
+    """Load the tests and return the test suite for this file."""
+    if not loader:
+        loader = unittest.TestLoader()
+    suite_list = [
+        loader.loadTestsFromTestCase(TestEnvInterpolation),
+    ]
+    return unittest.TestSuite(suite_list)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,7 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-"""Tests for parsing env variables."""
+"""Tests for the configuration."""
 
 import os
 import unittest


### PR DESCRIPTION
# Overview

This is an example implementation on how the env interpolation could work.

# Related Issue / Discussion

See https://github.com/geopython/pywps/issues/675

# Additional Information

This is currently just the solutiuon as it is in the pycsw. But it still hope it could be helpful for the future.
I'm a little bit worried about the backward compatibility. But as the system doesn't expand values for that there are no env variables it should be okayish for use cases that used the $ syntax for their values in the past.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
