### PR TITLE
Mark tests that require network or geotiff dependency.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 addopts = --import-mode=importlib
 pythonpath = tests
 testpaths = tests
+markers =
+    online: marks tests requiring network
+    geotiff: marks tests requiring geotiff module

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -235,6 +235,7 @@ def get_output(doc):
 class ExecuteTest(TestBase):
     """Test for Exeucte request KVP request"""
 
+    @pytest.mark.online
     @pytest.mark.xfail(reason="test.opendap.org is offline")
     def test_dods(self):
         if not WITH_NC4:

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -15,6 +15,7 @@ import tempfile
 import json
 from pywps import inout
 import base64
+import pytest
 
 from pywps import Format, FORMATS
 from pywps.app.Common import Metadata
@@ -128,6 +129,7 @@ class IOHandlerTest(TestBase):
         with self.assertRaises(TypeError):
             self.iohandler[0].data = '5'
 
+    @pytest.mark.online
     def test_url(self):
         if not service_ok('https://demo.mapserver.org'):
             self.skipTest("mapserver is unreachable")
@@ -552,6 +554,7 @@ class ComplexOutputTest(TestBase):
         b = self.complex_out.base64
         self.assertEqual(base64.b64decode(b).decode(), self.data)
 
+    @pytest.mark.online
     def test_url_handler(self):
         wfsResource = 'http://demo.mapserver.org/cgi-bin/wfs?' \
                       'service=WFS&version=1.1.0&' \
@@ -798,6 +801,7 @@ class BBoxOutputTest(TestBase):
         )
 
 
+@pytest.mark.online
 class TestMetaLink(TestBase):
 
     def setUp(self) -> None:

--- a/tests/test_ows.py
+++ b/tests/test_ows.py
@@ -14,6 +14,7 @@ from pywps.exceptions import NoApplicableCode
 from pywps import get_ElementMakerForVersion
 import pywps.configuration as config
 from pywps.tests import client_for, assert_response_success, service_ok
+import pytest
 
 wfsResource = 'https://demo.mapserver.org/cgi-bin/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=continents&maxfeatures=10'  # noqa
 wcsResource = 'https://demo.mapserver.org/cgi-bin/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=ndvi&crs=EPSG:4326&bbox=-92,42,-85,45&format=image/tiff&width=400&height=300'  # noqa
@@ -91,6 +92,7 @@ class ExecuteTests(TestBase):
                            supported_formats=[get_format('GEOTIFF')])],
                        grass_location='epsg:4326')
 
+    @pytest.mark.online
     def test_wfs(self):
         if not service_ok('https://demo.mapserver.org'):
             self.skipTest("mapserver is unreachable")
@@ -117,6 +119,7 @@ class ExecuteTests(TestBase):
         # . the inclusion of output
         # . the type of output
 
+    @pytest.mark.online
     def test_wcs(self):
         if not config.CONFIG.get('grass', 'gisbase'):
             self.skipTest('GRASS lib not found')

--- a/tests/validator/test_complexvalidators.py
+++ b/tests/validator/test_complexvalidators.py
@@ -69,6 +69,7 @@ class ValidateTest(TestBase):
 
         return fake_input
 
+    @pytest.mark.online
     def test_gml_validator(self):
         """Test GML validator
         """
@@ -79,6 +80,7 @@ class ValidateTest(TestBase):
         # self.assertTrue(validategml(gml_input, MODE.VERYSTRICT), 'VERYSTRICT validation')
         gml_input.stream.close()
 
+    @pytest.mark.online
     @pytest.mark.xfail(reason="gml verystrict validation fails")
     def test_gml_validator_verystrict(self):
         """Test GML validator
@@ -117,6 +119,7 @@ class ValidateTest(TestBase):
         self.assertTrue(validateshapefile(shapefile_input, MODE.STRICT), 'STRICT validation')
         shapefile_input.stream.close()
 
+    @pytest.mark.geotiff
     def test_geotiff_validator(self):
         """Test GeoTIFF validator
         """
@@ -141,6 +144,7 @@ class ValidateTest(TestBase):
         else:
             self.assertFalse(validatenetcdf(netcdf_input, MODE.STRICT), 'STRICT validation')
 
+    @pytest.mark.online
     @pytest.mark.xfail(reason="test.opendap.org is offline")
     def test_dods_validator(self):
         opendap_input = ComplexInput('dods', 'opendap test', [FORMATS.DODS,])


### PR DESCRIPTION
# Overview

Add pytest markers to enable skipping certain tests like those that require network or certain dependencies.

# Additional Information

The Debian package build environment doesn't have network, tests requiring network need to be skipped.

The geotiff module is also not available.

# Contribution Agreement

- [x] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
