### PR TITLE
Support Python3.10/3.11, documentation fixes, and general codebase cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,22 @@ jobs:
       matrix:
         include:
           - tox-env: py37-extra
-            python-version: 3.7
+            python-version: "3.7"
           - tox-env: py38-extra
-            python-version: 3.8
+            python-version: "3.8"
           - tox-env: py39-extra
-            python-version: 3.9
+            python-version: "3.9"
+          - tox-env: py310-extra
+            python-version: "3.10"
+          - tox-env: py311-extra
+            python-version: "3.11"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install packages 📦
       run: |
         sudo apt-get update
         sudo apt-get -y install libnetcdf-dev libhdf5-dev
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install libnetcdf-dev libhdf5-dev
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
@@ -48,8 +48,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Setup Python 3.7
         with:
           python-version: 3.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,14 +16,13 @@ Code of Conduct
 ---------------
 
 Contributors to this project are expected to act respectfully towards others in
-accordance with the `OSGeo Code of Conduct
-<https://www.osgeo.org/code_of_conduct>`_.
+accordance with the `OSGeo Code of Conduct <https://www.osgeo.org/code_of_conduct>`_.
 
 Contributions and Licensing
 ---------------------------
 
 Contributors are asked to confirm that they comply with the project `license
-<https://github.com/geopython/PyWPS/blob/master/LICENSE.txt>`_ guidelines.
+<https://github.com/geopython/PyWPS/blob/main/LICENSE.txt>`_ guidelines.
 
 GitHub Commit Access
 ^^^^^^^^^^^^^^^^^^^^
@@ -32,10 +31,11 @@ GitHub Commit Access
   the pywps-devel `mailing list`_.  Proposals shall be approved by the PyWPS
   development team.  Committers shall be added by the project admin
 - removal of commit access shall be handled in the same manner
-- each committer must send an email to the PyWPS mailing list agreeing to the license guidelines (see
-  `Contributions and Licensing Agreement Template
-  <#contributions-and-licensing-agreement-template>`_).  **This is only required once**
-- each committer shall be listed in https://github.com/geopython/pywps/blob/master/COMMITTERS.txt
+- each committer must send an email to the PyWPS mailing list agreeing to the
+  license guidelines (see
+  `Contributions and Licensing Agreement Template <#contributions-and-licensing-agreement-template>`_).
+  **This is only required once**
+- each committer shall be listed in https://github.com/geopython/pywps/blob/main/COMMITTERS.txt
 
 GitHub Pull Requests
 ^^^^^^^^^^^^^^^^^^^^
@@ -52,10 +52,10 @@ GitHub Pull Requests
 - all contributors shall be listed at
   https://github.com/geopython/pywps/graphs/contributors
 - unclaimed copyright, by default, is assigned to the main copyright holders as
-  specified in https://github.com/geopython/pywps/blob/master/LICENSE.txt
-- make sure, the tests are passing on [travis-ci](https://travis-ci.org/geopython/pywps) sevice, as well as on your local machine `tox`::
+  specified in https://github.com/geopython/pywps/blob/main/LICENSE.txt
+- make sure, the tests are passing on [GitHub CI](https://github.com/geopython/pywps/actions/workflows/main.yml) service, as well as on your local machine `tox`::
 
-    tox
+    $ tox
 
 Contributions and Licensing Agreement Template
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,6 @@ Contributions and Licensing Agreement Template
 ``Hi all, I'd like to contribute <feature X|bugfix Y|docs|something else> to
 PyWPS.  I confirm that my contributions to PyWPS will be compatible with the
 PyWPS license guidelines at the time of contribution.``
-
 
 GitHub
 ------
@@ -82,8 +81,8 @@ Documentation
 
 - documentation is managed in ``docs/``, in reStructuredText format
 - `Sphinx`_ is used to generate the documentation
-- See the `reStructuredText Primer <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ on rST
-  markup and syntax
+- See the `reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+  on reST markup and syntax
 
 Bugs
 ----
@@ -109,8 +108,8 @@ GitHub Commit Guidelines
 - enhancements and bug fixes should be identified with a GitHub issue
 - commits should be granular enough for other developers to understand the
   nature / implications of the change(s)
-- for trivial commits that do not need `Travis CI
-  <https://travis-ci.org/geopython/pywps>`_ to run, include ``[ci skip]`` as
+- for trivial commits that do not need `GitHub CI
+  <https://github.com/geopython/pywps/actions/workflows/main.yml>`_ to run, include ``[ci skip]`` as
   part of the commit message
 - non-trivial Git commits shall be associated with a GitHub issue.  As
   documentation can always be improved, tickets need not be opened for improving
@@ -129,7 +128,7 @@ Coding Guidelines
 ^^^^^^^^^^^^^^^^^
 
 - PyWPS instead of pywps, pyWPS, Pywps, PYWPS
-- always code with `PEP 8`_ conventions
+- always code with `PEP8`_ conventions
 - always run source code through ``flake8``
 - for exceptions which make their way to OGC ``ows:ExceptionReport`` XML, always
   specify the appropriate ``locator`` and ``code`` parameters
@@ -139,61 +138,58 @@ Submitting a Pull Request
 
 This section will guide you through steps of working on PyWPS.  This section
 assumes you have forked PyWPS into your own GitHub repository. Note that 
-``master`` is the main development branch in PyWPS.
+``main`` is the main development branch in PyWPS.
 for stable releases and managed exclusively by the PyWPS team.
 
-.. code-block:: bash
+.. code-block:: console
 
   # setup a virtualenv
-  virtualenv mypywps && cd mypywps
-  . ./bin/activate
+  $ virtualenv mypywps && cd mypywps
+  $ . ./bin/activate
 
   # clone the repository locally
-  git clone git@github.com:USERNAME/pywps.git
-  cd pywps
-  pip install -e . && pip install -r requirements.txt
+  $ git clone git@github.com:USERNAME/pywps.git
+  $ cd pywps
+  $ pip install -e . && pip install -r requirements.txt
 
   # add the main PyWPS development branch to keep up to date with upstream changes
-  git remote add upstream https://github.com/geopython/pywps.git
-  git pull upstream master
+  $ git remote add upstream https://github.com/geopython/pywps.git
+  $ git pull upstream main
 
-  # create a local branch off master
+  # create a local branch off main
   # The name of the branch should include the issue number if it exists
-  git branch issue-72
-  git checkout issue-72
+  $ git branch issue-72
+  $ git checkout issue-72
 
-   
   # make code/doc changes
-  git commit -am 'fix xyz (#72)'
-  git push origin issue-72
+  $ git commit -am 'fix xyz (#72)'
+  $ git push origin issue-72
 
 Your changes are now visible on your PyWPS repository on GitHub.  You are now
-ready to create a pull request.  A member of the PyWPS team will review the pull
+ready to create a pull request. A member of the PyWPS team will review the pull
 request and provide feedback / suggestions if required.  If changes are
 required, make them against the same branch and push as per above (all changes
 to the branch in the pull request apply).
 
 The pull request will then be merged by the PyWPS team.  You can then delete
-your local branch (on GitHub), and then update
-your own repository to ensure your PyWPS repository is up to date with PyWPS
-master:
+your local branch (on GitHub), and then update your own repository to ensure
+your PyWPS repository is up to date with PyWPS main:
 
-.. code-block:: bash
+.. code-block:: console
 
-  git checkout master
-  git pull upstream master
+  $ git checkout main
+  $ git pull upstream main
 
 Release Packaging
 -----------------
 
 Release packaging notes are maintained at https://github.com/geopython/pywps/wiki/ReleasePackaging
 
-
 .. _`Corporate`: http://www.osgeo.org/sites/osgeo.org/files/Page/corporate_contributor.txt
 .. _`Individual`: http://www.osgeo.org/sites/osgeo.org/files/Page/individual_contributor.txt
 .. _`info@osgeo.org`: mailto:info@osgeo.org
 .. _`OSGeo`: http://www.osgeo.org/content/foundation/legal/licenses.html
-.. _`PEP 8`: https://www.python.org/dev/peps/pep-0008/
+.. _`PEP8`: https://www.python.org/dev/peps/pep-0008/
 .. _`flake8`: https://flake8.readthedocs.io/en/latest/
 .. _`Sphinx`: http://sphinx-doc.org/
 .. _`mailing list`: https://pywps.org/community

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * @jonas-eberle Jonas Eberle
 * @cehbrecht Carsten Ehbrecht
 * @idanmiara Idan Miara
+* @Zeitsperre Trevor James Smith
 
 # Contributor to older versions of PyWPS (< 4.x)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Install PyWPS 4
 
 Using pip: 
 
-    $ sudo pip install -e git+https://github.com/geopython/pywps.git@master#egg=pywps
+    $ sudo pip install -e git+https://github.com/geopython/pywps.git@main#egg=pywps
 
 Or in alternative install it manually:
 
@@ -25,7 +25,7 @@ Or in alternative install it manually:
     
     $ cd pywps/
     
-    $ sudo python setup.py install
+    $ sudo pip install .
 
 Install example service
 -----------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ to **geopython-security nospam @ lists.osgeo.org** - (remove the blanks and 'nos
 The PyWPS Project Steering Committee will release patches for security vulnerabilities for the following versions:
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 4.5.x | :white_check_mark: |
-| 4.4.x | :white_check_mark: |
-| < 4.4 | previous versions | :x:                |
+|---------|--------------------|
+| 4.5.x   | :white_check_mark: |
+| 4.4.x   | :white_check_mark: |
+| < 4.4   | previous versions  |

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,7 +46,7 @@ Using pip
         automatically in the system.  This might require superuser permissions
         (e.g. *sudo* in Debian based systems)::
 
-            $ sudo pip install -e git+https://github.com/geopython/pywps.git@main#egg=pywps-dev
+            $ sudo pip install -e git+https://github.com/geopython/pywps.git@main#egg=pywps
 
 .. todo::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,31 +3,39 @@
 Installation
 ============
 
-.. note:: PyWPS is not tested on the MS Windows platform. Please join the
-    development team if you need this platform to be supported. This is mainly 
-    because of the lack of a multiprocessing library.  It is used to process 
-    asynchronous execution, i.e., when making requests storing the response 
-    document and updating a status document displaying the progress of 
-    execution.
+.. note:: PyWPS is not tested on the Microsoft Windows platform. Please join the development team
+    if you need this platform to be supported. This is mainly because of the lack of a multiprocessing
+    library. It is used to process asynchronous execution, i.e., when making requests storing the response
+    document and updating a status document displaying the progress of execution.
 
 
 Dependencies and requirements
 -----------------------------
 
-PyWPS runs on Python 2.7, 3.3 or higher. PyWPS is currently tested and
-developed on Linux (mostly Ubuntu).  In the documentation we take this 
-distribution as reference.
+PyWPS runs on Python 3.7 or higher. PyWPS is currently tested and developed on Linux (mostly Ubuntu).
+In the documentation we take this distribution as reference.
 
 Prior to installing PyWPS, Git and the Python bindings for GDAL must be
-installed in the system.  In Debian based systems these packages can be
+installed in the system. On Debian based systems, these packages can be
 installed with a tool like *apt*::
 
     $ sudo apt-get install git python-gdal
 
-Alternatively, if GDAL is already installed on your system you can
-install the GDAL Python bindings via pip with::
+Alternatively, if GDAL is already installed on your system you can install the GDAL Python bindings via pip with::
 
-    $ pip install GDAL==1.10.0 --global-option=build_ext --global-option="-I/usr/include/gdal"
+    # Determine version of GDAL installed on your system
+    $ export GDAL_VERSION="$(gdal-config --version)"
+    # Install GDAL Python bindings
+    $ pip install gdal==$GDAL_VERSION --global-option=build_ext --global-option="-I/usr/include/gdal"
+
+.. Warning::
+    If you are using setuptools 63.0 or higher, you need to install the
+    GDAL Python bindings with the following command::
+
+        # Determine version of GDAL installed on your system
+        $ export GDAL_VERSION="$(gdal-config --version)"
+        # Install GDAL Python bindings
+        $ pip install --upgrade --force-reinstall --no-cache-dir gdal==$GDAL_VERSION --no-binary gdal
 
 Download and install
 --------------------
@@ -38,7 +46,7 @@ Using pip
         automatically in the system.  This might require superuser permissions
         (e.g. *sudo* in Debian based systems)::
 
-            $ sudo pip install -e git+https://github.com/geopython/pywps.git@master#egg=pywps-dev
+            $ sudo pip install -e git+https://github.com/geopython/pywps.git@main#egg=pywps-dev
 
 .. todo::
 
@@ -61,7 +69,7 @@ Manual installation
 
         To install PyWPS system-wide run::
 
-            $ sudo python setup.py install
+            $ sudo pip install .
 
 For Developers
         Installation of the source code using Git and Python's virtualenv tool::
@@ -75,7 +83,7 @@ For Developers
         Then install the package dependencies using pip as described in the Manual installation section. To install
         PyWPS::
 
-            $ python setup.py install
+            $ pip install .
 
         Note that installing PyWPS via a virtualenv environment keeps the installation of PyWPS and its
         dependencies isolated to the virtual environment and does not affect other parts of the system.  This

--- a/pywps/__init__.py
+++ b/pywps/__init__.py
@@ -4,7 +4,6 @@
 ##################################################################
 
 import logging
-
 import os
 
 from lxml.builder import ElementMaker
@@ -90,10 +89,10 @@ OGCUNIT = {
 
 from pywps.app import Process, Service, WPSRequest
 from pywps.app.WPSRequest import get_inputs_from_xml, get_output_from_xml
-from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput
-from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput
-from pywps.inout.formats import Format, FORMATS, get_format
 from pywps.inout import UOM
+from pywps.inout.formats import FORMATS, Format, get_format
+from pywps.inout.inputs import BoundingBoxInput, ComplexInput, LiteralInput
+from pywps.inout.outputs import BoundingBoxOutput, ComplexOutput, LiteralOutput
 
 if __name__ == "__main__":
     pass

--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -12,7 +12,7 @@ class Metadata(object):
     """
     ows:Metadata content model.
 
-    :param title: Metadata title, human readable string
+    :param title: Metadata title, human-readable string
     :param href: fully qualified URL
     :param role: fully qualified URL
     :param type_: fully qualified URL
@@ -70,7 +70,7 @@ class MetadataUrl(Metadata):
 
     Useful to avoid Sphinx "Duplicate explicit target name" warning.
 
-    See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks.
+    See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks.
 
     Meant to use in documentation only, not needed in the xml response, nor being serialized or
     deserialized to/from json.  So that's why it is not directly in the base class.

--- a/pywps/app/Common.py
+++ b/pywps/app/Common.py
@@ -9,8 +9,7 @@ LOGGER = logging.getLogger("PYWPS")
 
 
 class Metadata(object):
-    """
-    ows:Metadata content model.
+    """ows:Metadata content model.
 
     :param title: Metadata title, human-readable string
     :param href: fully qualified URL
@@ -36,8 +35,7 @@ class Metadata(object):
 
     @property
     def json(self):
-        """Get JSON representation of the metadata
-        """
+        """Get JSON representation of the metadata."""
         data = {
             'title': self.title,
             'href': self.href,

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -3,28 +3,31 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import importlib
+import json
 import logging
 import os
-from pywps.translations import lower_case_dict
+import shutil
 import sys
 import traceback
-import json
-import shutil
 
-from pywps import dblog
-from pywps.response import get_response
-from pywps.response.status import WPS_STATUS
-from pywps.response.execute import ExecuteResponse
-from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
-from pywps.exceptions import (StorageNotSupported, OperationNotSupported,
-                              ServerBusy, NoApplicableCode,
-                              InvalidParameterValue)
+from pywps import dblog
 from pywps.app.exceptions import ProcessError
-from pywps.inout.storage.builder import StorageBuilder
+from pywps.app.WPSRequest import WPSRequest
+from pywps.exceptions import (
+    InvalidParameterValue,
+    NoApplicableCode,
+    OperationNotSupported,
+    ServerBusy,
+    StorageNotSupported,
+)
 from pywps.inout.outputs import ComplexOutput
-import importlib
-
+from pywps.inout.storage.builder import StorageBuilder
+from pywps.response import get_response
+from pywps.response.execute import ExecuteResponse
+from pywps.response.status import WPS_STATUS
+from pywps.translations import lower_case_dict
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -371,6 +374,7 @@ class Process(object):
 
             import random
             import string
+
             from grass.script import core as grass
             from grass.script import setup as gsetup
 

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -181,7 +181,9 @@ class Process(object):
         return self.status_store.url(self.status_filename)
 
     def _execute_process(self, async_, wps_request, wps_response):
-        """Uses :module:`pywps.processing` module for sending process to
+        """
+
+        Uses :module:`pywps.processing` module for sending process to
         background BUT first, check for maxprocesses configuration value
 
         :param async_: run in asynchronous mode
@@ -220,7 +222,7 @@ class Process(object):
 
         # not async
         else:
-            if running >= maxparallel and maxparallel != -1:
+            if running >= maxparallel != -1:
                 raise ServerBusy('Maximum number of parallel running processes reached. Please try later.')
             wps_response._update_status(WPS_STATUS.ACCEPTED, "PyWPS Request accepted", 0)
             wps_response = self._run_process(wps_request, wps_response)
@@ -438,8 +440,10 @@ class Process(object):
                 grass.run_command('g.gisenv', set="MAPSET=%s" % mapset_name)
 
             else:
+                # FIXME: This will fail as location is not set.
                 raise NoApplicableCode('Location does exists or does not seem '
-                                       'to be in "EPSG:XXXX" form nor is it existing directory: {}'.format(location))
+                                       'to be in "EPSG:XXXX" form nor is it existing directory: '
+                                       '{}'.format(location))
 
             # set _grass_mapset attribute - will be deleted once handler ends
             self._grass_mapset = mapset_name

--- a/pywps/app/Process.py
+++ b/pywps/app/Process.py
@@ -16,8 +16,6 @@ from pywps.response import get_response
 from pywps.response.status import WPS_STATUS
 from pywps.response.execute import ExecuteResponse
 from pywps.app.WPSRequest import WPSRequest
-from pywps.inout.inputs import input_from_json
-from pywps.inout.outputs import output_from_json
 import pywps.configuration as config
 from pywps.exceptions import (StorageNotSupported, OperationNotSupported,
                               ServerBusy, NoApplicableCode,
@@ -38,7 +36,7 @@ class Process(object):
                     :class:`pywps.app.WPSRequest` argument and return a
                     :class:`pywps.app.WPSResponse` object.
     :param string identifier: Name of this process.
-    :param string title: Human readable title of process.
+    :param string title: Human-readable title of process.
     :param string abstract: Brief narrative description of the process.
     :param list keywords: Keywords that characterize a process.
     :param inputs: List of inputs accepted by this process. They
@@ -357,17 +355,15 @@ class Process(object):
             outpt.workdir = workdir
 
     def _set_grass(self, wps_request):
-        """Handle given grass_location parameter of the constructor
+        """Handle given grass_location parameter of the constructor.
 
-        location is either directory name, 'epsg:1234' form or a georeferenced
-        file
+        location is either directory name, 'epsg:1234' form or a geo-referenced file.
 
-        in the first case, new temporary mapset within the location will be
-        created
+        In the first case, new temporary mapset within the location will be created.
 
-        in the second case, location will be created in self.workdir
+        In the second case, location will be created in self.workdir.
 
-        the mapset should be deleted automatically using self.clean() method
+        The mapset should be deleted automatically using self.clean() method
         """
         if self.grass_location:
 
@@ -376,8 +372,7 @@ class Process(object):
             from grass.script import core as grass
             from grass.script import setup as gsetup
 
-            # HOME needs to be set - and that is usually not the case for httpd
-            # server
+            # HOME needs to be set - and that is usually not the case for httpd server
             os.environ['HOME'] = self.workdir
 
             # GISRC envvariable needs to be set

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -8,12 +8,11 @@ import tempfile
 from typing import Sequence, Optional, Dict
 
 from werkzeug.exceptions import HTTPException
-from werkzeug.wrappers import Request, Response
+from werkzeug.wrappers import Request
 from urllib.parse import urlparse
 from pywps.app.WPSRequest import WPSRequest
 import pywps.configuration as config
-from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
-    StorageNotSupported, FileURLNotSupported
+from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileURLNotSupported
 from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
 from pywps.dblog import log_request, store_status
 from pywps import response
@@ -24,16 +23,15 @@ import os
 import sys
 import uuid
 import copy
-import shutil
 
 
 LOGGER = logging.getLogger("PYWPS")
 
 
 class Service(object):
+    """The top-level object that represents a WPS service.
 
-    """ The top-level object that represents a WPS service. It's a WSGI
-    application.
+    A WSGI application.
 
     :param processes: A list of :class:`~Process` objects that are
                       provided by this service.

--- a/pywps/app/Service.py
+++ b/pywps/app/Service.py
@@ -3,27 +3,31 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import copy
 import logging
+import os
+import sys
 import tempfile
-from typing import Sequence, Optional, Dict
+import uuid
+from collections import OrderedDict, deque
+from typing import Dict, Optional, Sequence
+from urllib.parse import urlparse
 
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Request
-from urllib.parse import urlparse
-from pywps.app.WPSRequest import WPSRequest
+
 import pywps.configuration as config
-from pywps.exceptions import MissingParameterValue, NoApplicableCode, InvalidParameterValue, FileURLNotSupported
-from pywps.inout.inputs import ComplexInput, LiteralInput, BoundingBoxInput
-from pywps.dblog import log_request, store_status
 from pywps import response
+from pywps.app.WPSRequest import WPSRequest
+from pywps.dblog import log_request, store_status
+from pywps.exceptions import (
+    FileURLNotSupported,
+    InvalidParameterValue,
+    MissingParameterValue,
+    NoApplicableCode,
+)
+from pywps.inout.inputs import BoundingBoxInput, ComplexInput, LiteralInput
 from pywps.response.status import WPS_STATUS
-
-from collections import deque, OrderedDict
-import os
-import sys
-import uuid
-import copy
-
 
 LOGGER = logging.getLogger("PYWPS")
 

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -72,8 +72,7 @@ class WPSRequest(object):
             raise MethodNotAllowed()
 
     def _get_request(self):
-        """HTTP GET request parser
-        """
+        """HTTP GET request parser."""
 
         # service shall be WPS
         service = _get_get_param(self.http_request, 'service', None if wps_strict else 'wps')
@@ -93,8 +92,7 @@ class WPSRequest(object):
         request_parser(self.http_request)
 
     def _post_request(self):
-        """HTTP GET request parser
-        """
+        """HTTP POST request parser."""
         # check if input file size was not exceeded
         maxsize = configuration.get_config_value('server', 'maxrequestsize')
         maxsize = configuration.get_size_mb(maxsize) * 1024 * 1024
@@ -155,14 +153,12 @@ class WPSRequest(object):
             request_parser(jdoc)
 
     def _get_request_parser(self, operation):
-        """Factory function returing propper parsing function
-        """
+        """Factory function returning proper parsing function."""
 
         wpsrequest = self
 
         def parse_get_getcapabilities(http_request):
-            """Parse GET GetCapabilities request
-            """
+            """Parse GET GetCapabilities request."""
 
             acceptedversions = _get_get_param(http_request, 'acceptversions')
             wpsrequest.check_accepted_versions(acceptedversions)
@@ -181,8 +177,7 @@ class WPSRequest(object):
             wpsrequest.default_mimetype = _get_get_param(http_request, 'f', wpsrequest.default_mimetype)
 
         def parse_get_execute(http_request):
-            """Parse GET Execute request
-            """
+            """Parse GET Execute request."""
             version = _get_get_param(http_request, 'version')
             wpsrequest.check_and_set_version(version)
 
@@ -232,8 +227,9 @@ class WPSRequest(object):
                 'Unknown request {}'.format(self.operation), operation)
 
     def _post_request_parser(self, tagname):
-        """Factory function returning a proper parsing function
-        according to tagname and sets self.operation to the correct operation
+        """Factory function returning a proper parsing function according to tag name.
+
+        Sets `self.operation` to the correct operation.
         """
 
         wpsrequest = self
@@ -248,8 +244,7 @@ class WPSRequest(object):
             wpsrequest.check_accepted_versions(acceptedversions)
 
         def parse_post_describeprocess(doc):
-            """Parse POST DescribeProcess request
-            """
+            """Parse POST DescribeProcess request."""
 
             version = doc.attrib.get('version')
             wpsrequest.check_and_set_version(version)
@@ -259,8 +254,7 @@ class WPSRequest(object):
                                       self.xpath_ns(doc, './ows:Identifier')]
 
         def parse_post_execute(doc):
-            """Parse POST Execute request
-            """
+            """Parse POST Execute request."""
             version = doc.attrib.get('version')
             wpsrequest.check_and_set_version(version)
 
@@ -309,33 +303,27 @@ class WPSRequest(object):
                 'Unknown request {}'.format(tagname), 'request')
 
     def _post_json_request_parser(self):
-        """
-        Factory function returning a proper parsing function
-        according to self.operation.
-        self.operation is modified to be lowercase
-            or the default 'execute' operation if self.operation is None
+        """Factory function returning a proper parsing function according to self.operation.
+
+        self.operation is modified to be lowercase or the default 'execute' operation if `self.operation` is None.
         """
 
         wpsrequest = self
 
         def parse_json_post_getcapabilities(jdoc):
-            """Parse POST GetCapabilities request
-            """
+            """Parse POST GetCapabilities request."""
             acceptedversions = jdoc.get('acceptedversions')
             wpsrequest.check_accepted_versions(acceptedversions)
 
         def parse_json_post_describeprocess(jdoc):
-            """Parse POST DescribeProcess request
-            """
-
+            """Parse POST DescribeProcess request."""
             version = jdoc.get('version')
             wpsrequest.check_and_set_version(version)
             wpsrequest.identifiers = [identifier_el.text for identifier_el in
                                       self.xpath_ns(jdoc, './ows:Identifier')]
 
         def parse_json_post_execute(jdoc):
-            """Parse POST Execute request
-            """
+            """Parse POST Execute request."""
             version = jdoc.get('version')
             wpsrequest.check_and_set_version(version)
 
@@ -377,7 +365,8 @@ class WPSRequest(object):
         self.WPS, self.OWS = get_ElementMakerForVersion(self.version)
 
     def check_accepted_versions(self, acceptedversions):
-        """
+        """Check for accepted versions.
+
         :param acceptedversions: string
         """
 
@@ -398,8 +387,7 @@ class WPSRequest(object):
                 'The requested version "{}" is not supported by this server'.format(acceptedversions), 'version')
 
     def check_and_set_version(self, version, allow_default=True):
-        """set this.version
-        """
+        """Check and set `this.version`."""
 
         if not version:
             if allow_default:
@@ -413,8 +401,7 @@ class WPSRequest(object):
             self.set_version(version)
 
     def check_and_set_language(self, language):
-        """set this.language
-        """
+        """Check and set this.language."""
         supported_languages = configuration.get_config_value('server', 'language').split(',')
         supported_languages = [lang.strip() for lang in supported_languages]
 
@@ -432,8 +419,7 @@ class WPSRequest(object):
 
     @property
     def json(self):
-        """Return JSON encoded representation of the request
-        """
+        """Return JSON encoded representation of the request."""
         class ExtendedJSONEncoder(json.JSONEncoder):
             def default(self, obj):
                 if isinstance(obj, datetime.date) or isinstance(obj, datetime.time):
@@ -462,7 +448,7 @@ class WPSRequest(object):
 
     @json.setter
     def json(self, value):
-        """init this request from json back again
+        """Init this request from json back again.
 
         :param value: the json (not string) representation
         """
@@ -514,42 +500,48 @@ def get_inputs_from_xml(doc):
         literal_data = xpath_ns(input_el, './wps:Data/wps:LiteralData')
         if literal_data:
             value_el = literal_data[0]
-            inpt = {}
-            inpt['identifier'] = identifier_el.text
-            inpt['data'] = str(value_el.text)
-            inpt['uom'] = value_el.attrib.get('uom', '')
-            inpt['datatype'] = value_el.attrib.get('datatype', '')
+            inpt = {
+                'identifier': identifier_el.text,
+                'data': str(value_el.text),
+                'uom': value_el.attrib.get('uom', ''),
+                'datatype': value_el.attrib.get('datatype', '')
+            }
             the_inputs[identifier].append(inpt)
             continue
 
         complex_data = xpath_ns(input_el, './wps:Data/wps:ComplexData')
         if complex_data:
             complex_data_el = complex_data[0]
-            inpt = {}
-            inpt['identifier'] = identifier_el.text
-            inpt['mimeType'] = complex_data_el.attrib.get('mimeType', None)
-            inpt['encoding'] = complex_data_el.attrib.get('encoding', '').lower()
-            inpt['schema'] = complex_data_el.attrib.get('schema', '')
-            inpt['method'] = complex_data_el.attrib.get('method', 'GET')
+            inpt = {
+                'identifier': identifier_el.text,
+                'mimeType': complex_data_el.attrib.get('mimeType', None),
+                'encoding': complex_data_el.attrib.get('encoding', '').lower(),
+                'schema': complex_data_el.attrib.get('schema', ''),
+                'method': complex_data_el.attrib.get('method', 'GET')
+            }
+
             if len(complex_data_el.getchildren()) > 0:
                 value_el = complex_data_el[0]
                 inpt['data'] = _get_dataelement_value(value_el)
             else:
                 inpt['data'] = _get_rawvalue_value(
                     complex_data_el.text, inpt['encoding'])
+
             the_inputs[identifier].append(inpt)
             continue
 
         reference_data = xpath_ns(input_el, './wps:Reference')
         if reference_data:
             reference_data_el = reference_data[0]
-            inpt = {}
-            inpt['identifier'] = identifier_el.text
-            inpt[identifier_el.text] = reference_data_el.text
-            inpt['href'] = reference_data_el.attrib.get(
-                '{http://www.w3.org/1999/xlink}href', '')
-            inpt['mimeType'] = reference_data_el.attrib.get('mimeType', None)
-            inpt['method'] = reference_data_el.attrib.get('method', 'GET')
+            inpt = {
+                'identifier': identifier_el.text,
+                identifier_el.text: reference_data_el.text,
+                'href': reference_data_el.attrib.get(
+                    '{http://www.w3.org/1999/xlink}href', ''
+                ),
+                'mimeType': reference_data_el.attrib.get('mimeType', None),
+                'method': reference_data_el.attrib.get('method', 'GET')
+            }
             header_element = xpath_ns(reference_data_el, './wps:Header')
             if header_element:
                 inpt['header'] = _get_reference_header(header_element)
@@ -572,11 +564,12 @@ def get_inputs_from_xml(doc):
                 bbox = BoundingBox(bbox_data)
                 LOGGER.debug("parse bbox: minx={}, miny={}, maxx={},maxy={}".format(
                     bbox.minx, bbox.miny, bbox.maxx, bbox.maxy))
-                inpt = {}
-                inpt['identifier'] = identifier_el.text
-                inpt['data'] = [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy]
-                inpt['crs'] = bbox.crs.getcodeurn() if bbox.crs else None
-                inpt['dimensions'] = bbox.dimensions
+                inpt = {
+                    'identifier': identifier_el.text,
+                    'data': [bbox.minx, bbox.miny, bbox.maxx, bbox.maxy],
+                    'crs': bbox.crs.getcodeurn() if bbox.crs else None,
+                    'dimensions': bbox.dimensions
+                }
                 the_inputs[identifier].append(inpt)
     return the_inputs
 
@@ -590,24 +583,26 @@ def get_output_from_xml(doc):
     if xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:ResponseDocument'):
         for output_el in xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:ResponseDocument/wps:Output'):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
-            outpt = {}
-            outpt[identifier_el.text] = ''
-            outpt['mimetype'] = output_el.attrib.get('mimeType', None)
-            outpt['encoding'] = output_el.attrib.get('encoding', '')
-            outpt['schema'] = output_el.attrib.get('schema', '')
-            outpt['uom'] = output_el.attrib.get('uom', '')
-            outpt['asReference'] = output_el.attrib.get('asReference', 'false')
+            outpt = {
+                identifier_el.text: '',
+                'mimetype': output_el.attrib.get('mimeType', None),
+                'encoding': output_el.attrib.get('encoding', ''),
+                'schema': output_el.attrib.get('schema', ''),
+                'uom': output_el.attrib.get('uom', ''),
+                'asReference': output_el.attrib.get('asReference', 'false')
+            }
             the_output[identifier_el.text] = outpt
 
     elif xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:RawDataOutput'):
         for output_el in xpath_ns(doc, '/wps:Execute/wps:ResponseForm/wps:RawDataOutput'):
             [identifier_el] = xpath_ns(output_el, './ows:Identifier')
-            outpt = {}
-            outpt[identifier_el.text] = ''
-            outpt['mimetype'] = output_el.attrib.get('mimeType', None)
-            outpt['encoding'] = output_el.attrib.get('encoding', '')
-            outpt['schema'] = output_el.attrib.get('schema', '')
-            outpt['uom'] = output_el.attrib.get('uom', '')
+            outpt = {
+                identifier_el.text: '',
+                'mimetype': output_el.attrib.get('mimeType', None),
+                'encoding': output_el.attrib.get('encoding', ''),
+                'schema': output_el.attrib.get('schema', ''),
+                'uom': output_el.attrib.get('uom', '')
+            }
             the_output[identifier_el.text] = outpt
 
     return the_output
@@ -666,12 +661,13 @@ def get_output_from_dict(output_ids, raw):
     for identifier, output_el in output_ids.items():
         if isinstance(output_el, list):
             output_el = output_el[0]
-        outpt = {}
-        outpt[identifier] = ''
-        outpt['mimetype'] = output_el.get('mimeType', None)
-        outpt['encoding'] = output_el.get('encoding', '')
-        outpt['schema'] = output_el.get('schema', '')
-        outpt['uom'] = output_el.get('uom', '')
+        outpt = {
+            identifier: '',
+            'mimetype': output_el.get('mimeType', None),
+            'encoding': output_el.get('encoding', ''),
+            'schema': output_el.get('schema', ''),
+            'uom': output_el.get('uom', '')
+        }
         if not raw:
             outpt['asReference'] = output_el.get('asReference', 'false')
         the_output[identifier] = outpt
@@ -724,8 +720,7 @@ def get_data_from_kvp(data, part=None):
 
 
 def _check_version(version):
-    """ check given version
-    """
+    """Check given version."""
     if version not in ['1.0.0', '2.0.0']:
         return False
     else:
@@ -733,8 +728,7 @@ def _check_version(version):
 
 
 def _get_get_param(http_request, key, default=None, aslist=False):
-    """Returns value from the key:value pair, of the HTTP GET request, for
-    example 'service' or 'request'
+    """Returns value from the key:value pair, of the HTTP GET request, for example 'service' or 'request'.
 
     :param http_request: http_request object
     :param key: key value you need to dig out of the HTTP GET request
@@ -754,9 +748,7 @@ def _get_get_param(http_request, key, default=None, aslist=False):
 
 
 def _get_dataelement_value(value_el):
-    """Return real value of XML Element (e.g. convert Element.FeatureCollection
-    to String
-    """
+    """Return real value of XML Element (e.g. convert Element.FeatureCollection to String."""
 
     if isinstance(value_el, lxml.etree._Element):
         return etree.tostring(value_el, encoding=str)
@@ -782,17 +774,16 @@ def _get_rawvalue_value(data, encoding=None):
 
 
 def _get_reference_header(header_element):
-    """Parses ReferenceInput Header element
-    """
-    header = {}
-    header['key'] = header_element.attrib('key')
-    header['value'] = header_element.attrib('value')
+    """Parses ReferenceInput Header element."""
+    header = {
+        'key': header_element.attrib('key'),
+        'value': header_element.attrib('value')
+    }
     return header
 
 
 def _get_reference_body(body_element):
-    """Parses ReferenceInput Body element
-    """
+    """Parses ReferenceInput Body element."""
 
     body = None
     if len(body_element.getchildren()) > 0:
@@ -805,7 +796,6 @@ def _get_reference_body(body_element):
 
 
 def _get_reference_bodyreference(referencebody_element):
-    """Parse ReferenceInput BodyReference element
-    """
+    """Parse ReferenceInput BodyReference element."""
     return referencebody_element.attrib.get(
         '{http://www.w3.org/1999/xlink}href', '')

--- a/pywps/app/WPSRequest.py
+++ b/pywps/app/WPSRequest.py
@@ -3,24 +3,28 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-import logging
-
-import lxml
-from pywps import xml_util as etree
-from werkzeug.exceptions import MethodNotAllowed
-from pywps import get_ElementMakerForVersion
 import base64
 import datetime
-from pywps.app.basic import get_xpath_ns, parse_http_url
-from pywps.inout.inputs import input_from_json
-from pywps.exceptions import NoApplicableCode, OperationNotSupported, MissingParameterValue, VersionNegotiationFailed, \
-    InvalidParameterValue, FileSizeExceeded
-from pywps import configuration
-from pywps.configuration import wps_strict
-from pywps import get_version_from_ns
-
 import json
+import logging
 from urllib.parse import unquote
+
+import lxml
+from werkzeug.exceptions import MethodNotAllowed
+
+from pywps import configuration, get_ElementMakerForVersion, get_version_from_ns
+from pywps import xml_util as etree
+from pywps.app.basic import get_xpath_ns, parse_http_url
+from pywps.configuration import wps_strict
+from pywps.exceptions import (
+    FileSizeExceeded,
+    InvalidParameterValue,
+    MissingParameterValue,
+    NoApplicableCode,
+    OperationNotSupported,
+    VersionNegotiationFailed,
+)
+from pywps.inout.inputs import input_from_json
 
 LOGGER = logging.getLogger("PYWPS")
 default_version = '1.0.0'

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -7,7 +7,7 @@ XML tools
 """
 
 import logging
-from typing import Optional, Tuple
+from typing import Tuple
 
 from werkzeug.wrappers import Response
 import pywps.configuration as config
@@ -16,8 +16,9 @@ LOGGER = logging.getLogger('PYWPS')
 
 
 def get_xpath_ns(version):
-    """Get xpath namespace for specified WPS version
-    currently 1.0.0 or 2.0.0 are supported
+    """Get xpath namespace for specified WPS version.
+
+    Versions 1.0.0 or 2.0.0 are supported.
     """
 
     def xpath_ns(ele, path):
@@ -30,13 +31,15 @@ def get_xpath_ns(version):
         elif version == "2.0.0":
             from pywps import namespaces200
             nsp = namespaces200
+        else:
+            raise NotImplementedError(version)
         return ele.xpath(path, namespaces=nsp)
 
     return xpath_ns
 
 
 def make_response(doc, content_type):
-    """response serializer"""
+    """Response serializer."""
     if not content_type:
         content_type = get_default_response_mimetype()
     response = Response(doc, content_type=content_type)

--- a/pywps/app/basic.py
+++ b/pywps/app/basic.py
@@ -10,6 +10,7 @@ import logging
 from typing import Tuple
 
 from werkzeug.wrappers import Response
+
 import pywps.configuration as config
 
 LOGGER = logging.getLogger('PYWPS')

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -5,13 +5,13 @@
 
 """Process exceptions raised intentionally in processes to provide information for users."""
 
+import logging
 import re
 
-DEFAULT_ALLOWED_CHARS = ".:!?=,;-_/"
-
-import logging
 
 LOGGER = logging.getLogger('PYWPS')
+
+DEFAULT_ALLOWED_CHARS = ".:!?=,;-_/"
 
 
 def format_message(text, min_length=3, max_length=300, allowed_chars=None):
@@ -28,11 +28,13 @@ def format_message(text, min_length=3, max_length=300, allowed_chars=None):
 
 
 class ProcessError(Exception):
-    """:class:`pywps.app.exceptions.ProcessError` is an :class:`Exception`
-    you can intentionally raise in a process
-    to provide a user-friendly error message.
+    """ProcessError class.
+
+    :class:`pywps.app.exceptions.ProcessError` is an :class:`Exception`
+    you can intentionally raise in a process to provide a user-friendly error message.
+
     The error message gets formatted (3<= message length <=300) and only
-    alpha numeric characters and a few special characters are allowed.
+    alphanumeric characters and a few special characters are allowed.
     """
     default_msg = 'Sorry, process failed. Please check server error log.'
 

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -3,9 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-"""
-Process exceptions raised intentionally in processes to provide information for users.
-"""
+"""Process exceptions raised intentionally in processes to provide information for users."""
 
 import re
 

--- a/pywps/app/exceptions.py
+++ b/pywps/app/exceptions.py
@@ -8,7 +8,6 @@
 import logging
 import re
 
-
 LOGGER = logging.getLogger('PYWPS')
 
 DEFAULT_ALLOWED_CHARS = ".:!?=,;-_/"

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -7,13 +7,13 @@
 Reads the PyWPS configuration file
 """
 
-import logging
-import sys
-import os
-import tempfile
-import pywps
-
 import configparser
+import logging
+import os
+import sys
+import tempfile
+
+import pywps
 
 __author__ = "Calin Ciociu"
 

--- a/pywps/configuration.py
+++ b/pywps/configuration.py
@@ -34,6 +34,8 @@ def get_config_value(section, option, default_value=''):
     :type section: string
     :param option: option in the section
     :type option: string
+    :param default_value: default value for configuration
+    :type default_value: string
     :returns: value found in the configuration file
     """
 
@@ -58,6 +60,7 @@ def get_config_value(section, option, default_value=''):
 
 def load_configuration(cfgfiles=None):
     """Load PyWPS configuration from configuration files.
+
     The later configuration file in the array overwrites configuration
     from the first.
 
@@ -191,15 +194,17 @@ def _check_config():
 
 
 def _get_default_config_files_location():
-    """Get the locations of the standard configuration files. These are
+    """Get the locations of the standard configuration files.
+
+    These are:
     Unix/Linux:
         1. `/etc/pywps.cfg`
         2. `$HOME/.pywps.cfg`
     Windows:
         1. `pywps\\etc\\default.cfg`
-
     Both:
         1. `$PYWPS_CFG environment variable`
+
     :returns: configuration files
     :rtype: list of strings
     """

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -12,10 +12,7 @@ import sys
 
 from pywps import configuration
 from pywps.exceptions import NoApplicableCode
-import sqlite3
 import datetime
-import pickle
-import json
 import os
 from multiprocessing import Lock
 

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -7,26 +7,24 @@
 Implementation of logging for PyWPS-4
 """
 
-import logging
-import sys
-
-from pywps import configuration
-from pywps.exceptions import NoApplicableCode
 import datetime
+import logging
 import os
+import sys
 from multiprocessing import Lock
 
 import sqlalchemy
-
-from sqlalchemy import Column, Integer, String, VARCHAR, Float, DateTime, LargeBinary
+from sqlalchemy import VARCHAR, Column, DateTime, Float, Integer, LargeBinary, String
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool, StaticPool
+
+from pywps import configuration
+from pywps.exceptions import NoApplicableCode
 
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
-
 
 from pywps.response.status import WPS_STATUS
 

--- a/pywps/dblog.py
+++ b/pywps/dblog.py
@@ -17,10 +17,16 @@ import os
 from multiprocessing import Lock
 
 import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
+
 from sqlalchemy import Column, Integer, String, VARCHAR, Float, DateTime, LargeBinary
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool, StaticPool
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
+
 
 from pywps.response.status import WPS_STATUS
 

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -12,14 +12,13 @@ https://lists.ogc.org/pipermail/wps-dev/2013-October/000335.html
 """
 
 import json
+import logging
 
+from markupsafe import escape
 from werkzeug.datastructures import MIMEAccept
+from werkzeug.exceptions import HTTPException
 from werkzeug.http import parse_accept_header
 from werkzeug.wrappers import Response
-from werkzeug.exceptions import HTTPException
-from markupsafe import escape
-
-import logging
 
 from pywps import __version__
 from pywps.app.basic import get_json_indent, get_response_type, parse_http_url

--- a/pywps/exceptions.py
+++ b/pywps/exceptions.py
@@ -8,7 +8,7 @@ OGC OWS and WPS Exceptions
 
 Based on OGC OWS, WPS and
 
-http://lists.opengeospatial.org/pipermail/wps-dev/2013-October/000335.html
+https://lists.ogc.org/pipermail/wps-dev/2013-October/000335.html
 """
 
 import json

--- a/pywps/ext_autodoc.py
+++ b/pywps/ext_autodoc.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from docutils.parsers.rst import directives
 from sphinx.ext.autodoc import ClassDocumenter, bool_option
 from sphinx.ext.napoleon.docstring import NumpyDocstring
 from sphinx.util.docstrings import prepare_docstring
-from docutils.parsers.rst import directives
+
 from pywps import Process
 from pywps.app.Common import Metadata, MetadataUrl
 

--- a/pywps/inout/__init__.py
+++ b/pywps/inout/__init__.py
@@ -3,7 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-from pywps.inout.inputs import LiteralInput, ComplexInput, BoundingBoxInput
-from pywps.inout.outputs import LiteralOutput, ComplexOutput, BoundingBoxOutput
-from pywps.inout.formats import Format, FORMATS, get_format
 from pywps.inout.basic import UOM
+from pywps.inout.formats import FORMATS, Format, get_format
+from pywps.inout.inputs import BoundingBoxInput, ComplexInput, LiteralInput
+from pywps.inout.outputs import BoundingBoxOutput, ComplexOutput, LiteralOutput

--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -2,42 +2,49 @@
 # Copyright 2018 Open Source Geospatial Foundation and others    #
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
-import json
-from pathlib import PurePath
-
-from pywps.inout.formats import Supported_Formats
-from pywps.inout.types import Translations
-from pywps.translations import lower_case_dict
-from io import StringIO
-import os
-from io import open
-import shutil
-import requests
-import tempfile
-import logging
-import pywps.configuration as config
-from pywps.inout.literaltypes import (LITERAL_DATA_TYPES, convert,
-                                      make_allowedvalues, is_anyvalue,
-                                      is_values_reference)
-from pywps import OGCUNIT
-from pywps.validator.mode import MODE
-from pywps.validator.base import emptyvalidator
-from pywps.validator import get_validator
-from pywps.validator.literalvalidator import (validate_value,
-                                              validate_anyvalue,
-                                              validate_allowed_values,
-                                              validate_values_reference)
-from pywps.exceptions import NoApplicableCode, InvalidParameterValue, FileSizeExceeded, \
-    FileURLNotSupported
-from urllib.parse import urlparse
 import base64
+import json
+import logging
+import os
+import shutil
+import tempfile
+import weakref
 from collections import namedtuple
 from copy import deepcopy
-from io import BytesIO
+from io import BytesIO, StringIO, open
+from pathlib import PurePath
+from urllib.parse import urlparse
+
 import humanize
+import requests
 
-import weakref
-
+import pywps.configuration as config
+from pywps import OGCUNIT
+from pywps.exceptions import (
+    FileSizeExceeded,
+    FileURLNotSupported,
+    InvalidParameterValue,
+    NoApplicableCode,
+)
+from pywps.inout.formats import Supported_Formats
+from pywps.inout.literaltypes import (
+    LITERAL_DATA_TYPES,
+    convert,
+    is_anyvalue,
+    is_values_reference,
+    make_allowedvalues,
+)
+from pywps.inout.types import Translations
+from pywps.translations import lower_case_dict
+from pywps.validator import get_validator
+from pywps.validator.base import emptyvalidator
+from pywps.validator.literalvalidator import (
+    validate_allowed_values,
+    validate_anyvalue,
+    validate_value,
+    validate_values_reference,
+)
+from pywps.validator.mode import MODE
 
 _SOURCE_TYPE = namedtuple('SOURCE_TYPE', 'MEMORY, FILE, STREAM, DATA, URL')
 SOURCE_TYPE = _SOURCE_TYPE(0, 1, 2, 3, 4)

--- a/pywps/inout/formats/__init__.py
+++ b/pywps/inout/formats/__init__.py
@@ -11,8 +11,8 @@
 # based on Web Processing Service Best Practices Discussion Paper, OGC 12-029
 # http://opengeospatial.org/standards/wps
 
-from collections import namedtuple
 import mimetypes
+from collections import namedtuple
 from typing import Optional, Sequence, Union
 
 _FORMATS = namedtuple('FORMATS', 'GEOJSON, JSON, SHP, GML, GPX, METALINK, META4, KML, KMZ, GEOTIFF,'

--- a/pywps/inout/inputs.py
+++ b/pywps/inout/inputs.py
@@ -4,15 +4,15 @@
 ##################################################################
 import base64
 import re
-from pywps import xml_util as etree
+from copy import deepcopy
 
+from pywps import xml_util as etree
 from pywps.app.Common import Metadata
 from pywps.exceptions import InvalidParameterValue
-from pywps.inout.formats import Format
 from pywps.inout import basic
-from copy import deepcopy
+from pywps.inout.formats import Format
+from pywps.inout.literaltypes import AllowedValue, AnyValue, NoValue, ValuesReference
 from pywps.validator.mode import MODE
-from pywps.inout.literaltypes import AnyValue, NoValue, ValuesReference, AllowedValue
 
 CDATA_PATTERN = re.compile(r'<!\[CDATA\[(.*?)\]\]>')
 

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -3,8 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-"""Literaltypes are used for LiteralInputs, to make sure, input data are OK
-"""
+"""Literaltypes are used for LiteralInputs, to make sure input data are OK."""
 from urllib.parse import urlparse
 from dateutil.parser import parse as date_parser
 import datetime
@@ -193,7 +192,7 @@ def convert(data_type, data):
     """Convert data to target value
     """
 
-    convert = LITERAL_DATA_TYPES.get(data_type, None)
+    convert = LITERAL_DATA_TYPES.get(data_type, None)  # noqa
     if convert is None:
         raise InvalidParameterValue(
             "Invalid data_type value of LiteralInput "
@@ -208,7 +207,7 @@ def convert(data_type, data):
 
 @register_convert_type('boolean')
 def convert_boolean(inpt):
-    """Return boolean value from input boolean input
+    """Return boolean value from input boolean input.
 
     >>> convert_boolean('1')
     True
@@ -232,14 +231,14 @@ def convert_boolean(inpt):
                 val = False
             else:
                 val = True
-        except Exception:
+        except (ValueError, TypeError):
             val = True
     return val
 
 
 @register_convert_type('float')
 def convert_float(inpt):
-    """Return float value from inpt
+    """Return float value from input.
 
     >>> convert_float('1')
     1.0
@@ -250,7 +249,7 @@ def convert_float(inpt):
 
 @register_convert_type('integer')
 def convert_integer(inpt):
-    """Return integer value from input inpt
+    """Return integer value from input input.
 
     >>> convert_integer('1.0')
     1
@@ -261,7 +260,7 @@ def convert_integer(inpt):
 
 @register_convert_type('string')
 def convert_string(inpt):
-    """Return string value from input lit_input
+    """Return string value from input lit_input.
 
     >>> convert_string(1)
     '1'
@@ -272,7 +271,7 @@ def convert_string(inpt):
 @register_convert_type('nonNegativeInteger')
 @register_convert_type('positiveInteger')
 def convert_positiveInteger(inpt):
-    """Return value of input"""
+    """Return value of input."""
 
     inpt = convert_integer(inpt)
     if inpt < 0:
@@ -284,7 +283,7 @@ def convert_positiveInteger(inpt):
 
 @register_convert_type('anyURI')
 def convert_anyURI(inpt):
-    """Return value of input
+    """Return value of input.
 
     :rtype: url components
     """
@@ -300,10 +299,9 @@ def convert_anyURI(inpt):
 
 @register_convert_type('time')
 def convert_time(inpt):
-    """Return value of input
-    time formating assumed according to ISO standard:
+    """Return value of input time formatting assumed according to ISO standard.
 
-    https://www.w3.org/TR/xmlschema-2/#time
+    * https://www.w3.org/TR/xmlschema-2/#time
 
     Examples: 12:00:00
 
@@ -316,10 +314,9 @@ def convert_time(inpt):
 
 @register_convert_type('date')
 def convert_date(inpt):
-    """Return value of input
-    date formating assumed according to ISO standard:
+    """Return value of input date formatting assumed according to ISO standard.
 
-    https://www.w3.org/TR/xmlschema-2/#date
+    * https://www.w3.org/TR/xmlschema-2/#date
 
     Examples: 2016-09-20
 
@@ -332,8 +329,7 @@ def convert_date(inpt):
 
 @register_convert_type('dateTime')
 def convert_datetime(inpt):
-    """Return value of input
-    dateTime formating assumed according to ISO standard:
+    """Return value of input dateTime formatting assumed according to ISO standard.
 
     * http://www.w3.org/TR/NOTE-datetime
     * https://www.w3.org/TR/xmlschema-2/#dateTime
@@ -372,7 +368,7 @@ def convert_angle(inpt):
 
 
 def make_allowedvalues(allowed_values):
-    """convert given value list to AllowedValue objects
+    """Convert given value list to AllowedValue objects.
 
     :return: list of pywps.inout.literaltypes.AllowedValue
     """
@@ -412,8 +408,7 @@ def make_allowedvalues(allowed_values):
 
 
 def is_anyvalue(value):
-    """Check for any value object of given value
-    """
+    """Check for any value object of given value."""
 
     is_av = False
 
@@ -430,8 +425,7 @@ def is_anyvalue(value):
 
 
 def is_values_reference(value):
-    """Check for ValuesReference in given value
-    """
+    """Check for ValuesReference in given value."""
 
     check = False
 

--- a/pywps/inout/literaltypes.py
+++ b/pywps/inout/literaltypes.py
@@ -4,14 +4,15 @@
 ##################################################################
 
 """Literaltypes are used for LiteralInputs, to make sure input data are OK."""
-from urllib.parse import urlparse
-from dateutil.parser import parse as date_parser
 import datetime
-from pywps.exceptions import InvalidParameterValue
-from pywps.validator.allowed_value import RANGECLOSURETYPE
-from pywps.validator.allowed_value import ALLOWEDVALUETYPE
-
 import logging
+from urllib.parse import urlparse
+
+from dateutil.parser import parse as date_parser
+
+from pywps.exceptions import InvalidParameterValue
+from pywps.validator.allowed_value import ALLOWEDVALUETYPE, RANGECLOSURETYPE
+
 LOGGER = logging.getLogger('PYWPS')
 
 LITERAL_DATA_TYPES = dict()

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -52,8 +52,7 @@ class BoundingBoxOutput(basic.BBoxOutput):
 
     @property
     def json(self):
-        """Get JSON representation of the output
-        """
+        """Get JSON representation of the output."""
         return {
             'identifier': self.identifier,
             'title': self.title,
@@ -130,8 +129,7 @@ class ComplexOutput(basic.ComplexOutput):
 
     @property
     def json(self):
-        """Get JSON representation of the output
-        """
+        """Get JSON representation of the output."""
         data = {
             "identifier": self.identifier,
             "title": self.title,
@@ -197,8 +195,7 @@ class ComplexOutput(basic.ComplexOutput):
         return instance
 
     def _json_reference(self, data):
-        """Return Reference node
-        """
+        """Return Reference node."""
         data["type"] = "reference"
 
         # get_url will create the file and return the url for it
@@ -240,7 +237,7 @@ class ComplexOutput(basic.ComplexOutput):
                                 data["data"] = out
                             else:
                                 # Check if the data does not contain ]]> patern if is safe to use CDATA
-                                # other wise we fallback to base64 encoding.
+                                # otherwise we fall back to base64 encoding.
                                 if not re.search('\\]\\]>', out):
                                     data["data"] = '<![CDATA[{}]]>'.format(out)
                                 else:
@@ -255,8 +252,8 @@ class ComplexOutput(basic.ComplexOutput):
                         if CDATA_PATTERN.match(out):
                             data["data"] = out
                         else:
-                            # Check if the data does not contain ]]> patern if is safe to use CDATA
-                            # other wise we fallback to base64 encoding.
+                            # Check if the data does not contain ]]> pattern if is safe to use CDATA
+                            # otherwise we fall back to base64 encoding.
                             if not re.search('\\]\\]>', out):
                                 data["data"] = '<![CDATA[{}]]>'.format(out)
                             else:
@@ -272,7 +269,7 @@ class LiteralOutput(basic.LiteralOutput):
     :param str title: Title of the input
     :param pywps.inout.literaltypes.LITERAL_DATA_TYPES data_type: data type
     :param str abstract: Input abstract
-    :param str uoms: units
+    :param list uoms: units
     :param pywps.validator.mode.MODE mode: validation mode (none to strict)
     :param metadata: List of metadata advertised by this process. They
                      should be :class:`pywps.app.Common.Metadata` objects.
@@ -341,8 +338,8 @@ class MetaFile:
     def __init__(self, identity=None, description=None, fmt=None):
         """Create a `MetaFile` object.
 
-        :param str identity: human readable identity.
-        :param str description: human readable file description.
+        :param str identity: human-readable identity.
+        :param str description: human-readable file description.
         :param pywps.FORMAT fmt: file mime type.
 
         The content of each metafile is set like `ComplexOutputs`, ie
@@ -463,8 +460,8 @@ class MetaLink:
                  workdir=None, checksums=False):
         """Create a MetaLink v3.0 instance.
 
-        :param str identity: human readable identity.
-        :param str description: human readable file description.
+        :param str identity: human-readable identity.
+        :param str description: human-readable file description.
         :param str publisher: The name of the file's publisher.
         :param tuple files: Sequence of files to include in Metalink. Can also be added using `append`.
         :param str workdir: Work directory to store temporary files.

--- a/pywps/inout/outputs.py
+++ b/pywps/inout/outputs.py
@@ -5,19 +5,19 @@
 """
 WPS Output classes
 """
-from typing import Optional, Sequence, Dict, Union
-
-from pywps import xml_util as etree
 import os
 import re
+from typing import Dict, Optional, Sequence, Union
+
+from pywps import configuration as config
+from pywps import xml_util as etree
 from pywps.app.Common import Metadata
 from pywps.exceptions import InvalidParameterValue
 from pywps.inout import basic
+from pywps.inout.formats import FORMATS, Format, Supported_Formats
 from pywps.inout.storage.file import FileStorageBuilder
 from pywps.inout.types import Translations
 from pywps.validator.mode import MODE
-from pywps import configuration as config
-from pywps.inout.formats import Format, Supported_Formats, FORMATS
 
 
 class BoundingBoxOutput(basic.BBoxOutput):
@@ -523,8 +523,9 @@ class MetaLink:
         return config.get_config_value('server', 'url')
 
     def _load_template(self):
-        from pywps.response import RelEnvironment
         from jinja2 import PackageLoader
+
+        from pywps.response import RelEnvironment
 
         template_env = RelEnvironment(
             loader=PackageLoader('pywps', 'templates'),

--- a/pywps/inout/storage/builder.py
+++ b/pywps/inout/storage/builder.py
@@ -3,9 +3,10 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-from .s3 import S3StorageBuilder
-from .file import FileStorageBuilder
 import pywps.configuration as wpsConfig  # noqa
+
+from .file import FileStorageBuilder
+from .s3 import S3StorageBuilder
 
 STORAGE_MAP = {
     's3': S3StorageBuilder,

--- a/pywps/inout/storage/builder.py
+++ b/pywps/inout/storage/builder.py
@@ -5,7 +5,7 @@
 
 from .s3 import S3StorageBuilder
 from .file import FileStorageBuilder
-import pywps.configuration as wpsConfig
+import pywps.configuration as wpsConfig  # noqa
 
 STORAGE_MAP = {
     's3': S3StorageBuilder,

--- a/pywps/inout/storage/file.py
+++ b/pywps/inout/storage/file.py
@@ -32,13 +32,13 @@ def _build_output_name(output):
         suffix = output.data_format.extension
     _, file_name = os.path.split(prefix)
     output_name = file_name + suffix
-    return (output_name, suffix)
+    return output_name, suffix
 
 
 class FileStorage(CachedStorage):
     """File storage implementation, stores data to file system
 
-    >>> import ConfigParser
+    >>> from configparser import ConfigParser
     >>> config = ConfigParser.RawConfigParser()
     >>> config.add_section('FileStorage')
     >>> config.set('FileStorage', 'target', './')
@@ -55,8 +55,8 @@ class FileStorage(CachedStorage):
     ...         tiff_file.close()
     ...         return 'file.tiff'
     >>> fake_out = FakeOutput()
-    >>> (type, path, url) = store.store(fake_out)
-    >>> type == STORE_TYPE.PATH
+    >>> (store_type, path, url) = store.store(fake_out)
+    >>> store_type == STORE_TYPE.PATH
     True
     """
 
@@ -148,9 +148,7 @@ class FileStorage(CachedStorage):
             shutil.copy2(src, dst)
 
     def write(self, data, destination, data_format=None):
-        """
-        Write data to self.target
-        """
+        """Write data to self.target."""
         if not os.path.exists(os.path.dirname(self.target)):
             os.makedirs(self.target)
 
@@ -179,8 +177,7 @@ class FileStorage(CachedStorage):
 
 
 def get_free_space(folder):
-    """ Return folder/drive free space (in bytes)
-    """
+    """Return folder/drive free space (in bytes)."""
     import platform
 
     if platform.system() == 'Windows':

--- a/pywps/inout/storage/file.py
+++ b/pywps/inout/storage/file.py
@@ -6,13 +6,13 @@
 import logging
 import os
 from urllib.parse import urljoin
-from pywps.exceptions import NotEnoughStorage, FileStorageError
+
 from pywps import configuration as config
+from pywps.exceptions import FileStorageError, NotEnoughStorage
 from pywps.inout.basic import IOHandler
 
-from . import CachedStorage
+from . import STORE_TYPE, CachedStorage
 from .implementationbuilder import StorageImplementationBuilder
-from . import STORE_TYPE
 
 LOGGER = logging.getLogger('PYWPS')
 
@@ -77,8 +77,8 @@ class FileStorage(CachedStorage):
         - Copy / link output in work directory to output directory
         - Return store type, output path and output URL
         """
-        import platform
         import math
+        import platform
         import tempfile
         import uuid
 

--- a/pywps/inout/storage/s3.py
+++ b/pywps/inout/storage/s3.py
@@ -3,13 +3,13 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-import pywps.configuration as wpsConfig
-from . import StorageAbstract
-from .implementationbuilder import StorageImplementationBuilder
-from . import STORE_TYPE
-
-import os
 import logging
+import os
+
+import pywps.configuration as wpsConfig
+
+from . import STORE_TYPE, StorageAbstract
+from .implementationbuilder import StorageImplementationBuilder
 
 LOGGER = logging.getLogger('PYWPS')
 

--- a/pywps/inout/storage/s3.py
+++ b/pywps/inout/storage/s3.py
@@ -35,22 +35,22 @@ def _build_s3_file_path(prefix, filename):
 
 
 def _build_extra_args(public=False, encrypt=False, mime_type=''):
-    extraArgs = dict()
+    extra_args = dict()
 
     if public:
-        extraArgs['ACL'] = 'public-read'
+        extra_args['ACL'] = 'public-read'
     if encrypt:
-        extraArgs['ServerSideEncryption'] = 'AES256'
+        extra_args['ServerSideEncryption'] = 'AES256'
 
-    extraArgs['ContentType'] = mime_type
+    extra_args['ContentType'] = mime_type
 
-    return extraArgs
+    return extra_args
 
 
 class S3Storage(StorageAbstract):
     """
     Implements a simple class to store files on AWS S3
-    Can optionally set the outputs to be publically readable
+    Can optionally set the outputs to be publicly readable
     and can also encrypt files at rest
     """
     def __init__(self, bucket, prefix, public_access, encrypt, region):
@@ -67,14 +67,15 @@ class S3Storage(StorageAbstract):
         waiter.wait(Bucket=self.bucket, Key=filename)
 
     def uploadData(self, data, filename, extraArgs):
-        """
+        """Creates or updates a file on S3 in the bucket specified in the server configuration.
+
+        The key of the created object will be equal to the
+        configured prefix with the destination parameter appended.
+
         :param data: Data to upload to S3
         :param filename: name of the file to upload to s3
-                         will be appened to the configured prefix
+                         will be appended to the configured prefix
         :returns: url to access the uploaded file
-        Creates or updates a file on S3 in the bucket specified in the server
-        configuration. The key of the created object will be equal to the
-        configured prefix with the destination parameter appended.
         """
         import boto3
 
@@ -89,12 +90,11 @@ class S3Storage(StorageAbstract):
         return url
 
     def uploadFileToS3(self, filename, extraArgs):
-        """
+        """Uploads a file from the local filesystem to AWS S3.
+
         :param filename: Path to file on local filesystem
         :returns: url to access the uploaded file
-        Uploads a file from the local filesystem to AWS S3
         """
-        url = ''
         with open(filename, "rb") as data:
             s3_path = _build_s3_file_path(self.prefix, os.path.basename(filename))
             url = self.uploadData(data, s3_path, extraArgs)
@@ -109,11 +109,11 @@ class S3Storage(StorageAbstract):
         """
         filename = output.file
         s3_path = _build_s3_file_path(self.prefix, os.path.basename(filename))
-        extraArgs = _build_extra_args(
+        extra_args = _build_extra_args(
             public=self.public,
             encrypt=self.encrypt,
             mime_type=output.data_format.mime_type)
-        url = self.uploadFileToS3(filename, extraArgs)
+        url = self.uploadFileToS3(filename, extra_args)
         return (STORE_TYPE.S3, s3_path, url)
 
     def write(self, data, destination, data_format=None):
@@ -131,11 +131,11 @@ class S3Storage(StorageAbstract):
         # Get MimeType from format if it exists
         mime_type = data_format.mime_type if data_format is not None else ''
         s3_path = _build_s3_file_path(self.prefix, destination)
-        extraArgs = _build_extra_args(
+        extra_args = _build_extra_args(
             public=self.public,
             encrypt=self.encrypt,
             mime_type=mime_type)
-        return self.uploadData(data, s3_path, extraArgs)
+        return self.uploadData(data, s3_path, extra_args)
 
     def url(self, destination):
         """

--- a/pywps/inout/types.py
+++ b/pywps/inout/types.py
@@ -3,6 +3,6 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 Translations = Optional[Dict[str, Dict[str, str]]]

--- a/pywps/processing/__init__.py
+++ b/pywps/processing/__init__.py
@@ -3,14 +3,16 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import logging
+
 import pywps.configuration as config
-from pywps.processing.basic import MultiProcessing, DetachProcessing
-from pywps.processing.scheduler import Scheduler
+
 # api only
 from pywps.processing.basic import Processing  # noqa: F401
+from pywps.processing.basic import DetachProcessing, MultiProcessing
 from pywps.processing.job import Job  # noqa: F401
+from pywps.processing.scheduler import Scheduler
 
-import logging
 LOGGER = logging.getLogger("PYWPS")
 
 MULTIPROCESSING = 'multiprocessing'

--- a/pywps/processing/job.py
+++ b/pywps/processing/job.py
@@ -3,15 +3,15 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import json
+import logging
 import os
 import tempfile
+
 import pywps.configuration as config
 from pywps import Process, WPSRequest
 from pywps.response.execute import ExecuteResponse
 
-import json
-
-import logging
 LOGGER = logging.getLogger("PYWPS")
 
 

--- a/pywps/processing/job.py
+++ b/pywps/processing/job.py
@@ -75,7 +75,6 @@ class Job(object):
             fp.write(self.json)
             LOGGER.debug("dumped job status to {}".format(filename))
             return filename
-        return None
 
     @classmethod
     def load(cls, filename):
@@ -83,7 +82,6 @@ class Job(object):
         with open(filename, 'r') as fp:
             job = Job.from_json(json.load(fp))
             return job
-        return None
 
     def run(self):
         getattr(self.process, self.method)(self.wps_request, self.wps_response)

--- a/pywps/processing/scheduler.py
+++ b/pywps/processing/scheduler.py
@@ -3,13 +3,14 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
+import logging
 import os
+
 import pywps.configuration as config
-from pywps.processing.basic import Processing
 from pywps.exceptions import SchedulerNotAvailable
+from pywps.processing.basic import Processing
 from pywps.response.status import WPS_STATUS
 
-import logging
 LOGGER = logging.getLogger("PYWPS")
 
 

--- a/pywps/processing/scheduler.py
+++ b/pywps/processing/scheduler.py
@@ -19,7 +19,7 @@ class Scheduler(Processing):
     like slurm, grid-engine and torque. It uses the drmaa python library
     as client to launch jobs on a scheduler system.
 
-    See: http://drmaa-python.readthedocs.io/en/latest/index.html
+    See: https://drmaa-python.readthedocs.io/en/latest/index.html
     """
 
     def start(self):

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -7,7 +7,7 @@ from jinja2 import Environment
 class RelEnvironment(Environment):
     """Override join_path() to enable relative template paths."""
     def join_path(self, template, parent):
-        return os.path.dirname(parent).joinpath(template)
+        return os.path.dirname(parent) + '/' + template
 
 
 def get_response(operation):

--- a/pywps/response/__init__.py
+++ b/pywps/response/__init__.py
@@ -7,7 +7,7 @@ from jinja2 import Environment
 class RelEnvironment(Environment):
     """Override join_path() to enable relative template paths."""
     def join_path(self, template, parent):
-        return os.path.dirname(parent) + '/' + template
+        return os.path.dirname(parent).joinpath(template)
 
 
 def get_response(operation):

--- a/pywps/response/basic.py
+++ b/pywps/response/basic.py
@@ -1,14 +1,18 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from pywps import WPSRequest
 
+import os
+
+from jinja2 import Environment, PackageLoader
+
 from pywps.dblog import store_status
+from pywps.translations import get_translation
+
 from . import RelEnvironment
 from .status import WPS_STATUS
-from pywps.translations import get_translation
-from jinja2 import Environment, PackageLoader
-import os
 
 
 class WPSResponse(object):

--- a/pywps/response/basic.py
+++ b/pywps/response/basic.py
@@ -35,9 +35,9 @@ class WPSResponse(object):
         Update status report of currently running process instance
 
         :param str message: Message you need to share with the client
-        :param int status_percentage: Percent done (number betwen <0-100>)
+        :param int status_percentage: Percent done (number between <0-100>)
         :param pywps.response.status.WPS_STATUS status: process status - user should usually
-            ommit this parameter
+            omit this parameter
         """
         self.message = message
         self.status = status

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -6,7 +6,6 @@ from pywps.app.basic import make_response, get_response_type, get_json_indent
 from .basic import WPSResponse
 from pywps import __version__
 from pywps.exceptions import NoApplicableCode
-import os
 
 
 class CapabilitiesResponse(WPSResponse):

--- a/pywps/response/capabilities.py
+++ b/pywps/response/capabilities.py
@@ -1,11 +1,13 @@
 import json
 
 from werkzeug.wrappers import Request
+
 import pywps.configuration as config
-from pywps.app.basic import make_response, get_response_type, get_json_indent
-from .basic import WPSResponse
 from pywps import __version__
+from pywps.app.basic import get_json_indent, get_response_type, make_response
 from pywps.exceptions import NoApplicableCode
+
+from .basic import WPSResponse
 
 
 class CapabilitiesResponse(WPSResponse):

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -1,13 +1,17 @@
 import json
 
 from werkzeug.wrappers import Request
+
 import pywps.configuration as config
-from pywps.app.basic import make_response, get_response_type, get_json_indent
-from pywps.exceptions import NoApplicableCode
-from pywps.exceptions import MissingParameterValue
-from pywps.exceptions import InvalidParameterValue
-from .basic import WPSResponse
 from pywps import __version__
+from pywps.app.basic import get_json_indent, get_response_type, make_response
+from pywps.exceptions import (
+    InvalidParameterValue,
+    MissingParameterValue,
+    NoApplicableCode,
+)
+
+from .basic import WPSResponse
 
 
 class DescribeResponse(WPSResponse):

--- a/pywps/response/describe.py
+++ b/pywps/response/describe.py
@@ -8,7 +8,6 @@ from pywps.exceptions import MissingParameterValue
 from pywps.exceptions import InvalidParameterValue
 from .basic import WPSResponse
 from pywps import __version__
-import os
 
 
 class DescribeResponse(WPSResponse):

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -6,20 +6,24 @@
 import json
 import logging
 import time
-from werkzeug.wrappers import Request
-from pywps import get_ElementMakerForVersion
-from pywps.app.basic import get_response_type, get_json_indent, get_default_response_mimetype
-from pywps.exceptions import NoApplicableCode
-import pywps.configuration as config
-from werkzeug.wrappers import Response
-
-from pywps.inout.array_encode import ArrayEncoder
-from pywps.response.status import WPS_STATUS
-from .basic import WPSResponse
-from pywps.inout.formats import FORMATS
-
 import urllib.parse as urlparse
 from urllib.parse import urlencode
+
+from werkzeug.wrappers import Request, Response
+
+import pywps.configuration as config
+from pywps import get_ElementMakerForVersion
+from pywps.app.basic import (
+    get_default_response_mimetype,
+    get_json_indent,
+    get_response_type,
+)
+from pywps.exceptions import NoApplicableCode
+from pywps.inout.array_encode import ArrayEncoder
+from pywps.inout.formats import FORMATS
+from pywps.response.status import WPS_STATUS
+
+from .basic import WPSResponse
 
 LOGGER = logging.getLogger("PYWPS")
 

--- a/pywps/response/execute.py
+++ b/pywps/response/execute.py
@@ -17,7 +17,6 @@ from pywps.inout.array_encode import ArrayEncoder
 from pywps.response.status import WPS_STATUS
 from .basic import WPSResponse
 from pywps.inout.formats import FORMATS
-from pywps.inout.outputs import ComplexOutput
 
 import urllib.parse as urlparse
 from urllib.parse import urlencode
@@ -152,10 +151,11 @@ class ExecuteResponse(WPSResponse):
 
     @property
     def json(self):
-        data = {}
-        data["language"] = self.wps_request.language
-        data["service_instance"] = self._get_serviceinstance()
-        data["process"] = self.process.json
+        data = {
+            "language": self.wps_request.language,
+            "service_instance": self._get_serviceinstance(),
+            "process": self.process.json
+        }
 
         if self.store_status_file:
             if self.process.status_location:

--- a/pywps/tests.py
+++ b/pywps/tests.py
@@ -3,23 +3,28 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 import json
+import logging
+import re
 import tempfile
 from pathlib import Path
 
 import lxml
-from pywps import xml_util as etree
 import requests
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
-from pywps import __version__
-from pywps import Process
-from pywps.inout import LiteralInput, LiteralOutput, ComplexInput, ComplexOutput, BoundingBoxInput, BoundingBoxOutput
-from pywps.inout import Format
+
+from pywps import Process, __version__
+from pywps import xml_util as etree
 from pywps.app.Common import Metadata, MetadataUrl
-
-import re
-
-import logging
+from pywps.inout import (
+    BoundingBoxInput,
+    BoundingBoxOutput,
+    ComplexInput,
+    ComplexOutput,
+    Format,
+    LiteralInput,
+    LiteralOutput,
+)
 
 logging.disable(logging.CRITICAL)
 

--- a/pywps/translations.py
+++ b/pywps/translations.py
@@ -40,7 +40,7 @@ def get_translation(obj, attribute, language):
 def lower_case_dict(translations=None):
     """Returns a new dict, with its keys converted to lowercase.
 
-    :param dict[str, Any] translations: A dictionnary to be converted.
+    :param dict[str, Any] translations: A dictionary to be converted.
     """
     if translations is None:
         return

--- a/pywps/util.py
+++ b/pywps/util.py
@@ -4,9 +4,8 @@
 ##################################################################
 
 import platform
-from typing import Union
-
 from pathlib import Path
+from typing import Union
 from urllib.parse import urlparse
 
 is_windows = platform.system() == 'Windows'

--- a/pywps/validator/__init__.py
+++ b/pywps/validator/__init__.py
@@ -8,9 +8,18 @@
 
 
 import logging
-from pywps.validator.complexvalidator import validategml, validateshapefile, validatejson, validategeojson, \
-    validategeotiff, validatenetcdf, validatedods, validategpx
+
 from pywps.validator.base import emptyvalidator
+from pywps.validator.complexvalidator import (
+    validatedods,
+    validategeojson,
+    validategeotiff,
+    validategml,
+    validategpx,
+    validatejson,
+    validatenetcdf,
+    validateshapefile,
+)
 
 LOGGER = logging.getLogger('PYWPS')
 

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -3,8 +3,7 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-"""Validator classes are used for ComplexInputs, to validate the content
-"""
+"""Validator classes are used for ComplexInputs, to validate the content"""
 
 
 import logging
@@ -22,7 +21,7 @@ LOGGER = logging.getLogger('PYWPS')
 
 
 def validategml(data_input, mode):
-    """GML validation function
+    """GML validation function.
 
     :param data_input: :class:`ComplexInput`
     :param pywps.validator.mode.MODE mode:
@@ -76,7 +75,7 @@ def validategml(data_input, mode):
 
 
 def validategpx(data_input, mode):
-    """GPX validation function
+    """GPX validation function.
 
     :param data_input: :class:`ComplexInput`
     :param pywps.validator.mode.MODE mode:
@@ -130,7 +129,7 @@ def validategpx(data_input, mode):
 
 
 def validatexml(data_input, mode):
-    """XML validation function
+    """XML validation function.
 
     :param data_input: :class:`ComplexInput`
     :param pywps.validator.mode.MODE mode:
@@ -176,7 +175,7 @@ def validatexml(data_input, mode):
 
 
 def validatejson(data_input, mode):
-    """JSON validation function
+    """JSON validation function.
 
     :param data_input: :class:`ComplexInput`
     :param pywps.validator.mode.MODE mode:
@@ -221,16 +220,16 @@ def validatejson(data_input, mode):
 def validategeojson(data_input, mode):
     """GeoJSON validation example
 
-    >>> import StringIO
+    >>> from io import StringIO
     >>> class FakeInput(object):
     ...     json = open('point.geojson','w')
     ...     json.write('''{"type":"Feature", "properties":{}, "geometry":{"type":"Point", "coordinates":[8.5781228542328, 22.87500500679]}, "crs":{"type":"name", "properties":{"name":"urn:ogc:def:crs:OGC:1.3:CRS84"}}}''')  # noqa
     ...     json.close()
     ...     file = 'point.geojson'
-    >>> class fake_data_format(object):
+    >>> class FakeDataFormat(object):
     ...     mimetype = 'application/geojson'
     >>> fake_input = FakeInput()
-    >>> fake_input.data_format = fake_data_format()
+    >>> fake_input.data_format = FakeDataFormat()
     >>> validategeojson(fake_input, MODE.SIMPLE)
     True
     """
@@ -299,9 +298,7 @@ def validategeojson(data_input, mode):
 
 
 def validateshapefile(data_input, mode):
-    """ESRI Shapefile validation example
-
-    """
+    """ESRI Shapefile validation example."""
 
     LOGGER.info('validating Shapefile; Mode: {}'.format(mode))
     passed = False
@@ -328,8 +325,7 @@ def validateshapefile(data_input, mode):
 
 
 def validategeotiff(data_input, mode):
-    """GeoTIFF validation example
-    """
+    """GeoTIFF validation example."""
 
     LOGGER.info('Validating Shapefile; Mode: {}'.format(mode))
     passed = False
@@ -347,6 +343,7 @@ def validategeotiff(data_input, mode):
 
         try:
             from geotiff import GeoTiff
+
             data_source = GeoTiff(data_input.file)
             passed = (data_source.crs_code > 0)
         except (ModuleNotFoundError, ImportError):
@@ -356,8 +353,7 @@ def validategeotiff(data_input, mode):
 
 
 def validatenetcdf(data_input, mode):
-    """netCDF validation.
-    """
+    """NetCDF validation."""
 
     LOGGER.info('Validating netCDF; Mode: {}'.format(mode))
     passed = False
@@ -388,8 +384,7 @@ def validatenetcdf(data_input, mode):
 
 
 def validatedods(data_input, mode):
-    """OPeNDAP validation.
-        """
+    """OPeNDAP validation."""
 
     LOGGER.info('Validating OPeNDAP; Mode: {}'.format(mode))
     passed = False
@@ -419,8 +414,7 @@ def validatedods(data_input, mode):
 
 
 def _get_schemas_home():
-    """Get path to schemas directory
-    """
+    """Get path to schemas directory."""
     schema_dir = os.path.join(
         os.path.abspath(
             os.path.dirname(__file__)

--- a/pywps/validator/complexvalidator.py
+++ b/pywps/validator/complexvalidator.py
@@ -7,15 +7,15 @@
 
 
 import logging
-
-from pywps.validator.mode import MODE
-from pywps.inout.formats import FORMATS
-from lxml.etree import XMLSchema
-from pywps import xml_util as etree
-from urllib.request import urlopen
 import mimetypes
 import os
+from urllib.request import urlopen
 
+from lxml.etree import XMLSchema
+
+from pywps import xml_util as etree
+from pywps.inout.formats import FORMATS
+from pywps.validator.mode import MODE
 
 LOGGER = logging.getLogger('PYWPS')
 
@@ -257,8 +257,9 @@ def validategeojson(data_input, mode):
 
     if mode >= MODE.VERYSTRICT:
 
-        import jsonschema
         import json
+
+        import jsonschema
 
         # this code comes from
         # https://github.com/om-henners/GeoJSON_Validation/blob/master/geojsonvalidation/geojson_validation.py

--- a/pywps/validator/literalvalidator.py
+++ b/pywps/validator/literalvalidator.py
@@ -9,9 +9,8 @@ import logging
 from decimal import Decimal
 
 from pywps.inout.literaltypes import AnyValue, NoValue, ValuesReference
-from pywps.validator.mode import MODE
 from pywps.validator.allowed_value import ALLOWEDVALUETYPE, RANGECLOSURETYPE
-
+from pywps.validator.mode import MODE
 
 LOGGER = logging.getLogger('PYWPS')
 

--- a/pywps/xml_util.py
+++ b/pywps/xml_util.py
@@ -1,6 +1,5 @@
 from lxml import etree as _etree
 
-
 PARSER = _etree.XMLParser(
     resolve_entities=False,
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
+bump2version
 coverage
 coveralls
-pytest
-pytest-cov
+docutils
 flake8
 pylint
-Sphinx
+pytest
+pytest-cov
+sphinx
+tox>=4.0
 twine
 wheel
-bump2version
-tox>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
+markupsafe
+sqlalchemy
+fiona
+geotiff
+humanize
 jinja2
 jsonschema
 lxml
 owslib
 python-dateutil
 requests
-SQLAlchemy
 werkzeug
-MarkupSafe
-humanize
-geotiff
-fiona

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 # licensed under MIT, Please consult LICENSE.txt for details     #
 ##################################################################
 
-import sys
-
 try:
     from setuptools import setup
 except ImportError:
@@ -59,6 +57,8 @@ CONFIG = {
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: GIS",
     ],
     "install_requires": INSTALL_REQUIRES,

--- a/tests/test_filestorage.py
+++ b/tests/test_filestorage.py
@@ -10,10 +10,8 @@ from pywps.inout.basic import ComplexOutput
 from pywps.util import file_uri
 
 from pywps import configuration, FORMATS
-from urllib.parse import urlparse
 
 import tempfile
-import os
 
 import unittest
 

--- a/tests/test_s3storage.py
+++ b/tests/test_s3storage.py
@@ -8,10 +8,8 @@ from pywps.inout.storage import STORE_TYPE
 from pywps.inout.basic import ComplexOutput
 
 from pywps import configuration, FORMATS
-from urllib.parse import urlparse
 
 import tempfile
-import os
 
 import unittest
 from unittest.mock import patch

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,7 +11,6 @@ from pywps.inout.storage.s3 import S3Storage
 from pywps import configuration
 
 from pathlib import Path
-import unittest
 import tempfile
 
 

--- a/tests/test_wpsrequest.py
+++ b/tests/test_wpsrequest.py
@@ -8,7 +8,6 @@ from pywps.app import WPSRequest
 import tempfile
 import datetime
 import json
-from owslib.crs import Crs
 
 from pywps.inout.literaltypes import AnyValue
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py{37,38,39}{-extra,}
+min_version = 4.0
+envlist = py{37,38,39,310,311}{-extra,}
 requires = pip >= 20.0
 opts = --verbose
 
@@ -8,7 +9,10 @@ setenv =
     PYTEST_ADDOPTS = "--color=yes"
     PYTHONPATH = {toxinidir}
     COV_CORE_SOURCE =
-passenv = CI, GITHUB_*, LD_LIBRARY_PATH
+passenv =
+    CI,
+    GITHUB_*,
+    LD_LIBRARY_PATH
 download = True
 install_command =
     python -m pip install --no-user {opts} {packages}


### PR DESCRIPTION
# Overview

This PR does a bit of cleaning in the code base:

* Many unused imports have been removed.
* Many Markdown and reST formatting issues (outside the `docs`) have been corrected.
* Some docstrings for functions have been cleaned up for typos and better rendering in the documentation.
* Some URL targets that pointed to insecure addresses (`http://`) have been promoted to secured ones (`https://`).
* References to the `master` branch have been changed to `main`.
* Updated Installation instructions to reflect modern approaches.
* Added builds on GitHub CI for Python3.10 and Python3.11.
* Resolved a DeprecationWarning emitted by sqlalchemy (backwards-compatible).
* Ran `isort` over the code base to organize imports.

# Related Issue / Discussion

Closes #673
Closes #637 
Closes #590 

Addresses some comments in the following issues:
#669
#336 

# Additional Information

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
