### PR TITLE
Reconfigure CI and Documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build ⚙️
+name: Build PyWPS ⚙️
 
 on:
   push:
@@ -7,7 +7,28 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Linting Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install tox
+        run: |
+          pip install tox>=4.0
+      - name: Run linting suite ⚙️
+        run: |
+          tox -e lint
+
   test:
+    name: Testing with Python${{ matrix.python-version }}
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,20 +42,15 @@ jobs:
           - tox-env: py311-extra
             python-version: "3.11"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install packages 📦
       run: |
         sudo apt-get update
         sudo apt-get -y install libnetcdf-dev libhdf5-dev
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Run flake8 ⚙️
-      run: |
-        pip install flake8
-        flake8 pywps
-      if: matrix.python-version == 3.8
     - name: Install tox 📦
       run: pip install "tox>=4.0"
     - name: Run tests with tox ⚙️
@@ -44,14 +60,16 @@ jobs:
       uses: AndreMiras/coveralls-python-action@develop
 
   docs:
+    name: Build docs 🏗️
+    needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         name: Setup Python 3.8
         with:
           python-version: 3.8
-      - name: Build docs 🏗️
+      - name: Build documentation 🏗️
         run: |
           pip install -e .[dev]
           cd docs && make html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-22.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+# Make additional formats available for download
+formats:
+  - pdf
+  - epub
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,18 @@
 [tox]
 min_version = 4.0
-envlist = py{37,38,39,310,311}{-extra,}
+envlist =
+    py{37,38,39,310,311}{-extra,},
+    lint
 requires = pip >= 20.0
 opts = --verbose
+
+[testenv:lint]
+skip_install = true
+extras =
+deps =
+    flake8
+commands =
+    flake8 pywps
 
 [testenv]
 setenv =


### PR DESCRIPTION
# Overview

This Pull Request adds a linting step to the CI configuration and also adds a ReadTheDocs v2 configuration (needed since 2020).

# Additional Information

I've set ReadTheDocs to build Pull Requests, but since this PR is coming from a fork, I don't think that ReadTheDocs's configuration will change until the changes here are merged to master.

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
