### PR TITLE
fix invalid supported UOMs description

### DIFF
--- a/pywps/inout/basic.py
+++ b/pywps/inout/basic.py
@@ -77,7 +77,7 @@ class UOM(object):
         self.reference = reference
 
         if self.reference is None:
-            self.reference = OGCUNIT[self.uom]
+            self.reference = OGCUNIT.get(self.uom, '')
 
     @property
     def json(self):

--- a/pywps/templates/1.0.0/describe/literal.xml
+++ b/pywps/templates/1.0.0/describe/literal.xml
@@ -2,11 +2,11 @@
                 {% if put.uom %}
                 <UOMs>
                     <Default>
-                        <ows:UOM {%if put.uom %}ows:reference="{{ put.uom.reference }}"{% endif %}>{{ put.uom.uom }}</ows:UOM>
+                        <ows:UOM {%if put.uom.reference %}ows:reference="{{ put.uom.reference }}"{% endif %}>{{ put.uom.uom }}</ows:UOM>
                     </Default>
                     <Supported>
                         {% for uom in put.uoms %}
-                        <ows:UOM ows:reference="{{ put.uom.reference }}">{{ put.uom.uom }}</ows:UOM>
+                        <ows:UOM {%if uom.reference %}ows:reference="{{ uom.reference }}"{% endif %}>{{ uom.uom }}</ows:UOM>
                         {% endfor %}
                     </Supported>
                 </UOMs>


### PR DESCRIPTION
# Overview

Fix process description literal UOMs reporting duplicates of the first default UOM instead of all supported UOMs.

For example, passing `uoms=['metre', 'feet']` to `LiteralInput` would cause it to report as follows in the WPS description.
The default UOM would be repeated for as many supported UOMs that were passed to the input.
```xml
<LiteralData>
  <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#float">float</ows:DataType>
  <UOMs>
    <Default>
      <ows:UOM ows:reference="">m/s²</ows:UOM>
    </Default>
    <Supported>
      <ows:UOM ows:reference="">metre</ows:UOM>
      <ows:UOM ows:reference="">metre</ows:UOM>  <!-- error should be 'feet' -->
    </Supported>
  </UOMs>
</LiteralData>
```

At the same time, this fixes the optional `reference` attribute accordingly if it was not provided explicitly, or could not be mapped to a known unit of OGC URN. 

According to https://schemas.opengis.net/ows/1.1.0/owsDomainType.xsd
the `ows:UOM` which depends on `ows:DomainMetadataType`
shows `<attribute ref="ows:reference" use="optional" />`

But the previous check of `UOM` class caused it to check of `OGCUNIT` if not provided with an empty string.
The corresponding `if` in the template were also not consistent about reporting `reference`. 

# Related Issue / Discussion

Required by https://github.com/crim-ca/weaver/pull/541 
Required by https://github.com/crim-ca/weaver/issues/430
Fixes https://github.com/geopython/pywps/issues/685


# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute bugfix to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
